### PR TITLE
Sync agent json patches

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -200,6 +200,7 @@ func startSpecSyncers(ctx context.Context, GVRs []string, controlPlaneClient dyn
 		DownstreamNS:       dataPlaneNamespace,
 		Mutators: []syncer.Mutator{
 			&mutator.JSONPatch{},
+			&mutator.AnnotationCleaner{},
 		},
 	}
 
@@ -231,6 +232,7 @@ func startStatusSyncers(ctx context.Context, GVRs []string, controlPlaneClient d
 		NeverSyncedGVRs:    NEVER_SYNCED_GVRs,
 		UpstreamNamespaces: []string{dataPlaneNamespace},
 		DownstreamNS:       controlPlaneNS,
+		Mutators:           []syncer.Mutator{},
 	}
 
 	statusSyncer, err := status.NewStatusSyncer(clusterID, dataPlaneClient, controlPlaneClient, statusSyncConfig)

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/clusterSecret"
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer/mutator"
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer/spec"
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer/status"
 )
@@ -197,6 +198,9 @@ func startSpecSyncers(ctx context.Context, GVRs []string, controlPlaneClient dyn
 		NeverSyncedGVRs:    NEVER_SYNCED_GVRs,
 		UpstreamNamespaces: []string{controlPlaneNS},
 		DownstreamNS:       dataPlaneNamespace,
+		Mutators: []syncer.Mutator{
+			&mutator.JSONPatch{},
+		},
 	}
 
 	SpecSyncer, err := spec.NewSpecSyncer(clusterID, controlPlaneClient, dataPlaneClient, specSyncConfig)

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -123,7 +123,17 @@ func main() {
 
 	syncerContext, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	syncRunnable, err := startSpecSyncers(syncerContext, syncedResources, client.ObjectKey{Namespace: controlPlaneConfigSecretNamespace, Name: controlPlaneConfigSecretName}, mgr, controlPlaneNS)
+	controlPlaneDynamicClient, controlPlaneConfig, err := getControlPlaneObjects(syncerContext, mgr, client.ObjectKey{Namespace: controlPlaneConfigSecretNamespace, Name: controlPlaneConfigSecretName})
+	if err != nil {
+		setupLog.Error(err, "error getting control plane secret")
+		os.Exit(1)
+	}
+	dataPlaneDynamicClient, err := dynamic.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		setupLog.Error(err, "unable to create client from mgr rest config")
+		os.Exit(1)
+	}
+	syncRunnable, err := startSpecSyncers(syncerContext, syncedResources, controlPlaneDynamicClient, dataPlaneDynamicClient, controlPlaneConfig.Name, controlPlaneNS)
 	if err != nil {
 		setupLog.Error(err, "unable to start spec syncers")
 		os.Exit(1)
@@ -134,7 +144,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	statusRunnable, err := startStatusSyncers(syncerContext, syncedResources, client.ObjectKey{Namespace: controlPlaneConfigSecretNamespace, Name: controlPlaneConfigSecretName}, mgr, controlPlaneNS)
+	statusRunnable, err := startStatusSyncers(syncerContext, syncedResources, controlPlaneDynamicClient, dataPlaneDynamicClient, controlPlaneConfig.Name, controlPlaneNS)
 	if err != nil {
 		setupLog.Error(err, "unable to start status syncers")
 		os.Exit(1)
@@ -151,9 +161,7 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-func startSpecSyncers(ctx context.Context, GVRs []string, secretRef client.ObjectKey, mgr manager.Manager, controlPlaneNS string) (*syncer.SyncRunnable, error) {
-	logger := log.FromContext(ctx)
+func getControlPlaneObjects(ctx context.Context, mgr manager.Manager, secretRef client.ObjectKey) (dynamic.Interface, *clusterSecret.ClusterConfig, error) {
 	controlPlaneSecret := &corev1.Secret{}
 	secretClient, err := client.New(mgr.GetConfig(), client.Options{})
 	if err != nil {
@@ -162,41 +170,40 @@ func startSpecSyncers(ctx context.Context, GVRs []string, secretRef client.Objec
 	}
 	err = secretClient.Get(ctx, secretRef, controlPlaneSecret, &client.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve control plane config secret '%v', error: %v", secretRef.String(), err)
+		return nil, nil, fmt.Errorf("unable to retrieve control plane config secret '%v', error: %v", secretRef.String(), err)
 
 	}
-
-	upstreamClusterConfig, err := clusterSecret.ClusterConfigFromSecret(controlPlaneSecret)
+	controlPlaneClusterConfig, err := clusterSecret.ClusterConfigFromSecret(controlPlaneSecret)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create cluster config from control plane secret: %v", err)
+		return nil, nil, fmt.Errorf("unable to create cluster config from control plane secret: %v", err)
 	}
-	upstreamClient, err := clusterSecret.DynamicClientsetFromSecret(controlPlaneSecret)
+	controlPlaneClient, err := clusterSecret.DynamicClientsetFromSecret(controlPlaneSecret)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create client from control plane rest config: %v", err)
+		return nil, nil, fmt.Errorf("unable to create client from control plane rest config: %v", err)
 	}
-	informerFactory := dynamicinformer.NewDynamicSharedInformerFactory(upstreamClient, DEFAULT_RESYNC)
+	return controlPlaneClient, controlPlaneClusterConfig, nil
+}
+func startSpecSyncers(ctx context.Context, GVRs []string, controlPlaneClient dynamic.Interface, dataPlaneClient dynamic.Interface, clusterID, controlPlaneNS string) (*syncer.SyncRunnable, error) {
+	logger := log.FromContext(ctx)
+	informerFactory := dynamicinformer.NewDynamicSharedInformerFactory(controlPlaneClient, DEFAULT_RESYNC)
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	//for spec: upstream is control-plane, downstream is data plane
 	specSyncConfig := syncer.Config{
-		GVRs:            GVRs,
-		InformerFactory: informerFactory,
-		ClusterID:       upstreamClusterConfig.Name,
-		NeverSyncedGVRs: NEVER_SYNCED_GVRs,
-		UpstreamNS:      controlPlaneNS,
-		DownstreamNS:    dataPlaneNamespace,
+		GVRs:               GVRs,
+		InformerFactory:    informerFactory,
+		ClusterID:          clusterID,
+		NeverSyncedGVRs:    NEVER_SYNCED_GVRs,
+		UpstreamNamespaces: []string{controlPlaneNS},
+		DownstreamNS:       dataPlaneNamespace,
 	}
 
-	downstreamDynamicClient, err := dynamic.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		return nil, fmt.Errorf("could not make dynamic downstream client from manager rest config: %v", err.Error())
-	}
-	SpecSyncer, err := spec.NewSpecSyncer(upstreamClusterConfig.Name, upstreamClusterConfig.Name, upstreamClient, downstreamDynamicClient, specSyncConfig)
+	SpecSyncer, err := spec.NewSpecSyncer(clusterID, controlPlaneClient, dataPlaneClient, specSyncConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not create new spec syncer: %v", err.Error())
 	}
-	logger.Info("starting spec syncer", "name", upstreamClusterConfig.Name)
+	logger.Info("starting spec syncer", "name", clusterID)
 
 	go SpecSyncer.Start(ctx)
 
@@ -205,58 +212,31 @@ func startSpecSyncers(ctx context.Context, GVRs []string, secretRef client.Objec
 
 }
 
-func startStatusSyncers(ctx context.Context, GVRs []string, secretRef client.ObjectKey, mgr manager.Manager, controlPlaneNS string) (*syncer.SyncRunnable, error) {
+func startStatusSyncers(ctx context.Context, GVRs []string, controlPlaneClient dynamic.Interface, dataPlaneClient dynamic.Interface, clusterID, controlPlaneNS string) (*syncer.SyncRunnable, error) {
 	logger := log.FromContext(ctx)
-	controlPlaneSecret := &corev1.Secret{}
-	secretClient, err := client.New(mgr.GetConfig(), client.Options{})
-	if err != nil {
-		setupLog.Error(err, "unable to create sync secret client")
-		os.Exit(1)
-	}
-	err = secretClient.Get(ctx, secretRef, controlPlaneSecret, &client.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve control plane config secret '%v', error: %v", secretRef.String(), err)
 
-	}
-	downstreamClusterConfig, err := clusterSecret.ClusterConfigFromSecret(controlPlaneSecret)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create cluster config from control plane secret: %v", err)
-	}
-	downstreamClient, err := clusterSecret.DynamicClientsetFromSecret(controlPlaneSecret)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create client from control plane rest config: %v", err)
-	}
-	upstreamClient, err := dynamic.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		return nil, fmt.Errorf("unable to create client from mgr rest config: %v", err)
-	}
-	informerFactory := dynamicinformer.NewDynamicSharedInformerFactory(upstreamClient, DEFAULT_RESYNC)
+	informerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dataPlaneClient, DEFAULT_RESYNC)
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	//for status: downstream is control-plane, upstream is data plane
 	statusSyncConfig := syncer.Config{
-		GVRs:            GVRs,
-		InformerFactory: informerFactory,
-		ClusterID:       downstreamClusterConfig.Name,
-		NeverSyncedGVRs: NEVER_SYNCED_GVRs,
-		UpstreamNS:      dataPlaneNamespace,
-		DownstreamNS:    controlPlaneNS,
+		GVRs:               GVRs,
+		InformerFactory:    informerFactory,
+		ClusterID:          clusterID,
+		NeverSyncedGVRs:    NEVER_SYNCED_GVRs,
+		UpstreamNamespaces: []string{dataPlaneNamespace},
+		DownstreamNS:       controlPlaneNS,
 	}
 
