### PR TITLE
#85: Reconcile Gateway from watching cluster secret

### DIFF
--- a/pkg/_internal/clusterSecret/util.go
+++ b/pkg/_internal/clusterSecret/util.go
@@ -1,0 +1,14 @@
+package clusterSecret
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func IsClusterSecret(object metav1.Object) bool {
+	secretType, ok := object.GetLabels()["argocd.argoproj.io/secret-type"]
+	if !ok {
+		return false
+	}
+
+	return secretType == "cluster"
+}

--- a/pkg/_internal/clusterSecret/util.go
+++ b/pkg/_internal/clusterSecret/util.go
@@ -4,11 +4,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	CLUSTER_SECRET_LABEL       = "argocd.argoproj.io/secret-type"
+	CLUSTER_SECRET_LABEL_VALUE = "cluster"
+)
+
 func IsClusterSecret(object metav1.Object) bool {
-	secretType, ok := object.GetLabels()["argocd.argoproj.io/secret-type"]
+	secretType, ok := object.GetLabels()[CLUSTER_SECRET_LABEL]
 	if !ok {
 		return false
 	}
 
-	return secretType == "cluster"
+	return secretType == CLUSTER_SECRET_LABEL_VALUE
 }

--- a/pkg/_internal/slice/slice.go
+++ b/pkg/_internal/slice/slice.go
@@ -41,3 +41,14 @@ func Find[T any](slice []T, predicate func(T) bool) (element T, ok bool) {
 
 	return
 }
+
+func Filter[T any](slice []T, predicate func(T) bool) []T {
+	result := []T{}
+	for _, elem := range slice {
+		if predicate(elem) {
+			result = append(result, elem)
+		}
+	}
+
+	return result
+}

--- a/pkg/controllers/gateway/cluster_eventhandler.go
+++ b/pkg/controllers/gateway/cluster_eventhandler.go
@@ -1,0 +1,79 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/clusterSecret"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/slice"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type ClusterEventHandler struct {
+	client client.Client
+}
+
+var _ handler.EventHandler = &ClusterEventHandler{}
+
+// Create implements handler.EventHandler
+func (eh *ClusterEventHandler) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	eh.enqueueForObject(e.Object, q)
+}
+
+// Delete implements handler.EventHandler
+func (eh *ClusterEventHandler) Delete(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	eh.enqueueForObject(e.Object, q)
+}
+
+// Generic implements handler.EventHandler
+func (eh *ClusterEventHandler) Generic(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	eh.enqueueForObject(e.Object, q)
+}
+
+// Update implements handler.EventHandler
+func (eh *ClusterEventHandler) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	eh.enqueueForObject(e.ObjectNew, q)
+}
+
+func (eh *ClusterEventHandler) enqueueForObject(obj v1.Object, q workqueue.RateLimitingInterface) {
+	if !clusterSecret.IsClusterSecret(obj) {
+		return
+	}
+
+	gateways, err := eh.getGatewaysFor(obj.(*corev1.Secret))
+	if err != nil {
+		log.Log.Error(err, "failed to get gateways when enqueueing from cluster secret")
+		return
+	}
+
+	for _, gateway := range gateways {
+		log.Log.Info(fmt.Sprintf("Enqueing reconciliation from secret update to gateway/%s", gateway.Name))
+		q.Add(ctrl.Request{
+			NamespacedName: client.ObjectKeyFromObject(&gateway),
+		})
+	}
+}
+
+func (eh *ClusterEventHandler) getGatewaysFor(secret *corev1.Secret) ([]gatewayv1beta1.Gateway, error) {
+	clusterConfig, err := clusterSecret.ClusterConfigFromSecret(secret)
+	if err != nil {
+		return nil, err
+	}
+
+	gateways := &gatewayv1beta1.GatewayList{}
+	if err := eh.client.List(context.TODO(), gateways); err != nil {
+		return nil, err
+	}
+
+	return slice.Filter(gateways.Items, func(gateway gatewayv1beta1.Gateway) bool {
+		return slice.ContainsString(selectClusters(gateway), clusterConfig.Name)
+	}), nil
+}

