### PR TITLE
Fix local-setup on linux

### DIFF
--- a/hack/local-setup.sh
+++ b/hack/local-setup.sh
@@ -240,7 +240,7 @@ deployOCMHub(){
       sleep 10
       [[ counter -eq $max_retry ]] && echo "Failed!" && exit 1
       echo "Trying again. Try #$counter"
-      ((counter++))
+      ((++counter))
     done
     deployOLM ${KIND_CLUSTER_CONTROL_PLANE}
     deployIstio ${KIND_CLUSTER_CONTROL_PLANE}
@@ -265,7 +265,7 @@ deployOCMSpoke(){
      sleep 10
      [[ counter -eq $max_retry ]] && echo "Failed!" && exit 1
      echo "Trying again. Try #$counter"
-     ((counter++))
+     ((++counter))
   done
 
 }


### PR DESCRIPTION
Make sure the counter expression never has a value of 0.

see https://unix.stackexchange.com/questions/146773/why-bash-increment-n-0n-return-error/146777

Alternatively just setting the initial value of the counters to 1 would also likely work