### PR TITLE
GH-214 dns package unit coverage

### DIFF
--- a/pkg/dns/service.go
+++ b/pkg/dns/service.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	labelRecordID          = "kuadrant.io/record-id"
+	LabelRecordID          = "kuadrant.io/record-id"
 	LabelGatewayReference  = "kuadrant.io/gateway-uid"
 	ProviderSpecificWeight = "weight"
 )
@@ -99,7 +99,7 @@ func (s *Service) CreateDNSRecord(ctx context.Context, subDomain string, managed
 			Name:      managedHost,
 			Namespace: managedZone.Namespace,
 			Labels: map[string]string{
-				labelRecordID:         subDomain,
+				LabelRecordID:         subDomain,
 				LabelGatewayReference: string(owner.GetUID()),
 			},
 		},

--- a/pkg/dns/service_test.go
+++ b/pkg/dns/service_test.go
@@ -4,12 +4,15 @@ package dns_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
+	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -21,14 +24,17 @@ import (
 type fakeHostResolver struct{}
 
 func (fr *fakeHostResolver) LookupIPAddr(_ context.Context, _ string) ([]dns.HostAddress, error) {
-	return nil, nil
+	return []dns.HostAddress{
+		{
+			Host: "example.com",
+			IP:   []byte{0, 0, 0, 0},
+			TTL:  time.Second * 60,
+			TXT:  "example.com",
+		},
+	}, nil
 }
 
 func TestDNS_GetDNSRecords(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("falied to add work scheme %s ", err)
-	}
 	cases := []struct {
 		Name      string
 		Resolver  func() dns.HostResolver
@@ -110,6 +116,46 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 			},
 		},
 		{
+			Name: "test get dns error when referencing different gateway",
+			Resolver: func() dns.HostResolver {
+				return &fakeHostResolver{}
+			},
+			MZ: func() *v1alpha1.ManagedZone {
+				return &v1alpha1.ManagedZone{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "b.c.com",
+						Namespace: "test",
+					},
+					Spec: v1alpha1.ManagedZoneSpec{
+						DomainName: "b.c.com",
+					},
+				}
+			},
+			SubDomain: "a",
+			DNSRecord: &v1alpha1.DNSRecord{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "a.b.c.com",
+					Namespace: "test",
+					Labels: map[string]string{
+						dns.LabelGatewayReference: "reference",
+					},
+				},
+			},
+			Gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					UID: types.UID("test"),
+				},
+			},
+			Assert: func(t *testing.T, dnsRecord *v1alpha1.DNSRecord, err error) {
+				if err == nil {
+					t.Fatalf("expected an error but got none")
+				}
+				if k8serrors.IsNotFound(err) {
+					t.Fatalf("expected a custom error but got %s", err)
+				}
+			},
+		},
+		{
 			Name: "test get dns error when not owned by gateway",
 			Resolver: func() dns.HostResolver {
 				return &fakeHostResolver{}
@@ -154,7 +200,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			gw := traffic.NewGateway(tc.Gateway)
-			f := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.DNSRecord).Build()
+			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(tc.DNSRecord).Build()
 			s := dns.NewService(f, tc.Resolver())
 			record, err := s.GetDNSRecord(context.TODO(), tc.SubDomain, tc.MZ(), gw)
 			tc.Assert(t, record, err)
@@ -352,6 +398,16 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 				}
 			},
 		},
+		{
+			Name:  "no managed zones for host give error",
+			Host:  "sub.domain.test.example.co.uk",
+			Zones: []v1alpha1.ManagedZone{},
+			Assert: func(zone *v1alpha1.ManagedZone, subdomain string, err error) {
+				if err == nil {
+					t.Fatalf("expected error, got %v", err)
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -359,4 +415,437 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 			tc.Assert(dns.FindMatchingManagedZone(tc.Host, tc.Host, tc.Zones))
 		})
 	}