-	upstreamDynamicClient, err := dynamic.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		return nil, fmt.Errorf("could not make dynamic downstream client from manager rest config: %v", err.Error())
-	}
-	statusSyncer, err := status.NewStatusSyncer(downstreamClusterConfig.Name, downstreamClusterConfig.Name, upstreamDynamicClient, downstreamClient, statusSyncConfig)
+	statusSyncer, err := status.NewStatusSyncer(clusterID, dataPlaneClient, controlPlaneClient, statusSyncConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not create new spec syncer: %v", err.Error())
 	}
-	logger.Info("starting status syncer", "name", downstreamClusterConfig.Name)
+	logger.Info("starting status syncer", "name", clusterID)
 
 	go statusSyncer.Start(ctx)
 
 	syncRunnable := syncer.GetSyncerRunnable(statusSyncConfig, syncer.InformerForGVR, statusSyncer)
 	return syncRunnable, nil
-
 }

--- a/config/samples/gateway.yaml
+++ b/config/samples/gateway.yaml
@@ -4,6 +4,10 @@ metadata:
   name: example-gateway
   annotations:
     kuadrant.io/gateway-cluster-label-selector: type=test
+    mctc-syncer-patch/kind-mctc-workload-1: '[
+      {"op": "replace", "path": "/spec/gatewayClassName", "value": "boo"},
+      {"op": "replace", "path": "/spec/listeners/0/name", "value": "test"}
+      ]'
 spec:
   gatewayClassName: mctc-gw-istio-external-instance-per-cluster
   listeners:

