### PR TITLE
Add e2e test to ci

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -19,10 +19,18 @@ on:
       - 'LICENSE'
 
 jobs:
+  event_payload:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cat $GITHUB_EVENT_PATH
   authorize:
+    # see https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+    # for info on author association
     environment:
       ${{ github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR' &&
       'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -1,0 +1,57 @@
+name: CI-E2E
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.adoc'
+      - '**.md'
+      - 'samples/**'
+      - 'LICENSE'
+  pull_request_target:
+    branches:
+      - main
+    paths-ignore:
+      - '**.adoc'
+      - '**.md'
+      - 'samples/**'
+      - 'LICENSE'
+
+jobs:
+  authorize:
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: "true"
+  e2e_test_suite:
+    name: E2E Test Suite
+    needs: authorize
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.19"
+      - name: Create controller-config.env
+        run: |
+          echo "AWS_DNS_PUBLIC_ZONE_ID=${{ secrets.E2E_AWS_DNS_PUBLIC_ZONE_ID }}" >> controller-config.env
+          echo "ZONE_ROOT_DOMAIN=${{ secrets.E2E_AWS_DNS_PUBLIC_ZONE_NAME }}" >> controller-config.env
+
+      - name: Create aws-credentials.env
+        run: |
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.E2E_AWS_ACCESS_KEY_ID }}" >> aws-credentials.env
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.E2E_AWS_SECRET_ACCESS_KEY }}" >> aws-credentials.env
+          echo "AWS_REGION=${{ env.AWS_REGION }}" >> aws-credentials.env
+      - name: Run suite
+        run: |
+          export OCM_SINGLE=1
+          export TEST_HUB_NAMESPACE=multi-cluster-gateways
+          export TEST_HUB_KUBE_CONTEXT=kind-mgc-control-plane
+          export TEST_MANAGED_ZONE=${{ secrets.E2E_AWS_DNS_PUBLIC_ZONE_NAME }}
+          make local-setup && make test-e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,28 +72,3 @@ jobs:
       - name: Run suite
         run: |
           make test
-
-  e2e_test_suite:
-    name: E2E Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.19"
-      - name: Create controller-config.env
-        run: |
-          echo "AWS_DNS_PUBLIC_ZONE_ID=${{ secrets.E2E_AWS_DNS_PUBLIC_ZONE_ID }}" >> controller-config.env
-          echo "ZONE_ROOT_DOMAIN=${{ secrets.E2E_AWS_DNS_PUBLIC_ZONE_NAME }}" >> controller-config.env
-      - name: Create aws-credentials.env
-        run: |
-          echo "AWS_ACCESS_KEY_ID=${{ secrets.E2E_AWS_ACCESS_KEY_ID }}" >> aws-credentials.env
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.E2E_AWS_SECRET_ACCESS_KEY }}" >> aws-credentials.env
-          echo "AWS_REGION=${{ env.AWS_REGION }}" >> aws-credentials.env
-      - name: Run suite
-        run: |
-          export OCM_SINGLE=1
-          export TEST_HUB_NAMESPACE=multi-cluster-gateways
-          export TEST_HUB_KUBE_CONTEXT=kind-mgc-control-plane
-          export TEST_MANAGED_ZONE=${{ secrets.E2E_AWS_DNS_PUBLIC_ZONE_NAME }}
-          make local-setup && make test-e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,21 +81,19 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "1.19"
-      - name: create controller-config.env
+      - name: Create controller-config.env
         run: |
           echo "AWS_DNS_PUBLIC_ZONE_ID=${{ secrets.AWS_DNS_PUBLIC_ZONE_ID }}" >> controller-config.env
           echo "ZONE_ROOT_DOMAIN=${{ secrets.AWS_DNS_PUBLIC_ZONE_NAME }}" >> controller-config.env
-      - name: create aws-credentials.env
+      - name: Create aws-credentials.env
         run: |
           echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> aws-credentials.env
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> aws-credentials.env
           echo "AWS_REGION=${{ env.AWS_REGION }}" >> aws-credentials.env
-      - name: configure e2e test suite
+      - name: Run suite
         run: |
           export OCM_SINGLE=1
           export TEST_HUB_NAMESPACE=multi-cluster-gateways
           export TEST_HUB_KUBE_CONTEXT=kind-mgc-control-plane
           export TEST_MANAGED_ZONE=${{ secrets.AWS_DNS_PUBLIC_ZONE_NAME }}
-      - name: Run suite
-        run: |
           make local-setup && make test-e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,10 @@ on:
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: v1.19
       - uses: golangci/golangci-lint-action@v2
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
         id: go
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
         id: go
