### PR TITLE
Improvements/fixes to the E2E CI workflow

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -19,7 +19,9 @@ on:
       - 'LICENSE'
 
 jobs:
-  e2e_authorize:
+  e2e_test_suite:
+    name: E2E Test Suite
+    runs-on: ubuntu-latest
     # see https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
     # for info on author association
     environment:
@@ -29,14 +31,8 @@ jobs:
       github.event.pull_request.author_association != 'COLLABORATOR' &&
       github.event.pull_request.author_association != 'CONTRIBUTOR' &&
       'e2e-external' || 'e2e-internal' }}
-    runs-on: ubuntu-latest
     steps:
       - run: cat $GITHUB_EVENT_PATH
-  e2e_test_suite:
-    name: E2E Test Suite
-    needs: authorize
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -19,11 +19,7 @@ on:
       - 'LICENSE'
 
 jobs:
-  event_payload:
-    runs-on: ubuntu-latest
-    steps:
-      - run: cat $GITHUB_EVENT_PATH
-  authorize:
+  e2e_authorize:
     # see https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
     # for info on author association
     environment:
@@ -31,10 +27,11 @@ jobs:
       github.event.pull_request.author_association != 'OWNER' &&
       github.event.pull_request.author_association != 'MEMBER' &&
       github.event.pull_request.author_association != 'COLLABORATOR' &&
-      'external' || 'internal' }}
+      github.event.pull_request.author_association != 'CONTRIBUTOR' &&
+      'e2e-external' || 'e2e-internal' }}
     runs-on: ubuntu-latest
     steps:
-      - run: "true"
+      - run: cat $GITHUB_EVENT_PATH
   e2e_test_suite:
     name: E2E Test Suite
     needs: authorize


### PR DESCRIPTION
Some improvements/fixes to the E2E CI workflow:

* Add the contributor "role" to those that don't require approval. I have reviewed the PRs after the e2e workflow was in place and have seen that even though we are all members of the Kuadrant org, in the event for the pull_request we are marked as contributors.
* Rename the GH environments so they are clearly identified as part of the e2e workflow
* Merge all jobs into one using several steps instead

/cc @david-martin 