### PR TITLE
Make docker-build removes builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+LABEL stage=mctc-builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
+	docker image prune -f --filter label=stage=mctc-builder
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
## Description

Currently, the docker-build Make target uses the multi-stage build feature. This results in a lighter runnable image, but still keeps the previous build image in the local repository. The build image takes 2GB of space which can accumulate quite quickly.

Add a command to the make target to prune the build image immediately after building

## Verification steps

1. Build the image
    ```sh
    make docker-build
    ```
2. Ensure only one image remains in the repository
    ```sh
    docker images | head
    REPOSITORY                                               TAG                           IMAGE ID       CREATED         SIZE
    controller                                               latest                        25dc47a6e736   7 minutes ago   67.9MB
    ...
    ```
    