### PR TITLE
Build syncer and automatically update unstable env

### DIFF
--- a/.github/workflows/syncer-image.yaml
+++ b/.github/workflows/syncer-image.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish Controller Image
+name: Build and Publish Syncer Image
 
 on:
   push:
@@ -17,11 +17,11 @@ env:
 jobs:
   build:
     if: github.repository_owner == 'kuadrant'
-    name: Build and Publish Controller Image
+    name: Build and Publish Syncer Image
     runs-on: ubuntu-22.04
     outputs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
-      controller_image: ${{ steps.vars.outputs.base_image }}-${{ steps.vars.outputs.sha_short }}
+      syncer_image: ${{ steps.vars.outputs.base_image }}-${{ steps.vars.outputs.sha_short }}
     steps:
       - uses: actions/checkout@v3
 
@@ -29,7 +29,7 @@ jobs:
         id: vars
         run: |
           echo "sha_short=$(echo ${{ github.sha }} | cut -b -7)" >> $GITHUB_OUTPUT
-          echo "base_image=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_REGISTRY_REPO }}:controller" >> $GITHUB_OUTPUT
+          echo "base_image=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_REGISTRY_REPO }}:syncer" >> $GITHUB_OUTPUT
 
       - name: Add image tags
         id: add-tags
@@ -48,13 +48,13 @@ jobs:
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
 
-      - name: Build and push Controller Image
+      - name: Build and push Syncer Image
         id: build-and-push
         uses: docker/build-push-action@v4
         with:
           push: true
           tags: ${{ env.IMG_TAGS }}
-          target: controller
+          target: syncer
 
       - name: Print Image URL
         run: |
@@ -78,13 +78,13 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<kuadrant.dev@redhat.com>"
-      - name: Update controller image
+      - name: Update syncer image
         run: |
           export KUSTOMIZE=$(pwd)/bin/kustomize
-          cd hcg/control-plane/mctc-controller/environments/unstable
-          ${KUSTOMIZE} edit set image controller=${{ needs.build.outputs.controller_image }}
+          cd hcg/data-plane/syncer/environments/unstable
+          ${KUSTOMIZE} edit set image syncer=${{ needs.build.outputs.syncer_image }}
       - name: Commit the change for ArgoCD to pick it up
         run: |
-          git add hcg/control-plane/mctc-controller/environments/unstable/kustomization.yaml
-          git commit -m "Update controller image to ${{ needs.build.outputs.controller_image }}"
+          git add hcg/data-plane/syncer/environments/unstable/kustomization.yaml
+          git commit -m "Update syncer image to ${{ needs.build.outputs.syncer_image }}"
           git push origin main


### PR DESCRIPTION
Adds a workflow to build the syncer image and deploy it to the unstable environment. This PR depends on https://github.com/redhat-cps/glbc-deployments/pull/48 being merged first.

The workflows will produce images with the following naming:

* `quay.io/kuadrant/multi-cluster-traffic-controller:controller-7762515` and `quay.io/kuadrant/multi-cluster-traffic-controller:controller-latest`
* `quay.io/kuadrant/multi-cluster-traffic-controller:syncer-7762515` and `quay.io/kuadrant/multi-cluster-traffic-controller:syncer-latest`