### PR TITLE
#118: Ability to handle parameters in GatewayClass

### DIFF
--- a/config/samples/gatewayclass.yaml
+++ b/config/samples/gatewayclass.yaml
@@ -4,3 +4,8 @@ metadata:
   name: mctc-gw-istio-external-instance-per-cluster
 spec:
   controllerName: "kuadrant.io/mctc-gw-controller"
+  parametersRef:
+    group: ""
+    kind: "ConfigMap"
+    namespace: "multi-cluster-traffic-controller-system"
+    name: "gateway-params"

--- a/config/samples/gatewayclass_params.json
+++ b/config/samples/gatewayclass_params.json
@@ -1,0 +1,3 @@
+{
+  "downstreamClass": "istio"
+}

--- a/hack/local-setup.sh
+++ b/hack/local-setup.sh
@@ -286,3 +286,8 @@ fi
 
 #10. Ensure the current context points to the control plane cluster
 kubectl config use-context kind-${KIND_CLUSTER_CONTROL_PLANE}
+
+ # Create configmap with gateway parameters for clusters
+kubectl create configmap gateway-params \
+  --from-file=params=config/samples/gatewayclass_params.json \
+  -n multi-cluster-traffic-controller-system

--- a/pkg/controllers/gateway/params.go
+++ b/pkg/controllers/gateway/params.go
@@ -1,0 +1,106 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type Params struct {
+	// DownstreamClass specifies what GatewayClassName to set in the
+	// downstream clusters. For example:
+	DownstreamClass string `json:"downstreamClass,omitempty"`
+}
+
+func (p *Params) GetDownstreamClass() string {
+	return p.DownstreamClass
+}
+
+var defaultParams Params = Params{
+	DownstreamClass: "istio",
+}
+
+type InvalidParamsError struct {
+	message string
+}
+
+var _ error = &InvalidParamsError{}
+
+// Error implements error
+func (e *InvalidParamsError) Error() string {
+	return e.message
+}
+
+func IsInvalidParamsError(err error) (is bool) {
+	_, is = err.(*InvalidParamsError)
+	return
+}
+
+type ParamsResolver func(context.Context, client.Client, gatewayv1beta1.ParametersReference) (*Params, error)
+
+var paramsResolvers = map[schema.GroupKind]ParamsResolver{
+	{Group: corev1.GroupName, Kind: "ConfigMap"}: fromNamespacedObject(fromConfigMap),
+}
+
+func fromNamespacedObject[T client.Object](getParams func(T) (*Params, error)) ParamsResolver {
+	template := *new(T)
+	objectType := reflect.TypeOf(template).Elem()
+
+	return func(ctx context.Context, client client.Client, paramsRef gatewayv1beta1.ParametersReference) (*Params, error) {
+		if paramsRef.Namespace == nil || *paramsRef.Namespace == "" {
+			return nil, &InvalidParamsError{"Namespace must be defined"}
+		}
+
+		obj := reflect.New(objectType).Interface().(T)
+		namespace := string(*paramsRef.Namespace)
+
+		if err := client.Get(ctx, types.NamespacedName{
+			Name:      paramsRef.Name,
+			Namespace: namespace,
+		}, obj); err != nil {
+			return nil, &InvalidParamsError{fmt.Sprintf("failed to get object %s/%s: %s", namespace, paramsRef.Name, err.Error())}
+		}
+
+		return getParams(obj)
+	}
+}
+
+func fromConfigMap(configMap *corev1.ConfigMap) (*Params, error) {
+	paramsRaw, ok := configMap.Data["params"]
+	if !ok {
+		return nil, &InvalidParamsError{"Parameters must be defined in \"params\" field of ConfigMap"}
+	}
+
+	result := &Params{}
+	if err := json.Unmarshal([]byte(paramsRaw), result); err != nil {
+		return nil, &InvalidParamsError{fmt.Sprintf("Failed to unmarshal params: %v", err)}
+	}
+
+	return result, nil
+}
+
+func getParams(ctx context.Context, client client.Client, gatewayClass *gatewayv1beta1.GatewayClass) (*Params, error) {
+	if gatewayClass.Spec.ParametersRef == nil {
+		// Default parameters
+		return &defaultParams, nil
+	}
+
+	groupKind := schema.GroupKind{
+		Group: string(gatewayClass.Spec.ParametersRef.Group),
+		Kind:  string(gatewayClass.Spec.ParametersRef.Kind),
+	}
+
+	resolveParams, ok := paramsResolvers[groupKind]
+	if !ok {
+		return nil, &InvalidParamsError{fmt.Sprintf("unable to retrieve parameters for GroupKind %s", groupKind.String())}
+	}
+
+	return resolveParams(ctx, client, *gatewayClass.Spec.ParametersRef)
+}

