### PR TITLE
Domain name crd validation

### DIFF
--- a/config/crd/bases/kuadrant.io_managedzones.yaml
+++ b/config/crd/bases/kuadrant.io_managedzones.yaml
@@ -61,6 +61,7 @@ spec:
                 type: string
               domainName:
                 description: Domain name of this ManagedZone
+                pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
                 type: string
               id:
                 description: ID is the provider assigned id of this  zone (i.e. route53.HostedZone.ID).

--- a/pkg/apis/v1alpha1/managedzone_types.go
+++ b/pkg/apis/v1alpha1/managedzone_types.go
@@ -33,6 +33,7 @@ type ManagedZoneSpec struct {
 	// +optional
 	ID string `json:"id,omitempty"`
 	//Domain name of this ManagedZone
+	// +kubebuilder:validation:Pattern=`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`
 	DomainName string `json:"domainName"`
 	//Description for this ManagedZone
 	Description string `json:"description"`

--- a/pkg/controllers/managedzone/suite_test.go
+++ b/pkg/controllers/managedzone/suite_test.go
@@ -183,5 +183,21 @@ var _ = Describe("ManagedZoneReconciler", func() {
 				return errors.IsNotFound(err)
 			}, EventuallyTimeoutMedium, TestRetryIntervalMedium).Should(BeTrue())
 		})
+
+		It("should reject a managed zone with an invalid domain name", func() {
+			invalidDomainNameManagedZone := &v1alpha1.ManagedZone{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid_domain",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ManagedZoneSpec{
+					ID:         "invalid_domain",
+					DomainName: "invalid_domain",
+				},
+			}
+			err := k8sClient.Create(ctx, invalidDomainNameManagedZone)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.domainName in body should match"))
+		})
 	})
 })


### PR DESCRIPTION
Fixes https://github.com/Kuadrant/multicluster-gateway-controller/issues/323

Adds hostname validation to `domainName` in the `managedzone` CR

Regex:

https://regex101.com/r/ZIYOaE/1