### PR TITLE
Fixing some walkthrough docs

### DIFF
--- a/docs/how-to/ocm-control-plane-walkthrough.md
+++ b/docs/how-to/ocm-control-plane-walkthrough.md
@@ -19,10 +19,8 @@ We will start with a single cluster and move to multiple clusters to illustrate 
 * Setup a `./controller-config.env` file in the root of the repo with the following key values
 
     ```bash
-    # this sets up your default managed zone
-    AWS_DNS_PUBLIC_ZONE_ID=<AWS ZONE ID>
-    # this is the domain at the root of your zone (foo.example.com)
-    ZONE_ROOT_DOMAIN=test.hcpapps.net # replace this with your root domain
+    AWS_DNS_PUBLIC_ZONE_ID=<AWS ZONE ID> # this sets up your default managed zone
+    ZONE_ROOT_DOMAIN=test.hcpapps.net # this is the domain at the root of your zone (foo.example.com)
     LOG_LEVEL=1
     ```   
 
@@ -142,7 +140,7 @@ Open two windows, which we'll refer to throughout this walkthrough as:
     make build-controller kind-load-controller deploy-controller
     ```
 
-    *Alternatively, you can run the controller locally instead by running:*
+    *Alternatively, in `T2`, you can run the controller locally instead by running:*
 
     ```bash
     (export $(cat ./controller-config.env | xargs) && export $(cat ./aws-credentials.env | xargs) && make build-controller install run-controller)
@@ -154,6 +152,11 @@ Open two windows, which we'll refer to throughout this walkthrough as:
 
     ```bash
     export KUBECONFIG=$(pwd)/local/kube/control-plane.yaml
+    ```
+
+    followed by:
+
+    ```bash
     kubectl get managedzone -n multi-cluster-gateways
     ```
 1. You should see the following:    

--- a/docs/how-to/ocm-control-plane-walkthrough.md
+++ b/docs/how-to/ocm-control-plane-walkthrough.md
@@ -47,7 +47,7 @@ export MGC_SUB_DOMAIN=myapp.test.hcpapps.net # replace this
 
 For this walkthrough, we're going to use multiple terminal sessions/windows, all using `multicluster-gateway-controller` as the `pwd`.
 
-Open three windows, which we'll refer to throughout this walkthrough as:
+Open two windows, which we'll refer to throughout this walkthrough as:
 
 * `T1` (Hub Cluster)
 * `T2` (Workloads cluster)
@@ -136,10 +136,16 @@ Open three windows, which we'll refer to throughout this walkthrough as:
 
 ### Start the Gateway Controller
 
-1. In `T1` run the following to start the Gateway Controller:
+1. In `T1` run the following to build and deploy the Gateway Controller in a container:
 
     ```bash
     make build-controller kind-load-controller deploy-controller
+    ```
+
+    *Alternatively, you can run the controller locally instead by running:*
+
+    ```bash
+    (export $(cat ./controller-config.env | xargs) && export $(cat ./aws-credentials.env | xargs) && make build-controller install run-controller)
     ```
 
 ### Check the managed zone


### PR DESCRIPTION
Stepping through the OCM walkthrough today to get things back up and running, I ran into some issues:

* The `./controller-config.env` you end up with as part of the walkthrough is malforme
* Created a related issue here https://github.com/Kuadrant/multicluster-gateway-controller/issues/323 to not allow malformed domain names for `managezone`'s
* Added a `kubectl patch` for the numberOfClusters command later in the walkthrough