--- a/pkg/controllers/gateway/params_test.go
+++ b/pkg/controllers/gateway/params_test.go
@@ -1,0 +1,166 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestGetParams(t *testing.T) {
+	cases := []struct {
+		name string
+
+		gatewayClass *gatewayv1beta1.GatewayClass
+		paramsObj    client.Object
+		assertParams func(*Params, error) error
+	}{
+		{
+			name: "ConfigMap found",
+			gatewayClass: &gatewayv1beta1.GatewayClass{
+				Spec: gatewayv1beta1.GatewayClassSpec{
+					ParametersRef: &gatewayv1beta1.ParametersReference{
+						Group:     "",
+						Kind:      "ConfigMap",
+						Name:      "test-params",
+						Namespace: addr(gatewayv1beta1.Namespace("test-ns")),
+					},
+				},
+			},
+			paramsObj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-params",
+					Namespace: "test-ns",
+				},
+				Data: map[string]string{
+					"params": `{"downstreamClass": "istio"}`,
+				},
+			},
+			assertParams: and(
+				noError,
+				paramsEqual(Params{
+					DownstreamClass: "istio",
+				}),
+			),
+		},
+		{
+			name: "ConfigMap not found",
+
+			gatewayClass: &gatewayv1beta1.GatewayClass{
+				Spec: gatewayv1beta1.GatewayClassSpec{
+					ParametersRef: &gatewayv1beta1.ParametersReference{
+						Group:     "",
+						Kind:      "ConfigMap",
+						Name:      "test-params-no-exist",
+						Namespace: addr(gatewayv1beta1.Namespace("test-ns")),
+					},
+				},
+			},
+			paramsObj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-params",
+					Namespace: "test-ns",
+				},
+			},
+			assertParams: assertError(IsInvalidParamsError),
+		},
+		{
+			name: "Unsupported GroupKind",
+
+			gatewayClass: &gatewayv1beta1.GatewayClass{
+				Spec: gatewayv1beta1.GatewayClassSpec{
+					ParametersRef: &gatewayv1beta1.ParametersReference{
+						Group:     "foo",
+						Kind:      "Unsupported",
+						Name:      "test-params",
+						Namespace: addr(gatewayv1beta1.Namespace("test-ns")),
+					},
+				},
+			},
+			paramsObj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-params",
+					Namespace: "test-ns",
+				},
+			},
+			assertParams: assertError(IsInvalidParamsError),
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := gatewayv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unexpected error building scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unexpected error building scheme: %v", err)
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(testCase.gatewayClass, testCase.paramsObj).
+				Build()
+
+			params, err := getParams(context.TODO(), client, testCase.gatewayClass)
+
+			if err := testCase.assertParams(params, err); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func addr[T any](value T) *T {
+	return &value
+}
+
+// Assertion utils
+
+func and(assertions ...func(*Params, error) error) func(*Params, error) error {
+	return func(p *Params, err error) error {
+		for _, assertion := range assertions {
+			if err := assertion(p, err); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func noError(_ *Params, err error) error {
+	if err != nil {
+		return fmt.Errorf("unexpected error: %v", err)
+	}
+
+	return nil
+}
+
+func assertError(assertion func(error) bool) func(*Params, error) error {
+	return func(p *Params, err error) error {
+		if !assertion(err) {
+			return fmt.Errorf("failed to assert error %v", err)
+		}
+
+		return nil
+	}
+}
+
+func paramsEqual(expected Params) func(*Params, error) error {
+	return func(p *Params, _ error) error {
+		got := *p
+		if reflect.DeepEqual(got, expected) {
+			return nil
+		}
+
+		return fmt.Errorf("unexpected params. Expected %v, got %v", expected, got)
+	}
+}


### PR DESCRIPTION
## Description 

> Closes #118 

Ability to get parameters from a resourced referenced in the `parametersRef` of the GatewayClass

## Verification steps

As the parameters are currently not used, in order to verify this functionality, ensure that the adequate status condition is reconciled when the `parametersRef` is misconfigured.

1. Start the local development clusters
    ```sh
    MCTC_WORKLOAD_CLUSTERS_COUNT=1 make local-setup
    ```

3. Run the controller
    ```sh
    (export $(cat ./controller-config.env | xargs) && export $(cat ./aws-credentials.env | xargs) && make build-controller install run-controller)
    ```

1. Create the parameters ConfigMap
    ```sh
    kubectl create configmap gateway-params --from-file=params=config/samples/gatewayclass_params.json -n multi-cluster-traffic-controller-system
    ```

5. Create the GatewayClass
    ```yaml
    apiVersion: gateway.networking.k8s.io/v1beta1
    kind: GatewayClass
    metadata:
      name: mctc-gw-istio-external-instance-per-cluster
    spec:
      controllerName: "kuadrant.io/mctc-gw-controller"
      parametersRef:
        group: ""
        kind: "ConfigMap"
        namespace: "multi-cluster-traffic-controller-system"
        name: "gateway-params"
    ```

7. Create the Gateway with `.spec.gatewayClassName = mctc-gw-istio-external-instance-per-cluster`
    ```sh
    kubectl create namespace mctc-tenant
    kubectl apply -n mctc-tenant -f gateway.yaml
    ```

1. Verify that once reconciled, the annotation is set
    ```sh
    kubectl get gateway/example-gateway -n mctc-tenant
    ```
    ```yaml
    metadata:
      name: example-gateway
      annotations:
        mctc-syncer-patch/kind-mctc-workload-1: [{"op":"replace","path":"/spec/gatewayClassName","value":"istio"}] 
    ```