--- a/config/samples/gateway.yaml
+++ b/config/samples/gateway.yaml
@@ -4,6 +4,7 @@ metadata:
   name: example-gateway
   annotations:
     kuadrant.io/gateway-cluster-label-selector: type=test
+    mctc-sync-agent/all: 'true'
     mctc-syncer-patch/kind-mctc-workload-1: '[
       {"op": "replace", "path": "/spec/gatewayClassName", "value": "boo"},
       {"op": "replace", "path": "/spec/listeners/0/name", "value": "test"}

--- a/config/syncer/kustomization.yaml
+++ b/config/syncer/kustomization.yaml
@@ -17,6 +17,6 @@ patches:
 - path: syncer_parameter_patch.json
   target:
     group: apps
-    version: v1
     kind: Deployment
     name: sync-agent
+    version: v1

--- a/hack/.argocdUtils
+++ b/hack/.argocdUtils
@@ -43,7 +43,7 @@ stringData:
     {
       "tlsClientConfig":
         {
-          "insecure": false,
+          "insecure": true,
           "caData": "${caData}",
           "certData": "${certData}",
           "keyData": "${keyData}"

--- a/hack/.clusterUtils
+++ b/hack/.clusterUtils
@@ -22,7 +22,7 @@ stringData:
     {
       "tlsClientConfig":
         {
-          "insecure": false,
+          "insecure": true,
           "caData": "${caData}",
           "certData": "${certData}",
           "keyData": "${keyData}"

--- a/hack/make/syncer.make
+++ b/hack/make/syncer.make
@@ -40,3 +40,8 @@ undeploy-syncer: ## Undeploy controller from the K8s cluster specified in ~/.kub
 
 .PHONY: redeploy-syncer
 redeploy-syncer: undeploy-syncer deploy-syncer
+
+.PHONY: restart-syncer
+restart-syncer:
+	kubectl rollout restart deploy sync-agent -n mctc-system
+    

--- a/pkg/_internal/metadata/annotations.go
+++ b/pkg/_internal/metadata/annotations.go
@@ -6,8 +6,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetAnnotationsByPrefix(obj metav1.Object, prefix string) []string {
-	annotations := []string{}
+func GetAnnotationsByPrefix(obj metav1.Object, prefix string) map[string]string {
+	annotations := map[string]string{}
 
 	//get any annotations that contain the prefix
 	exists, keys := HasAnnotationsContaining(obj, prefix)
@@ -17,7 +17,7 @@ func GetAnnotationsByPrefix(obj metav1.Object, prefix string) []string {
 	for k, v := range keys {
 		//check the annotation starts with the prefix
 		if strings.HasPrefix(k, prefix) {
-			annotations = append(annotations, v)
+			annotations[k] = v
 		}
 	}
 	return annotations
@@ -68,6 +68,15 @@ func AddAnnotation(obj metav1.Object, key, value string) {
 	}
 	annotations[key] = value
 	obj.SetAnnotations(annotations)
+}
+
+func RemoveAnnotationsByPrefix(obj metav1.Object, prefix string) int {
+	count := 0
+	for annotation, _ := range GetAnnotationsByPrefix(obj, prefix) {
+		RemoveAnnotation(obj, annotation)
+		count++
+	}
+	return count
 }
 
 func RemoveAnnotation(obj metav1.Object, key string) {

--- a/pkg/syncer/mutator/annotationCleaner.go
+++ b/pkg/syncer/mutator/annotationCleaner.go
@@ -1,0 +1,31 @@
+package mutator
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/metadata"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer/status"
+)
+
+type AnnotationCleaner struct {
+}
+
+func (m *AnnotationCleaner) GetName() string {
+	return "Annotation Cleaner"
+}
+
+func (m *AnnotationCleaner) Mutate(cfg syncer.MutatorConfig, obj *unstructured.Unstructured) error {
+	annotationPrefixes := []string{
+		JSONPatchAnnotationPrefix,
+		syncer.MCTC_SYNC_ANNOTATION_PREFIX,
+		status.SyncerClusterStatusAnnotationPrefix,
+		"kubectl.kubernetes.io/last-applied-configuration",
+	}
+
+	for _, annotationPrefix := range annotationPrefixes {
+		metadata.RemoveAnnotationsByPrefix(obj, annotationPrefix)
+	}
+
+	return nil
+}

--- a/pkg/syncer/mutator/jsonpatch.go
+++ b/pkg/syncer/mutator/jsonpatch.go
@@ -29,7 +29,6 @@ func (m *JSONPatch) Mutate(cfg syncer.MutatorConfig, obj *unstructured.Unstructu
 		return fmt.Errorf("no patch found for sync target '%v' on object: %v/%v", cfg.ClusterID, obj.GetNamespace(), obj.GetName())
 	}
 
-	cfg.Logger.Info("got patch", "string", patchString)
 	patch, err := jsonpatch.DecodePatch([]byte(patchString))
 	if err != nil {
 		return fmt.Errorf("error decoding patch: %v", err.Error())

--- a/pkg/syncer/mutator/jsonpatch.go
+++ b/pkg/syncer/mutator/jsonpatch.go
@@ -1,0 +1,52 @@
+package mutator
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/metadata"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+)
+
+const (
+	JSONPatchAnnotationPrefix = "mctc-syncer-patch/"
+)
+
+type JSONPatch struct {
+}
+
+func (m *JSONPatch) GetName() string {
+	return "JSON Patch"
+}
+
+func (m *JSONPatch) Mutate(cfg syncer.MutatorConfig, obj *unstructured.Unstructured) error {
+	patchString := metadata.GetAnnotation(obj, JSONPatchAnnotationPrefix+cfg.ClusterID)
+	if patchString == "" {
+		return fmt.Errorf("no patch found for sync target '%v' on object: %v/%v", cfg.ClusterID, obj.GetNamespace(), obj.GetName())
+	}
+
+	cfg.Logger.Info("got patch", "string", patchString)
+	patch, err := jsonpatch.DecodePatch([]byte(patchString))
+	if err != nil {
+		return fmt.Errorf("error decoding patch: %v", err.Error())
+	}
+	objBytes, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	objBytes, err = patch.Apply(objBytes)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(objBytes, obj)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -23,7 +24,17 @@ const (
 )
 
 type Syncer interface {
-	Handle(unstructured unstructured.Unstructured) error
+	Handle(obj unstructured.Unstructured) error
+}
+
+type MutatorConfig struct {
+	ClusterID string
+	Logger    logr.Logger
+}
+
+type Mutator interface {
+	Mutate(cfg MutatorConfig, obj *unstructured.Unstructured) error
+	GetName() string
 }
 
 type Config struct {
@@ -34,6 +45,7 @@ type Config struct {
 	UpstreamNamespaces []string
 	DownstreamNS       string
 	Syncer             Syncer
+	Mutators           []Mutator
 }
 
 type InformerEventsDecorator func(cfg Config, informer informers.GenericInformer, gvr *schema.GroupVersionResource, c SyncController) error

--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/metadata"
@@ -26,13 +27,13 @@ type Syncer interface {
 }
 
 type Config struct {
-	ClusterID       string
-	GVRs            []string
-	InformerFactory dynamicinformer.DynamicSharedInformerFactory
-	NeverSyncedGVRs []string
-	UpstreamNS      string
-	DownstreamNS    string
-	Syncer          Syncer
+	ClusterID          string
+	GVRs               []string
+	InformerFactory    dynamicinformer.DynamicSharedInformerFactory
+	NeverSyncedGVRs    []string
+	UpstreamNamespaces []string
+	DownstreamNS       string
+	Syncer             Syncer
 }
 
 type InformerEventsDecorator func(cfg Config, informer informers.GenericInformer, gvr *schema.GroupVersionResource, c SyncController) error
@@ -88,7 +89,7 @@ func InformerForGVR(cfg Config, informer informers.GenericInformer, gvr *schema.
 			if err != nil {
 				return
 			}
-			if metaAccessor.GetNamespace() != cfg.UpstreamNS {
+			if !slices.Contains(cfg.UpstreamNamespaces, metaAccessor.GetNamespace()) {
 				return
 			}
 			value := metadata.GetAnnotation(metaAccessor, MCTC_SYNC_ANNOTATION_PREFIX+cfg.ClusterID)
@@ -107,7 +108,7 @@ func InformerForGVR(cfg Config, informer informers.GenericInformer, gvr *schema.
 			if err != nil {
 				return
 			}
-			if metaAccessor.GetNamespace() != cfg.UpstreamNS {
+			if !slices.Contains(cfg.UpstreamNamespaces, metaAccessor.GetNamespace()) {
 				return
 			}
 			value := metadata.GetAnnotation(metaAccessor, MCTC_SYNC_ANNOTATION_PREFIX+cfg.ClusterID)
@@ -125,7 +126,7 @@ func InformerForGVR(cfg Config, informer informers.GenericInformer, gvr *schema.
 			if err != nil {
 				return
 			}
-			if metaAccessor.GetNamespace() != cfg.UpstreamNS {
+			if !slices.Contains(cfg.UpstreamNamespaces, metaAccessor.GetNamespace()) {
 				return
 			}
 			value := metadata.GetAnnotation(metaAccessor, MCTC_SYNC_ANNOTATION_PREFIX+cfg.ClusterID)


### PR DESCRIPTION
Primary changes:
- Implements specdiff annotations
- Removes MCTC annotations from downstream resources

## verification
- MCTC_WORKLOAD_CLUSTERS_COUNT=1 make local-setup
- export KUBECONFIG=./tmp/kubeconfigs/mctc-workload-1.kubeconfig
- make kind-load-syncer
- make deploy-syncer
- export KUBECONFIG=./tmp/kubeconfigs/mctc-control-plane.kubeconfig
- kubectl create namespace mctc-tenant
- kubectl apply -n mctc-tenant -f ./config/samples/gateway.yaml
- export KUBECONFIG=./tmp/kubeconfigs/mctc-workload-1.kubeconfig
- kubectl get gateways example-gateway -n mctc-downstream -o yaml
- see that the name of the listener is 'test' and the gatewayClassName is 'boo'
- see that no mctc specific annotations exist