### PR TITLE
Local setup updates

### DIFF
--- a/config/kuadrant/cr/kuadrant.yaml
+++ b/config/kuadrant/cr/kuadrant.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: mctc
+spec: {}

--- a/config/kuadrant/cr/kustomization.yaml
+++ b/config/kuadrant/cr/kustomization.yaml
@@ -1,0 +1,4 @@
+namespace: kuadrant-system
+
+resources:
+  - kuadrant.yaml

--- a/hack/.argocdUtils
+++ b/hack/.argocdUtils
@@ -6,51 +6,6 @@ argocdAddCluster() {
 
     makeSecretForCluster $managedCluster $managedCluster $LOCAL_ACCESS |
     setNamespacedName argocd $managedCluster |
-    setLabel argocd.argoproj.io/secret-type cluster | 
+    setLabel argocd.argoproj.io/secret-type cluster |
     kubectl apply --context kind-${hubCluster} -f -
-}
-
-
-CreateAgentSecret() {
-    local upstreamCluster=$1
-    local downstreamCluster=$2
-    local secretName=${downstreamCluster}
-    local internal=$3
-    local tmpfile=$(mktemp /tmp/kubeconfig-internal.XXXXXX)
-    if [ $internal == "true" ]; then
-        ${KIND_BIN} export kubeconfig --name ${upstreamCluster} --kubeconfig ${tmpfile}
-    else 
-        secretName=${downstreamCluster}-external
-        ${KIND_BIN} export kubeconfig --name ${upstreamCluster} --kubeconfig ${tmpfile}
-    fi
-    local server=$(kubectl --kubeconfig ${tmpfile} config view -o jsonpath="{$.clusters[?(@.name == 'kind-${upstreamCluster}')].cluster.server}")
-    local caData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.clusters[?(@.name == 'kind-${upstreamCluster}')].cluster.certificate-authority-data}")
-    local certData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${upstreamCluster}')].user.client-certificate-data}")
-    local keyData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${upstreamCluster}')].user.client-key-data}")
-    rm -f ${tmpfile}
-
-    kubectl create namespace mctc-system --context kind-${downstreamCluster} || true
-    cat <<EOF | kubectl apply --context kind-${downstreamCluster} -f -
-kind: Secret
-apiVersion: v1
-metadata:
-  name: ${secretName}
-  namespace: mctc-system
-  labels:
-    argocd.argoproj.io/secret-type: cluster
-stringData:
-  config: >-
-    {
-      "tlsClientConfig":
-        {
-          "insecure": true,
-          "caData": "${caData}",
-          "certData": "${certData}",
-          "keyData": "${keyData}"
-        }
-    }
-  name: ${downstreamCluster}
-  server: ${server}
-type: Opaque
-EOF
 }

--- a/hack/.clusterUtils
+++ b/hack/.clusterUtils
@@ -3,8 +3,7 @@
 makeSecretForKubeconfig() {
   local kubeconfig=$1
   local clusterName=$2
-  local targetCluster=$3
-  local targetClusterName=${targetCluster:=$clusterName}
+  local targetClusterName=$3
 
   local server=$(kubectl --kubeconfig ${kubeconfig} config view -o jsonpath="{$.clusters[?(@.name == '${clusterName}')].cluster.server}")
   local caData=$(kubectl --kubeconfig ${kubeconfig} config view --raw -o jsonpath="{$.clusters[?(@.name == '${clusterName}')].cluster.certificate-authority-data}")
@@ -37,9 +36,8 @@ EOF
 
 makeSecretForCluster() {
   local clusterName=$1
-  local targetCluster=$2
-  local targetClusterName=${targetCluster:=$clusterName}
-  local localAccess=${3}
+  local targetClusterName=$2
+  local localAccess=$3
 
   if [ "$localAccess" != "true" ]; then
     internalFlag="--internal"
@@ -48,7 +46,7 @@ makeSecretForCluster() {
   local tmpfile=$(mktemp /tmp/kubeconfig-internal.XXXXXX)
   ${KIND_BIN} export kubeconfig -q $internalFlag --name ${clusterName} --kubeconfig ${tmpfile}
 
-  makeSecretForKubeconfig $tmpfile kind-$clusterName $targetCluster $targetClusterName
+  makeSecretForKubeconfig $tmpfile kind-$clusterName $targetClusterName
   rm -f $tmpfile
 }
 

--- a/hack/make/syncer.make
+++ b/hack/make/syncer.make
@@ -6,11 +6,13 @@ SYNCER_IMG ?= syncer:$(TAG)
 build-syncer: manifests generate fmt vet ## Build syncer binary.
 	go build -o bin/syncer ./cmd/syncer/main.go
 
+METRICS_PORT ?= 8086
+HEALTH_PORT ?= 8087
 .PHONY: run-syncer
 run-syncer: manifests generate fmt vet install
 	go run ./cmd/syncer/main.go \
-	    --metrics-bind-address=:8086 \
-	    --health-probe-bind-address=:8087 \
+	    --metrics-bind-address=:${METRICS_PORT} \
+	    --health-probe-bind-address=:${HEALTH_PORT}\
 	    --control-plane-config-name=control-plane-cluster \
 	    --control-plane-config-namespace=mctc-system \
 	    --synced-resources=gateways.v1beta1.gateway.networking.k8s.io \


### PR DESCRIPTION
Local setup changes

- Allow overriding metrics and health ports on the `make run-syncer` command so you can run more than one locally:

```
METRICS_PORT=8088 HEALTH_PORT=8089 make run-syncer
```

- Remove kind from names in cluster secrets and make the cluster name consistent accross the control and data plane.

```
kubectl get secret mctc-workload-1 -n argocd --context kind-mctc-control-plane -o jsonpath="{.data.name}" | base64 --decode && echo ""
mctc-workload-1
kubectl get secret control-plane-cluster -n mctc-system --context kind-mctc-workload-1 -o jsonpath="{.data.name}" | base64 --decode && echo ""
mctc-workload-1
```

- Add kuadrant CR to local-setup