+}
+
+func TestService_CleanupDNSRecords(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		gateway *gatewayv1beta1.Gateway
+		record  *v1alpha1.DNSRecord
+		wantErr bool
+	}{
+		{
+			name: "DNS record gets deleted",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					UID: types.UID("test"),
+				},
+			},
+			record: &v1alpha1.DNSRecord{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						dns.LabelGatewayReference: "test",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "no DNS records do be deleted",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					UID: types.UID("test"),
+				},
+			},
+			record:  &v1alpha1.DNSRecord{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := traffic.NewGateway(tt.gateway)
+			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(tt.record).Build()
+			s := dns.NewService(f, &fakeHostResolver{})
+
+			if err := s.CleanupDNSRecords(context.TODO(), gw); (err != nil) != tt.wantErr {
+				t.Errorf("CleanupDNSRecords() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestService_GetManagedZoneForHost(t *testing.T) {
+	tests := []struct {
+		name          string
+		host          string
+		gateway       *gatewayv1beta1.Gateway
+		mz            *v1alpha1.ManagedZoneList
+		scheme        *runtime.Scheme
+		wantSubdomain string
+		wantErr       bool
+	}{
+		{
+			name: "found MZ",
+			host: "example.com",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test",
+				},
+			},
+			mz: &v1alpha1.ManagedZoneList{
+				Items: []v1alpha1.ManagedZone{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "example.com",
+							Namespace: "test",
+						},
+						Spec: v1alpha1.ManagedZoneSpec{
+							DomainName: "example.com",
+						},
+					},
+				},
+			},
+			scheme:        testScheme(t),
+			wantSubdomain: "example.com",
+			wantErr:       false,
+		},
+		{
+			name: "unable to list MZ",
+			host: "example.com",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test",
+				},
+			},
+			mz:      &v1alpha1.ManagedZoneList{},
+			scheme:  runtime.NewScheme(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := traffic.NewGateway(tt.gateway)
+			f := fake.NewClientBuilder().WithScheme(tt.scheme).WithLists(tt.mz).Build()
+			s := dns.NewService(f, &fakeHostResolver{})
+
+			gotMZ, gotSubdomain, err := s.GetManagedZoneForHost(context.TODO(), tt.host, gw)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetManagedZoneForHost() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(gotMZ.ObjectMeta, tt.mz.Items[0].ObjectMeta) {
+				t.Errorf("GetManagedZoneForHost() gotMZ = %v, want %v", gotMZ, tt.mz.Items[0])
+			}
+			if gotSubdomain != tt.wantSubdomain {
+				t.Errorf("GetManagedZoneForHost() gotSubdomain = %v, want %v", gotSubdomain, tt.wantSubdomain)
+			}
+		})
+	}
+}
+
+func TestService_SetEndpoints(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		addresses []gatewayv1beta1.GatewayAddress
+		dnsRecord *v1alpha1.DNSRecord
+		wantErr   bool
+	}{
+		{
+			name: "endpoints are set",
+			addresses: []gatewayv1beta1.GatewayAddress{
+				{
+					Type:  addr(gatewayv1beta1.IPAddressType),
+					Value: "1.1.1.1",
+				},
+				{
+					Type:  addr(gatewayv1beta1.HostnameAddressType),
+					Value: "example.com",
+				},
+			},
+			dnsRecord: &v1alpha1.DNSRecord{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "example.com",
+				},
+			},
+		},
+		{
+			name: "no new endpoints",
+			addresses: []gatewayv1beta1.GatewayAddress{
+				{
+					Type:  addr(gatewayv1beta1.IPAddressType),
+					Value: "1.1.1.1",
+				},
+			},
+			dnsRecord: &v1alpha1.DNSRecord{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "example.com",
+				},
+				Spec: v1alpha1.DNSRecordSpec{
+					Endpoints: []*v1alpha1.Endpoint{
+						{
+							DNSName:       "example.com",
+							SetIdentifier: "1.1.1.1",
+							Targets:       []string{"1.1.1.1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(tt.dnsRecord).Build()
+			s := dns.NewService(f, &fakeHostResolver{})
+
+			if err := s.SetEndpoints(context.TODO(), tt.addresses, tt.dnsRecord, &v1alpha1.DNSPolicy{}); (err != nil) != tt.wantErr {
+				t.Errorf("SetEndpoints() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestService_CreateDNSRecord(t *testing.T) {
+	type args struct {
+		subDomain   string
+		managedZone *v1alpha1.ManagedZone
+		owner       v1.Object
+	}
+	tests := []struct {
+		name       string
+		args       args
+		recordList *v1alpha1.DNSRecordList
+		wantRecord *v1alpha1.DNSRecord
+		wantErr    bool
+	}{
+		{
+			name: "DNS record gets created",
+			args: args{
+				subDomain: "sub",
+				managedZone: &v1alpha1.ManagedZone{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "mz",
+						Namespace: "test",
+					},
+					Spec: v1alpha1.ManagedZoneSpec{
+						DomainName: "domain.com",
+					},
+				},
+				owner: &gatewayv1beta1.Gateway{
+					ObjectMeta: v1.ObjectMeta{
+						UID: types.UID("gatewayUID"),
+					},
+				},
+			},
+			recordList: &v1alpha1.DNSRecordList{},
+			wantRecord: &v1alpha1.DNSRecord{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "sub.domain.com",
+					Namespace: "test",
+					Labels: map[string]string{
+						dns.LabelRecordID:         "sub",
+						dns.LabelGatewayReference: "gatewayUID",
+					},
+					OwnerReferences: []v1.OwnerReference{
+						{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+							UID:        types.UID("gatewayUID"),
+						},
+						{
+							APIVersion:         "kuadrant.io/v1alpha1",
+							Kind:               "ManagedZone",
+							Name:               "mz",
+							Controller:         addr(true),
+							BlockOwnerDeletion: addr(true),
+						},
+					},
+					ResourceVersion: "1",
+				},
+				Spec: v1alpha1.DNSRecordSpec{
+					ManagedZoneRef: &v1alpha1.ManagedZoneReference{
+						Name: "mz",
+					},
+				},
+			},
+		},
+		{
+			name: "DNS record already exists",
+			args: args{
+				subDomain: "sub",
+				managedZone: &v1alpha1.ManagedZone{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "mz",
+						Namespace: "test",
+					},
+					Spec: v1alpha1.ManagedZoneSpec{
+						DomainName: "domain.com",
+					},
+				},
+				owner: &gatewayv1beta1.Gateway{
+					ObjectMeta: v1.ObjectMeta{
+						UID: types.UID("gatewayUID"),
+					},
+				},
+			},
+			recordList: &v1alpha1.DNSRecordList{
+				Items: []v1alpha1.DNSRecord{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "sub.domain.com",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			wantRecord: &v1alpha1.DNSRecord{
+				ObjectMeta: v1.ObjectMeta{
+					Name:            "sub.domain.com",
+					Namespace:       "test",
+					ResourceVersion: "999",
+				},
+				TypeMeta: v1.TypeMeta{
+					Kind:       "DNSRecord",
+					APIVersion: "kuadrant.io/v1alpha1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithLists(tt.recordList).Build()
+			s := dns.NewService(f, &fakeHostResolver{})
+
+			gotRecord, err := s.CreateDNSRecord(context.TODO(), tt.args.subDomain, tt.args.managedZone, tt.args.owner)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateDNSRecord() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotRecord, tt.wantRecord) {
+				t.Errorf("CreateDNSRecord() gotRecord = \n%v, want \n%v", gotRecord, tt.wantRecord)
+			}
+		})
+	}
+}
+
+func TestService_GetManagedHosts(t *testing.T) {
+	tests := []struct {
+		name      string
+		gateway   *gatewayv1beta1.Gateway
+		initLists []client.ObjectList
+		want      []v1alpha1.ManagedHost
+		wantErr   bool
+	}{
+		{
+			name: "got managed hosts",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test",
+					UID:       types.UID("gatewayUID"),
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{
+						{
+							Hostname: addr(gatewayv1beta1.Hostname("sub.domain.com")),
+						},
+					},
+				},
+			},
+			initLists: []client.ObjectList{
+				&v1alpha1.ManagedZoneList{
+					Items: []v1alpha1.ManagedZone{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Namespace: "test",
+							},
+							Spec: v1alpha1.ManagedZoneSpec{
+								DomainName: "domain.com",
+							},
+						},
+					},
+				},
+				&v1alpha1.DNSRecordList{
+					Items: []v1alpha1.DNSRecord{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "sub.domain.com",
+								Namespace: "test",
+								Labels: map[string]string{
+									dns.LabelGatewayReference: "gatewayUID",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []v1alpha1.ManagedHost{
+				{
+					Subdomain: "sub",
+					Host:      "sub.domain.com",
+					ManagedZone: &v1alpha1.ManagedZone{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       "test",
+							ResourceVersion: "999",
+						},
+						Spec: v1alpha1.ManagedZoneSpec{
+							DomainName: "domain.com",
+						},
+					},
+					DnsRecord: &v1alpha1.DNSRecord{
+						ObjectMeta: v1.ObjectMeta{
+							Name:            "sub.domain.com",
+							Namespace:       "test",
+							ResourceVersion: "999",
+							Labels: map[string]string{
+								dns.LabelGatewayReference: "gatewayUID",
+							},
+						},
+						TypeMeta: v1.TypeMeta{
+							Kind:       "DNSRecord",
+							APIVersion: "kuadrant.io/v1alpha1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "No hosts retrieved for CNAME or externaly managed host",
+			gateway: &gatewayv1beta1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test",
+					UID:       types.UID("gatewayUID"),
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					Listeners: []gatewayv1beta1.Listener{
+						{
+							Hostname: addr(gatewayv1beta1.Hostname("sub.domain.com")),
+						},
+					},
+				},
+			},
+			initLists: []client.ObjectList{},
+			want:      []v1alpha1.ManagedHost{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithLists(tt.initLists...).Build()
+			s := dns.NewService(f, &fakeHostResolver{})
+
+			got, err := s.GetManagedHosts(context.TODO(), traffic.NewGateway(tt.gateway))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetManagedHosts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != len(tt.want) && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetManagedHosts() got = \n%v, want \n%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("falied to add work scheme %s ", err)
+	}
+	if err := gatewayv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("falied to add work scheme %s ", err)
+	}
+	return scheme
+}
+
+func addr[T any](value T) *T {
+	return &value
 }


### PR DESCRIPTION
## What 
Increasing test coverage for the DNS package. 
Touched only the `service.go`. 
The `health` controller doesn't have anything in there that would not be handy to test by integration suite. 
`target`, `hostresolv` and `dns` don't have much to unit test in them. 
The files in the AWS subpackage - not sure if it makes sense to also unit test them. 

