### PR TITLE
dependency pre-req and some associated makefile updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ When deploying the multicluster gateway controller using the make targets, the f
 
 ## Prerequisites:
 * AWS
-* Kind 
-    * `make kind`
-* yq 
-    * `make yq`
+* Various dependencies installed into $(pwd)/bin e.g. kind, yq etc.
+  * Run `make dependencies`
 * openssl>=3
     * On macos a later version is available with `brew install openssl`. You'll need to update your PATH as macos provides an older version via libressl as well
     * On fedora use `dnf install openssl`

--- a/hack/make/dependencies.make
+++ b/hack/make/dependencies.make
@@ -1,4 +1,4 @@
-## Build Dependencies
+##@ Build Dependencies
 
 ## system information
 ARCH ?= amd64
@@ -38,6 +38,7 @@ GINKGO_VERSION ?= v2.6.1
 .PHONY: dependencies
 dependencies: kustomize operator-sdk controller-gen envtest kind helm yq istioctl clusteradm subctl ginkgo
 	@echo "dependencies installed successfully"
+	@echo "consider running `export PATH=$PATH:$(pwd)/bin` if you haven't already done"
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/hack/make/dependencies.make
+++ b/hack/make/dependencies.make
@@ -1,4 +1,4 @@
-##@ Build Dependencies
+## Build Dependencies
 
 ## system information
 ARCH ?= amd64
@@ -20,6 +20,7 @@ OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 CLUSTERADM ?= $(LOCALBIN)/clusteradm
 SUBCTL ?= $(LOCALBIN)/subctl
 GINKGO ?= $(LOCALBIN)/ginkgo
+YQ ?= $(LOCALBIN)/yq
 
 
 ## Tool Versions
@@ -34,39 +35,42 @@ CLUSTERADM_VERSION ?= 0.6.0
 SUBCTL_VERSION ?= release-0.15
 GINKGO_VERSION ?= v2.6.1
 
+.PHONY: dependencies
+dependencies: kustomize operator-sdk controller-gen envtest kind helm yq istioctl clusteradm subctl ginkgo
+	@echo "dependencies installed successfully"
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
 $(KUSTOMIZE): $(LOCALBIN)
-	@if test -x $(LOCALBIN)/kustomize && ! $(LOCALBIN)/kustomize version | grep -q $(KUSTOMIZE_VERSION); then \
-		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
-		rm -rf $(LOCALBIN)/kustomize; \
+	@if test -x $(KUSTOMIZE) && ! $(KUSTOMIZE) version | grep -q $(KUSTOMIZE_VERSION); then \
+		echo "$(KUSTOMIZE) version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
+		rm -rf $(KUSTOMIZE); \
 	fi
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+	test -s $(KUSTOMIZE) || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
 .PHONY: operator-sdk
-operator-sdk:
-	@if test -x ${LOCALBIN}/operator-sdk && ! ${LOCALBIN}/operator-sdk version | grep -q ${OPERATOR_SDK_VERSION}; then \
+operator-sdk: $(OPERATOR_SDK)
+$(OPERATOR_SDK): $(LOCALBIN)
+	@if test -x ${OPERATOR_SDK} && ! ${OPERATOR_SDK} version | grep -q ${OPERATOR_SDK_VERSION}; then \
 		echo "${OPERATOR_SDK} version is not expected ${OPERATOR_SDK_VERSION}. Removing it before installing."; \
 		rm -rf ${OPERATOR_SDK}; \
 	fi
-ifeq ("$(shell ls ${OPERATOR_SDK})", "")
-	curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_${OS}_${ARCH}
-	chmod +x operator-sdk_${OS}_${ARCH}
-	mv operator-sdk_${OS}_${ARCH} $(OPERATOR_SDK)
-endif
+	test -s ${OPERATOR_SDK} || \
+	( curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_${OS}_${ARCH} && \
+	chmod +x operator-sdk_${OS}_${ARCH} && \
+	mv operator-sdk_${OS}_${ARCH} $(OPERATOR_SDK) )
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
+	test -s $(CONTROLLER_GEN) && $(CONTROLLER_GEN) --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(ENVTEST) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.
@@ -81,7 +85,8 @@ $(HELM):
 
 .PHONY: yq
 yq: $(YQ)
-	test -s $(LOCALBIN)/yq || GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
+$(YQ):
+	test -s $(YQ) || GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
 
 .PHONY: istioctl
 istioctl: $(ISTIOCTL)
@@ -89,17 +94,17 @@ $(ISTIOCTL):
 	$(eval ISTIO_TMP := $(shell mktemp -d))
 	cd $(ISTIO_TMP); curl -sSL https://istio.io/downloadIstio | ISTIO_VERSION=$(ISTIOVERSION) sh -
 	cp $(ISTIO_TMP)/istio-$(ISTIOVERSION)/bin/istioctl ${ISTIOCTL}
-	-rm -rf $(TMP)
+	-rm -rf $(ISTIO_TMP)
 
 .PHONY: clusteradm
 clusteradm: $(CLUSTERADM)
 $(CLUSTERADM):
-	test -s $(LOCALBIN)/clusteradm || curl -sL https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | INSTALL_DIR=bin bash -s -- $(CLUSTERADM_VERSION)
+	test -s $(CLUSTERADM)|| curl -sL https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | INSTALL_DIR=bin bash -s -- $(CLUSTERADM_VERSION)
 
 .PHONY: subctl
 subctl: $(SUBCTL)
 $(SUBCTL):
-	test -s $(LOCALBIN)/subctl || curl https://get.submariner.io | DESTDIR=$(LOCALBIN) VERSION=$(SUBCTL_VERSION) bash
+	test -s $(SUBCTL) || curl https://get.submariner.io | DESTDIR=$(LOCALBIN) VERSION=$(SUBCTL_VERSION) bash
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary


### PR DESCRIPTION
There's no issue for this. Should I create one?

Spotted a small error `ls: /Users/lfitzger/MCG/multicluster-gateway-controller/bin/operator-sdk: No such file or directory` when running any of the make commands before the operator-sdk one which prompted to me to make one change which resulted in a few more inside the depencies.make file.

# Verification
Running `make dependencies` should result in the following binaries installed into bin directory

 clusteradm     controller-gen ginkgo         helm           istioctl       kind           kustomize      operator-sdk   setup-envtest  subctl         yq

and a successful message whether you previously had them installed or not.
