### PR TITLE
add grace period to descheduled gateways

### DIFF
--- a/hack/make/controller.make
+++ b/hack/make/controller.make
@@ -39,3 +39,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 .PHONY: restart-controller
 restart-controller:
 	kubectl rollout restart deployment mgc-controller-manager -n multicluster-gateway-controller-system
+	
+.PHONY: tail-controller-logs
+tail-controller-logs:
+	kubectl logs -f deployment/mgc-controller-manager -n multicluster-gateway-controller-system

--- a/pkg/_internal/gracePeriod/gracePeriod.go
+++ b/pkg/_internal/gracePeriod/gracePeriod.go
@@ -1,0 +1,57 @@
+package gracePeriod
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/metadata"
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns"
+)
+
+const (
+	GraceTimestampAnnotation = "kuadrant.io/grace-timeout"
+	DefaultGracePeriod       = time.Second * dns.DefaultTTL * 10
+)
+
+var ErrGracePeriodNotExpired = fmt.Errorf("grace period has not yet expired")
+
+func WasGracePeriodNotExpiredErr(e error) bool {
+	return strings.Contains(e.Error(), "grace period has not yet expired")
+}
+
+func GracefulDelete(ctx context.Context, c client.Client, obj client.Object) error {
+	at := time.Now().Add(DefaultGracePeriod)
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		return err
+	}
+
+	// if At is before the current time, just delete it
+	if at.Before(time.Now()) || at.Equal(time.Now()) {
+		return c.Delete(ctx, obj)
+	}
+
+	//ensure finalizer and annotation are present
+	if !metadata.HasAnnotation(obj, GraceTimestampAnnotation) {
+		metadata.AddAnnotation(obj, GraceTimestampAnnotation, strconv.FormatInt(at.Unix(), 10))
+		return c.Update(ctx, obj)
+	}
+	deleteAt, err := strconv.Atoi(obj.GetAnnotations()[GraceTimestampAnnotation])
+	if err != nil {
+		//badly formed deleteAt annotation, remove it, so it will be regenerated
+		metadata.RemoveAnnotation(obj, GraceTimestampAnnotation)
+		if err := c.Update(ctx, obj); err != nil {
+			return err
+		}
+	} else {
+		//grace time reached, delete it
+		if int64(deleteAt) <= time.Now().Unix() {
+			return c.Delete(ctx, obj)
+		}
+	}
+	return ErrGracePeriodNotExpired
+}

--- a/pkg/_internal/gracePeriod/gracePeriod_test.go
+++ b/pkg/_internal/gracePeriod/gracePeriod_test.go
@@ -2,6 +2,7 @@ package gracePeriod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -40,7 +41,7 @@ func TestGracefulDelete(t *testing.T) {
 				},
 			},
 			Verify: func(t *testing.T, updatedObj client.Object, err, getErr error) {
-				if !WasGracePeriodNotExpiredErr(err) {
+				if errors.Is(err, ErrGracePeriodNotExpired) {
 					t.Fatalf("expected graceful delete error to be nil, got: %v", err)
 				}
 				if getErr != nil {

--- a/pkg/_internal/gracePeriod/gracePeriod_test.go
+++ b/pkg/_internal/gracePeriod/gracePeriod_test.go
@@ -1,0 +1,68 @@
+package gracePeriod
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	workv1 "open-cluster-management.io/api/work/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/metadata"
+)
+
+func init() {
+	if err := workv1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
+}
+
+func TestGracefulDelete(t *testing.T) {
+	now := time.Now()
+	oneSecondAway := now.Add(time.Second)
+	oneSecondAwayUnix := fmt.Sprint(oneSecondAway)
+	cases := []struct {
+		Name   string
+		Object client.Object
+		At     time.Time
+		Verify func(t *testing.T, updatedObj client.Object, err, getErr error)
+	}{
+		{
+			Name: "deleting in future sets expected annotation",
+			Object: &workv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-test-test",
+					Namespace: "test",
+				},
+			},
+			Verify: func(t *testing.T, updatedObj client.Object, err, getErr error) {
+				if !WasGracePeriodNotExpiredErr(err) {
+					t.Fatalf("expected graceful delete error to be nil, got: %v", err)
+				}
+				if getErr != nil {
+					t.Fatalf("expected get error to be 'nil', got '%v'", getErr)
+				}
+				if updatedObj.GetName() != "gateway-test-test" {
+					t.Fatalf("expected updated object, got %v", updatedObj)
+				}
+				if metadata.GetAnnotation(updatedObj, GraceTimestampAnnotation) != oneSecondAwayUnix {
+					t.Fatalf("expected grace timestamp: '%v' got '%v'", oneSecondAwayUnix, metadata.GetAnnotation(updatedObj, GraceTimestampAnnotation))
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			fc := fake.NewClientBuilder().WithObjects(tc.Object).Build()
+			err := GracefulDelete(context.TODO(), fc, tc.Object)
+			mw := &workv1.ManifestWork{}
+			getErr := fc.Get(context.TODO(), client.ObjectKeyFromObject(tc.Object), mw)
+			tc.Verify(t, mw, err, getErr)
+		})
+	}
+}

--- a/pkg/_internal/metadata/annotations.go
+++ b/pkg/_internal/metadata/annotations.go
@@ -64,6 +64,7 @@ func AddAnnotation(obj metav1.Object, key, value string) {
 			if v == value {
 				return
 			}
+			break
 		}
 	}
 	annotations[key] = value

