### PR TITLE
Syncer fix

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -215,7 +215,7 @@ func startSpecSyncers(ctx context.Context, GVRs []string, controlPlaneClient dyn
 
 	go SpecSyncer.Start(ctx)
 
-	syncRunnable := syncer.GetSyncerRunnable(specSyncConfig, syncer.InformerForGVR, SpecSyncer)
+	syncRunnable := syncer.GetSyncerRunnable(specSyncConfig, syncer.InformerForAnnotatedGVR, SpecSyncer)
 	return syncRunnable, nil
 
 }

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -40,6 +40,7 @@ import (
 	//+kubebuilder:scaffold:imports
 
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/clusterSecret"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/env"
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer"
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer/mutator"
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer/spec"
@@ -88,7 +89,7 @@ func main() {
 	flag.StringVar(&controlPlaneConfigSecretNamespace, "control-plane-config-namespace", "mctc-system", "The namespace containing the secret with the control plane client configuration")
 	flag.Var(&syncedResources, "synced-resources", "A list of GVRs to sync (e.g. ingresses.v1.networking.k8s.io)")
 	flag.StringVar(&controlPlaneNS, "control-plane-namespace", "mctc-tenant", "The name of the upstream namespace to sync resources from")
-	flag.StringVar(&dataPlaneNS, "data-plane-namespace", os.Getenv("DATAPLANE_NAMESPACE"), "The namespace in the data plane to sync resources to")
+	flag.StringVar(&dataPlaneNS, "data-plane-namespace", env.GetEnvString("DATAPLANE_NAMESPACE", "mctc-downstream"), "The namespace in the data plane to sync resources to")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/pkg/_internal/env/env.go
+++ b/pkg/_internal/env/env.go
@@ -1,0 +1,38 @@
+package env
+
+import (
+	"os"
+	"strconv"
+)
+
+func GetEnvString(key, fallback string) string {
+	value, found := os.LookupEnv(key)
+	if !found {
+		return fallback
+	}
+	return value
+}
+
+func GetEnvBool(key string, fallback bool) bool {
+	strValue, found := os.LookupEnv(key)
+	if !found {
+		return fallback
+	}
+	value, err := strconv.ParseBool(strValue)
+	if err != nil {
+		return fallback
+	}
+	return value
+}
+
+func GetEnvInt(key string, fallback int) int {
+	strValue, found := os.LookupEnv(key)
+	if !found {
+		return fallback
+	}
+	value, err := strconv.Atoi(strValue)
+	if err != nil {
+		return fallback
+	}
+	return value
+}

--- a/pkg/_internal/env/env_test.go
+++ b/pkg/_internal/env/env_test.go
@@ -1,0 +1,105 @@
+package env
+
+import (
+	"os"
+	"testing"
+)
+
+// These tests cannot be run in parallel and should be updated to use testing.SetEnv if/when we update to go 1.17+ https://pkg.go.dev/testing#B.Setenv
+
+func TestGetEnvBool(t *testing.T) {
+	setupTestEnv(t)
+	defer teardownTestEnv(t)
+	type args struct {
+		key      string
+		fallback bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "returns fallback",
+			args: args{
+				key:      "MGC_TST_NO_ENVAR",
+				fallback: false,
+			},
+			want: false,
+		},
+		{
+			name: "returns env var value",
+			args: args{
+				key:      "MGC_TST_FALSE_BOOL",
+				fallback: true,
+			},
+			want: false,
+		},
+		{
+			name: "returns fallback for non bool env var value",
+			args: args{
+				key:      "MGC_TST_NOT_BOOL",
+				fallback: false,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetEnvBool(tt.args.key, tt.args.fallback); got != tt.want {
+				t.Errorf("GetEnvBool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetEnvString(t *testing.T) {
+	setupTestEnv(t)
+	defer teardownTestEnv(t)
+
+	type args struct {
+		key      string
+		fallback string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "returns fallback",
+			args: args{
+				key:      "MGC_TST_NO_ENVAR",
+				fallback: "bar",
+			},
+			want: "bar",
+		},
+		{
+			name: "returns env var value",
+			args: args{
+				key:      "MGC_TST_FOO_STR",
+				fallback: "bar",
+			},
+			want: "foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetEnvString(tt.args.key, tt.args.fallback); got != tt.want {
+				t.Errorf("GetEnvString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func setupTestEnv(t *testing.T) {
+	_ = os.Setenv("MGC_TST_FALSE_BOOL", "false")
+	_ = os.Setenv("MGC_TST_NOT_BOOL", "notabool")
+	_ = os.Setenv("MGC_TST_FOO_STR", "foo")
+}
+
+func teardownTestEnv(t *testing.T) {
+	_ = os.Unsetenv("MGC_TST_FALSE_BOOL")
+	_ = os.Unsetenv("MGC_TST_NOT_BOOL")
+	_ = os.Unsetenv("MGC_TST_FOO_STR")
+}

--- a/pkg/syncer/spec/suite_test.go
+++ b/pkg/syncer/spec/suite_test.go
@@ -137,7 +137,7 @@ var _ = BeforeSuite(func() {
 
 	go SpecSyncer.Start(ctx)
 
-	specSyncRunnable := syncer.GetSyncerRunnable(specSyncConfig, syncer.InformerForGVR, SpecSyncer)
+	specSyncRunnable := syncer.GetSyncerRunnable(specSyncConfig, syncer.InformerForAnnotatedGVR, SpecSyncer)
 
 	log.Log.Info("adding syncer informer to manager")
 	go func() {

--- a/pkg/syncer/status/suite_test.go
+++ b/pkg/syncer/status/suite_test.go
@@ -207,8 +207,6 @@ var _ = Describe("Status Syncer", func() {
 		})
 
 		It("should annotate the status to the upstream resource", func() {
-			metadata.AddAnnotation(gateway, syncer.MCTC_SYNC_ANNOTATION_PREFIX+clusterID, "true")
-
 			//we will be creating the data plane gateway (as spec syncer is not running)
 			dataplaneGateway := gateway.DeepCopy()
 			dataplaneGateway.Namespace = dataPlaneNS


### PR DESCRIPTION
two fixes:
- Default downstream namespace if none provided
- Status syncer no longer expects the syncer annotation on downstream resources

ping @mikenairn @david-martin 