### PR TITLE
Add missing rbac

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,14 @@ rules:
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
   - placementdecisions
   verbs:
   - create

--- a/hack/make/controller.make
+++ b/hack/make/controller.make
@@ -33,8 +33,8 @@ deploy-controller: manifests kustomize ## Deploy controller to the K8s cluster s
 	$(KUSTOMIZE) --load-restrictor LoadRestrictionsNone build config/deploy/local | kubectl apply -f -
 
 .PHONY: undeploy-controller
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+undeploy-controller: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) --load-restrictor LoadRestrictionsNone build config/deploy/local | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: restart-controller
 restart-controller:

--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -64,6 +64,7 @@ type DNSPolicyReconciler struct {
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnspolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnspolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnspolicies/finalizers,verbs=update
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 
 func (r *DNSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Logger().WithValues("DNSPolicy", req.NamespacedName)


### PR DESCRIPTION
Adds the missing RBAC to allow watching OCM ManagedCluster resources from the DNSPolicy reconciler.

Should have been added as part of https://github.com/Kuadrant/multicluster-gateway-controller/pull/293