--- a/pkg/_internal/policy/policy.go
+++ b/pkg/_internal/policy/policy.go
@@ -1,13 +1,9 @@
 package policy
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
-
-	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 )
 
 const (
@@ -22,22 +18,4 @@ func GetTargetRefValueFromPolicy(policy common.KuadrantPolicy) string {
 		ns = &policyTypedNamespace
 	}
 	return string(targetRef.Name) + "," + string(*ns)
-}
-
-func NewDefaultDNSPolicy(gateway *gatewayv1beta1.Gateway) v1alpha1.DNSPolicy {
-	gatewayTypedNamespace := gatewayv1beta1.Namespace(gateway.Namespace)
-	return v1alpha1.DNSPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      gateway.Name,
-			Namespace: gateway.Namespace,
-		},
-		Spec: v1alpha1.DNSPolicySpec{
-			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
-				Group:     gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group),
-				Kind:      "Gateway",
-				Name:      gatewayv1beta1.ObjectName(gateway.Name),
-				Namespace: &gatewayTypedNamespace,
-			},
-		},
-	}
 }

--- a/pkg/_internal/policy/policy_test.go
+++ b/pkg/_internal/policy/policy_test.go
@@ -3,9 +3,10 @@
 package policy
 
 import (
+	"testing"
+
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/apis/v1alpha1/dnspolicy_types.go
+++ b/pkg/apis/v1alpha1/dnspolicy_types.go
@@ -135,3 +135,21 @@ const HttpProtocol HealthProtocol = "HTTP"
 func init() {
 	SchemeBuilder.Register(&DNSPolicy{}, &DNSPolicyList{})
 }
+
+func NewDefaultDNSPolicy(gateway *gatewayv1beta1.Gateway) DNSPolicy {
+	gatewayTypedNamespace := gatewayv1beta1.Namespace(gateway.Namespace)
+	return DNSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gateway.Name,
+			Namespace: gateway.Namespace,
+		},
+		Spec: DNSPolicySpec{
+			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
+				Group:     gatewayv1beta1.Group(gatewayv1beta1.GroupVersion.Group),
+				Kind:      "Gateway",
+				Name:      gatewayv1beta1.ObjectName(gateway.Name),
+				Namespace: &gatewayTypedNamespace,
+			},
+		},
+	}
+}