@@ -63,12 +63,39 @@ jobs:
           make verify-manifests
   test_suite:
     name: Test Suite
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: v1.19
       - name: Run suite
         run: |
           make test
+
+  e2e_test_suite:
+    name: E2E Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.19"
+      - name: create controller-config.env
+        run: |
+          echo "AWS_DNS_PUBLIC_ZONE_ID=${{ secrets.AWS_DNS_PUBLIC_ZONE_ID }}" >> controller-config.env
+          echo "ZONE_ROOT_DOMAIN=${{ secrets.AWS_DNS_PUBLIC_ZONE_NAME }}" >> controller-config.env
+      - name: create aws-credentials.env
+        run: |
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> aws-credentials.env
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> aws-credentials.env
+          echo "AWS_REGION=${{ env.AWS_REGION }}" >> aws-credentials.env
+      - name: configure e2e test suite
+        run: |
+          export OCM_SINGLE=1
+          export TEST_HUB_NAMESPACE=multi-cluster-gateways
+          export TEST_HUB_KUBE_CONTEXT=kind-mgc-control-plane
+          export TEST_MANAGED_ZONE=${{ secrets.AWS_DNS_PUBLIC_ZONE_NAME }}
+      - name: Run suite
+        run: |
+          make local-setup && make test-e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,17 +83,17 @@ jobs:
           go-version: "1.19"
       - name: Create controller-config.env
         run: |
-          echo "AWS_DNS_PUBLIC_ZONE_ID=${{ secrets.AWS_DNS_PUBLIC_ZONE_ID }}" >> controller-config.env
-          echo "ZONE_ROOT_DOMAIN=${{ secrets.AWS_DNS_PUBLIC_ZONE_NAME }}" >> controller-config.env
+          echo "AWS_DNS_PUBLIC_ZONE_ID=${{ secrets.E2E_AWS_DNS_PUBLIC_ZONE_ID }}" >> controller-config.env
+          echo "ZONE_ROOT_DOMAIN=${{ secrets.E2E_AWS_DNS_PUBLIC_ZONE_NAME }}" >> controller-config.env
       - name: Create aws-credentials.env
         run: |
-          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> aws-credentials.env
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> aws-credentials.env
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.E2E_AWS_ACCESS_KEY_ID }}" >> aws-credentials.env
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.E2E_AWS_SECRET_ACCESS_KEY }}" >> aws-credentials.env
           echo "AWS_REGION=${{ env.AWS_REGION }}" >> aws-credentials.env
       - name: Run suite
         run: |
           export OCM_SINGLE=1
           export TEST_HUB_NAMESPACE=multi-cluster-gateways
           export TEST_HUB_KUBE_CONTEXT=kind-mgc-control-plane
-          export TEST_MANAGED_ZONE=${{ secrets.AWS_DNS_PUBLIC_ZONE_NAME }}
+          export TEST_MANAGED_ZONE=${{ secrets.E2E_AWS_DNS_PUBLIC_ZONE_NAME }}
           make local-setup && make test-e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o co
 FROM builder as ocm_builder
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ocm cmd/ocm/main.go
 
-
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot as controller

--- a/hack/make/dependencies.make
+++ b/hack/make/dependencies.make
@@ -46,7 +46,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
 .PHONY: operator-sdk
-operator-sdk: 
+operator-sdk:
 	@if test -x ${LOCALBIN}/operator-sdk && ! ${LOCALBIN}/operator-sdk version | grep -q ${OPERATOR_SDK_VERSION}; then \
 		echo "${OPERATOR_SDK} version is not expected ${OPERATOR_SDK_VERSION}. Removing it before installing."; \
 		rm -rf ${OPERATOR_SDK}; \
@@ -89,7 +89,7 @@ $(ISTIOCTL):
 	$(eval ISTIO_TMP := $(shell mktemp -d))
 	cd $(ISTIO_TMP); curl -sSL https://istio.io/downloadIstio | ISTIO_VERSION=$(ISTIOVERSION) sh -
 	cp $(ISTIO_TMP)/istio-$(ISTIOVERSION)/bin/istioctl ${ISTIOCTL}
-	-rm -rf $(TMP)	
+	-rm -rf $(TMP)
 
 .PHONY: clusteradm
 clusteradm: $(CLUSTERADM)


### PR DESCRIPTION
Adds new job to the CI workflow to run the e2e tests against the local-setup environment. I also updated the go-setup to action to v4 as later versions have built-in caching.
The e2e suite takes a while to complete, something in the order of 12-14 minutes, with most of the time being spent on the local-setup script itself and the tests taking just about a couple of minutes. We might need to consider some improvements to the local-setup script to try and reduce this time (hiding the installation of some things like argocd and k8s-dashboard behind flags, some parallelization, etc).