--- a/pkg/controllers/gateway/cluster_eventhandler_test.go
+++ b/pkg/controllers/gateway/cluster_eventhandler_test.go
@@ -1,0 +1,225 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/clusterSecret"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestClusterEventHandler(t *testing.T) {
+	cases := []struct {
+		name string
+
+		gateways         []gatewayv1beta1.Gateway
+		secret           corev1.Secret
+		enqueuedGateways []gatewayv1beta1.Gateway
+	}{
+		{
+			name: "Queued one",
+			gateways: []gatewayv1beta1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-gateway",
+						Namespace: "test-ns",
+						Annotations: map[string]string{
+							GatewayClusterLabelSelectorAnnotation: "type=test",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-another-gateway",
+						Namespace: "test-ns",
+						Annotations: map[string]string{
+							GatewayClusterLabelSelectorAnnotation: "another",
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						clusterSecret.CLUSTER_SECRET_LABEL: clusterSecret.CLUSTER_SECRET_LABEL_VALUE,
+					},
+					Name:      "cluster",
+					Namespace: "test-ns",
+				},
+				Data: map[string][]byte{
+					"name": []byte("test_cluster_one"),
+					"config": []byte(
+						`
+				{
+					"tlsClientConfig":
+					  {
+					    "insecure": false,
+					    "caData": "test",
+					    "certData": "test",
+					    "keyData": "test"
+					  }
+				}
+				`),
+				},
+			},
+			enqueuedGateways: []gatewayv1beta1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-gateway",
+						Namespace: "test-ns",
+					},
+				},
+			},
+		},
+		{
+			name: "Not enqueued. Not a cluster secret",
+			gateways: []gatewayv1beta1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-gateway",
+						Namespace: "test-ns",
+						Annotations: map[string]string{
+							GatewayClusterLabelSelectorAnnotation: "type=test",
+						},
+					},
+				},
+			},
+			secret: corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated-secret",
+					Namespace: "test-ns",
+				},
+			},
+			enqueuedGateways: make([]gatewayv1beta1.Gateway, 0),
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := gatewayv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal("unexpected error building scheme", err)
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().WithScheme(scheme).WithLists(
+				&gatewayv1beta1.GatewayList{
+					Items: testCase.gateways,
+				},
+			).Build()
+
+			testQ := &testQueue{t: t}
+			clusterEventHandler := &ClusterEventHandler{
+				client: client,
+			}
+
+			clusterEventHandler.enqueueForObject(&testCase.secret, testQ)
+			testQ.MustHaveEnqueued(testCase.enqueuedGateways)
+		})
+	}
+}
+
+type testQueue struct {
+	t                *testing.T
+	enqueuedRequests map[types.NamespacedName]bool
+}
+
+func (q *testQueue) Add(item interface{}) {
+	req, ok := item.(ctrl.Request)
+	if !ok {
+		q.t.Fatalf("expected enqueued item to be of type ctrl.Request, got %v", item)
+	}
+
+	if q.enqueuedRequests == nil {
+		q.enqueuedRequests = make(map[types.NamespacedName]bool)
+	}
+
+	q.enqueuedRequests[req.NamespacedName] = true
+}
+
+func (q *testQueue) MustHaveEnqueued(gateways []gatewayv1beta1.Gateway) {
+	enqueuedCopy := map[types.NamespacedName]bool{}
+	for obj := range q.enqueuedRequests {
+		enqueuedCopy[obj] = true
+	}
+
+	for _, gateway := range gateways {
+		var nsn types.NamespacedName = types.NamespacedName{
+			Namespace: gateway.Namespace,
+			Name:      gateway.Name,
+		}
+
+		_, ok := q.enqueuedRequests[nsn]
+		if !ok {
+			q.t.Errorf("Object %s expected to be enqueued, but was not", nsn)
+			continue
+		}
+
+		delete(enqueuedCopy, nsn)
+	}
+
+	for obj := range enqueuedCopy {
+		q.t.Errorf("Object %s expected not to be enqueued, but was", obj)
+	}
+}
+
+// Unused methods below that must be defined for testQueue to implement the
+// workqueue.RateLimitingInterface:
+//
+// Done implements workqueue.RateLimitingInterface
+func (*testQueue) Done(item interface{}) {
+	panic("unimplemented")
+}
+
+// Get implements workqueue.RateLimitingInterface
+func (*testQueue) Get() (item interface{}, shutdown bool) {
+	panic("unimplemented")
+}
+
+// Len implements workqueue.RateLimitingInterface
+func (*testQueue) Len() int {
+	panic("unimplemented")
+}
+
+// ShutDown implements workqueue.RateLimitingInterface
+func (*testQueue) ShutDown() {
+	panic("unimplemented")
+}
+
+// ShutDownWithDrain implements workqueue.RateLimitingInterface
+func (*testQueue) ShutDownWithDrain() {
+	panic("unimplemented")
+}
+
+// ShuttingDown implements workqueue.RateLimitingInterface
+func (*testQueue) ShuttingDown() bool {
+	panic("unimplemented")
+}
+
+// AddAfter implements workqueue.RateLimitingInterface
+func (*testQueue) AddAfter(item interface{}, duration time.Duration) {
+	panic("unimplemented")
+}
+
+// AddRateLimited implements workqueue.RateLimitingInterface
+func (*testQueue) AddRateLimited(item interface{}) {
+	panic("unimplemented")
+}
+
+// Forget implements workqueue.RateLimitingInterface
+func (*testQueue) Forget(item interface{}) {
+	panic("unimplemented")
+}
+
+// NumRequeues implements workqueue.RateLimitingInterface
+func (*testQueue) NumRequeues(item interface{}) int {
+	panic("unimplemented")
+}
+
+var _ workqueue.RateLimitingInterface = &testQueue{}

--- a/pkg/controllers/gateway/gateway_controller.go
+++ b/pkg/controllers/gateway/gateway_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -342,8 +343,15 @@ func selectClusters(gateway gatewayv1beta1.Gateway) []string {
 func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1beta1.Gateway{}).
+		Watches(&source.Kind{
+			Type: &corev1.Secret{},
+		}, &ClusterEventHandler{client: r.Client}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			gateway := object.(*gatewayv1beta1.Gateway)
+			gateway, ok := object.(*gatewayv1beta1.Gateway)
+			if !ok {
+				return true
+			}
+
 			return slice.ContainsString(getSupportedClasses(), string(gateway.Spec.GatewayClassName))
 		})).
 		Complete(r)


### PR DESCRIPTION
## Description

> Closes #85

Add a watch for secrets in the Gateway controller that will enqueue gateways if there's a change in the related cluster secret

## Verification steps

1. For testing purposes, as #52 is not done, update [this line of code](https://github.com/david-martin/multi-cluster-traffic-controller/blob/8bb9849ad642abdc847d5995ea34f3d07a187b17/pkg/controllers/gateway/gateway_controller.go#L337) to the following:
    ```go
    return []string{"mctc-workload-1"}
    ```

1. Run local-setup and start the controller

1. Create a sample gateway

1. Update the secret for the workload cluster

1. Verify that the sample gateway is reconciled 