--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -32,11 +32,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayapiv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
+
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/conditions"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/gateway"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns"
-	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
 )
 
 const (

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -20,6 +20,10 @@ import (
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 )
 
+const (
+	DefaultTTL = 60
+)
+
 // Provider knows how to manage DNS zones only as pertains to routing.
 type Provider interface {
 

--- a/pkg/dns/service.go
+++ b/pkg/dns/service.go
@@ -88,22 +88,6 @@ func (s *Service) GetManagedHosts(ctx context.Context, traffic traffic.Interface
 	return managed, nil
 }
 
-func (s *Service) GetDNSRecordsFor(ctx context.Context, trafficAccessor traffic.Interface) ([]*v1alpha1.DNSRecord, error) {
-	allHosts := trafficAccessor.GetHosts()
-
-	return slice.MapErr(allHosts, func(host string) (*v1alpha1.DNSRecord, error) {
-		managedZone, subdomain, err := s.GetManagedZoneForHost(ctx, host, trafficAccessor)
-		if err != nil {
-			return nil, err
-		}
-		if managedZone == nil {
-			return nil, nil
-		}
-
-		return s.GetDNSRecord(ctx, subdomain, managedZone, trafficAccessor)
-	})
-}
-
 // CreateDNSRecord creates a new DNSRecord, if one does not already exist, in the given managed zone with the given subdomain.
 // Needs traffic.Interface owner to block other traffic objects from accessing this record
 func (s *Service) CreateDNSRecord(ctx context.Context, subDomain string, managedZone *v1alpha1.ManagedZone, owner metav1.Object) (*v1alpha1.DNSRecord, error) {
@@ -201,6 +185,7 @@ func (s *Service) SetEndpoints(ctx context.Context, addresses []gatewayv1beta1.G
 			Targets:       []string{ep},
 			RecordType:    "A",
 			SetIdentifier: ep,
+			RecordTTL:     DefaultTTL,
 		}
 		dnsRecord.Spec.Endpoints = append(dnsRecord.Spec.Endpoints, endpoint)
 	}

--- a/pkg/dns/service.go
+++ b/pkg/dns/service.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"golang.org/x/net/publicsuffix"
-
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,6 +88,22 @@ func (s *Service) GetManagedHosts(ctx context.Context, traffic traffic.Interface
 	return managed, nil
 }
 
+func (s *Service) GetDNSRecordsFor(ctx context.Context, trafficAccessor traffic.Interface) ([]*v1alpha1.DNSRecord, error) {
+	allHosts := trafficAccessor.GetHosts()
+
+	return slice.MapErr(allHosts, func(host string) (*v1alpha1.DNSRecord, error) {
+		managedZone, subdomain, err := s.GetManagedZoneForHost(ctx, host, trafficAccessor)
+		if err != nil {
+			return nil, err
+		}
+		if managedZone == nil {
+			return nil, nil
+		}
+
+		return s.GetDNSRecord(ctx, subdomain, managedZone, trafficAccessor)
+	})
+}
+
 // CreateDNSRecord creates a new DNSRecord, if one does not already exist, in the given managed zone with the given subdomain.
 // Needs traffic.Interface owner to block other traffic objects from accessing this record
 func (s *Service) CreateDNSRecord(ctx context.Context, subDomain string, managedZone *v1alpha1.ManagedZone, owner metav1.Object) (*v1alpha1.DNSRecord, error) {
@@ -159,7 +174,8 @@ func (s *Service) SetEndpoints(ctx context.Context, addresses []gatewayv1beta1.G
 	old := dnsRecord.DeepCopy()
 	host := dnsRecord.Name
 
-	// check if endpoint already exists in the DNSRecord
+	// check if endpoint already exists in the DNSRecord - we cannot delete and rebuild as health points are injected into
+	// these endpoints elsewhere - TODO refactor this to be all in one place.
 	endpoints := []string{}
 	for _, addr := range ips {
 		endpointFound := false
@@ -167,6 +183,7 @@ func (s *Service) SetEndpoints(ctx context.Context, addresses []gatewayv1beta1.G
 			if endpoint.DNSName == host && endpoint.SetIdentifier == addr {
 				log.Log.V(3).Info("address already exists in record for host", "address ", addr, "host", host)
 				endpointFound = true
+				// if this is an existing DNS Record, we need to ensure the TTL is updated if i
 				continue
 			}
 		}
@@ -184,7 +201,6 @@ func (s *Service) SetEndpoints(ctx context.Context, addresses []gatewayv1beta1.G
 			Targets:       []string{ep},
 			RecordType:    "A",
 			SetIdentifier: ep,
-			RecordTTL:     60,
 		}
 		dnsRecord.Spec.Endpoints = append(dnsRecord.Spec.Endpoints, endpoint)
 	}
@@ -221,17 +237,17 @@ func FindMatchingManagedZone(originalHost, host string, zones []v1alpha1.Managed
 		return nil, "", fmt.Errorf("%w : %s", ErrNoManagedZoneForHost, host)
 	}
 	host = strings.ToLower(host)
-	hostParts := strings.SplitN(host, ".", 2)
-	if len(hostParts) < 2 {
-		return nil, "", fmt.Errorf("unable to parse host : %s", host)
-	}
-
 	//get the TLD from this host
 	tld, _ := publicsuffix.PublicSuffix(host)
 
 	//The host is just the TLD, or the detected TLD is not an ICANN TLD
 	if host == tld {
 		return nil, "", fmt.Errorf("no valid zone found for host: %v", originalHost)
+	}
+
+	hostParts := strings.SplitN(host, ".", 2)
+	if len(hostParts) < 2 {
+		return nil, "", fmt.Errorf("no valid zone found for host: %s", originalHost)
 	}
 
 	zone, ok := slice.Find(zones, func(zone v1alpha1.ManagedZone) bool {

--- a/pkg/placement/ocm.go
+++ b/pkg/placement/ocm.go
@@ -22,6 +22,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/conditions"
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/gracePeriod"
 )
 
 const (
@@ -156,6 +157,7 @@ func (op *ocmPlacer) Place(ctx context.Context, upStreamGateway *gatewayv1beta1.
 		log.V(3).Info("placement: ", "added gateway to cluster ", cluster, "gateway", upStreamGateway.Name, "gateway ns", upStreamGateway.Namespace)
 		existingClusters.Insert(cluster)
 	}
+
 	// remove from remove
 	for _, cluster := range removeFrom.UnsortedList() {
 		log.V(3).Info("placement: ", "removing gateway from cluster ", cluster, "gateway", upStreamGateway.Name, "gateway ns", upStreamGateway.Namespace)
@@ -166,10 +168,18 @@ func (op *ocmPlacer) Place(ctx context.Context, upStreamGateway *gatewayv1beta1.
 				Namespace: cluster,
 			},
 		}
-		if err := op.c.Delete(ctx, w, &client.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
-			// use a multi-error
+		err = op.c.Get(ctx, client.ObjectKeyFromObject(w), w)
+		if err != nil {
 			return existingClusters, err
 		}
+
+		if err := gracePeriod.GracefulDelete(ctx, op.c, w); err != nil {
+			// use a multi-error
+			log.V(3).Info("error during graceful delete", "error", err)
+			return existingClusters, err
+		}
+
+		log.V(3).Info("graceful delete of gateway manifestwork complete, deleting RBAC")
 		rbac := &workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cluster,

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Kuadrant/multicluster-gateway-controller/pkg/placement"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/placement"
 )
 
 func init() {
@@ -84,9 +85,9 @@ func TestGetAddresses(t *testing.T) {
 				}
 				if address == nil || len(address) != 1 {
 					t.Fatalf("expected 1 address to be returned but got %v", address)
-					if address[0].Value != testAddress {
-						t.Fatalf("expected address to be %s but got %s", testAddress, address[0].Value)
-					}
+				}
+				if address[0].Value != testAddress {
+					t.Fatalf("expected address to be %s but got %s", testAddress, address[0].Value)
 				}
 			},
 		},
@@ -461,7 +462,7 @@ func TestGetClusters(t *testing.T) {
 	}
 }
 
-func TestPlace(t *testing.T) {
+func TestDeschedule(t *testing.T) {
 	var manifestWorkFunc = func(downstream, name string) *workv1.ManifestWork {
 
 		return &workv1.ManifestWork{
@@ -578,43 +579,6 @@ func TestPlace(t *testing.T) {
 					},
 				},
 			},
-			ManifestWork: manifestWorkFunc,
-			Assert:       commonAssert,
-		},
-		{
-			Name: "test gateway removed from clusters",
-			Upstream: &v1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
-					Labels:    map[string]string{placement.OCMPlacementLabel: "test"},
-					Namespace: "test",
-					Name:      "test",
-				},
-				TypeMeta: v1.TypeMeta{
-					Kind:       "Gateway",
-					APIVersion: "gateway.networking.k8s.io/v1beta1",
-				},
-			},
-			PlacementDecision: placementDecisionFunc,
-			Downstream: &v1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-					Name:      "test",
-				},
-				TypeMeta: v1.TypeMeta{
-					Kind:       "Gateway",
-					APIVersion: "gateway.networking.k8s.io/v1beta1",
-				},
-			},
-			TLSSecrets: []v1.Object{
-				&corev1.Secret{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-					},
-				},
-			},
-			Clusters:     sets.Set[string](sets.NewString("c1")),
-			Existing:     sets.Set[string](sets.NewString("c1", "c2")),
 			ManifestWork: manifestWorkFunc,
 			Assert:       commonAssert,
 		},


### PR DESCRIPTION
## Changes 
- Allow a grace period of 600 seconds when descheduling a gateway from a spoke cluster
- Update e2e tests
- Add new unit tests
- Few small refactoring changes 
  - Avoiding messy imports
  - Straightening out some of the managed zone matching logic

 ## Verification
follow [walkthrough](https://github.com/Kuadrant/multicluster-gateway-controller/blob/main/docs/how-to/ocm-control-plane-walkthrough.md) until gateway is replicated to the spoke cluster.
- deschedule the cluster:
  - kubectl label --overwrite managedcluster kind-mgc-control-plane ingress-cluster=false
  - See gateway and manifestworks still exist: 
    - kubectl get gateway -A
    - kubectl get manifestworks -A
  - Wait 10 minutes
    - See gateway and manifestworks are deleted