### PR TITLE
Add test build tags (unit and integration)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,17 @@ vet: ## Run go vet against code.
 lint: ## Run golangci-lint against code.
 	golangci-lint run ./...
 
+.PHONY: test-unit
+test-unit: manifests generate fmt vet envtest ## Run unit tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -tags=unit -coverprofile cover-unit.out -v
+
+.PHONY: test-integration
+test-integration: manifests generate fmt vet envtest ## Run integration tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -tags=integration -coverprofile cover-integration.out -ginkgo.v -v -timeout 0
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -tags=integration,unit -coverprofile cover.out
 
 .PHONY: local-setup
 local-setup: kind kustomize helm yq dev-tls istioctl operator-sdk clusteradm  ## Setup multi cluster traffic controller locally using kind.

--- a/pkg/_internal/env/env_test.go
+++ b/pkg/_internal/env/env_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package env
 
 import (

--- a/pkg/_internal/metadata/annotations_test.go
+++ b/pkg/_internal/metadata/annotations_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package metadata
 
 import (

--- a/pkg/_internal/metadata/finalizers_test.go
+++ b/pkg/_internal/metadata/finalizers_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package metadata
 
 import (

--- a/pkg/_internal/metadata/labels_test.go
+++ b/pkg/_internal/metadata/labels_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package metadata
 
 import (

--- a/pkg/_internal/sync/patch_test.go
+++ b/pkg/_internal/sync/patch_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package sync
 
 import (

--- a/pkg/controllers/dnspolicy/suite_test.go
+++ b/pkg/controllers/dnspolicy/suite_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package dnspolicy
 
 import (

--- a/pkg/controllers/dnsrecord/suite_test.go
+++ b/pkg/controllers/dnsrecord/suite_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
 Copyright 2022 The MultiCluster Traffic Controller Authors.
 

--- a/pkg/controllers/gateway/cluster_eventhandler_test.go
+++ b/pkg/controllers/gateway/cluster_eventhandler_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package gateway
 
 import (

--- a/pkg/controllers/gateway/params_test.go
+++ b/pkg/controllers/gateway/params_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package gateway
 
 import (

--- a/pkg/controllers/gateway/suite_test.go
+++ b/pkg/controllers/gateway/suite_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
 Copyright 2023 The MultiCluster Traffic Controller Authors.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/dns/aws/aws_test.go
+++ b/pkg/dns/aws/aws_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package aws
 
 import (

--- a/pkg/dns/aws/health_test.go
+++ b/pkg/dns/aws/health_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package aws
 
 import (

--- a/pkg/dns/service_test.go
+++ b/pkg/dns/service_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package dns_test
 
 import (

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package placement_test
 
 import (

--- a/pkg/syncer/mutator/annotationCleaner_test.go
+++ b/pkg/syncer/mutator/annotationCleaner_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package mutator
 
 import (

--- a/pkg/syncer/mutator/jsonpatch_test.go
+++ b/pkg/syncer/mutator/jsonpatch_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package mutator
 
 import (

--- a/pkg/syncer/spec/suite_test.go
+++ b/pkg/syncer/spec/suite_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
 Copyright 2023 The MultiCluster Traffic Controller Authors.
 

--- a/pkg/syncer/status/suite_test.go
+++ b/pkg/syncer/status/suite_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
 Copyright 2023 The MultiCluster Traffic Controller Authors.
 

--- a/pkg/traffic/gateway_test.go
+++ b/pkg/traffic/gateway_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package traffic
 
 import (


### PR DESCRIPTION
Add unit and integration buid tags to all test files and adds 2 new make targets to run the unit (make test-unit) and integration (make test-integration) tests. Running the integration tests will run it with the ginkgo verbose flag which fails when you try and use it on normal unit test files.