### PR TITLE
Clusteradm path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ When deploying the multicluster gateway controller using the make targets, the f
 * openssl>=3
     * On macos a later version is available with `brew install openssl`. You'll need to update your PATH as macos provides an older version via libressl as well
     * On fedora use `dnf install openssl`
+* go >= 1.20
 
 ### 1. Running the controller in the cluster:
 1. Create env files:

--- a/hack/local-setup.sh
+++ b/hack/local-setup.sh
@@ -221,7 +221,7 @@ deployOCMHub(){
   clusterName=${1}
   echo "installing the hub cluster in kind-(${clusterName}) "
 
-  clusteradm init --wait --context kind-${clusterName} 
+  ${CLUSTERADM_BIN} init --wait --context kind-${clusterName}
   echo "checking if cluster is single or multi"
   if [[ -n "${OCM_SINGLE}" ]]; then
     clusterName=kind-${KIND_CLUSTER_CONTROL_PLANE}


### PR DESCRIPTION
Use `${CLUSTERADM_BIN}` throughout `local-setup.sh`

Fixes:

```
secret/mctc-aws-credentials created
installing the hub cluster in kind-(mctc-control-plane)
./hack/local-setup.sh: line 224: clusteradm: command not found
make: *** [local-setup] Error 127
```