### PR TITLE
Gh 273 support for wildcard listeners and clean up dns and tls when listeners removed

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -45,7 +45,6 @@ import (
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/dnsrecord"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/gateway"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/managedzone"
-	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns/dnsprovider"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/placement"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/tls"
@@ -105,20 +104,16 @@ func main() {
 
 	placement := placement.NewOCMPlacer(mgr.GetClient())
 	provider := dnsprovider.NewProvider(mgr.GetClient())
-	dnsService := dns.NewService(mgr.GetClient())
 	certService := tls.NewService(mgr.GetClient(), certProvider)
 
 	if err = (&dnsrecord.DNSRecordReconciler{
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),
 		DNSProvider: provider.DNSProviderFactory,
-		HostService: dnsService,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DNSRecord")
 		os.Exit(1)
 	}
-
-	certService := tls.NewService(mgr.GetClient(), certProvider)
 
 	dnsPolicyBaseReconciler := reconcilers.NewBaseReconciler(
 		mgr.GetClient(), mgr.GetScheme(), mgr.GetAPIReader(),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -23,6 +23,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -117,6 +118,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	certService := tls.NewService(mgr.GetClient(), certProvider)
+
 	dnsPolicyBaseReconciler := reconcilers.NewBaseReconciler(
 		mgr.GetClient(), mgr.GetScheme(), mgr.GetAPIReader(),
 		log.Log.WithName("dnspolicy"),
@@ -128,7 +131,6 @@ func main() {
 			BaseReconciler: dnsPolicyBaseReconciler,
 		},
 		DNSProvider: provider.DNSProviderFactory,
-		HostService: dnsService,
 		Placement:   placement,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DNSPolicy")
@@ -155,7 +157,6 @@ func main() {
 		Client:       mgr.GetClient(),
 		Scheme:       mgr.GetScheme(),
 		Certificates: certService,
-		HostService:  dnsService,
 		Placement:    placement,
 	}).SetupWithManager(mgr, ctx); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Gateway")

--- a/config/cert-manager/kustomization.yaml
+++ b/config/cert-manager/kustomization.yaml
@@ -21,4 +21,4 @@ helmCharts:
       cainjector:
         enabled: false
       # Customize active controllers
-      extraArgs: ["--controllers=*,-ingress-shim"]
+      extraArgs: ["--controllers=*,-ingress-shim",--enable-certificate-owner-ref=true]

--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -56,7 +56,7 @@ func (c *DNSPolicyRefsConfig) PolicyRefsAnnotation() string {
 // DNSPolicyReconciler reconciles a DNSPolicy object
 type DNSPolicyReconciler struct {
 	reconcilers.TargetRefReconciler
-	DNSProvider dns.Provider
+	DNSProvider dns.DNSProviderFactory
 	Placement   gateway.GatewayPlacer
 }
 

--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -56,8 +56,7 @@ func (c *DNSPolicyRefsConfig) PolicyRefsAnnotation() string {
 // DNSPolicyReconciler reconciles a DNSPolicy object
 type DNSPolicyReconciler struct {
 	reconcilers.TargetRefReconciler
-	DNSProvider dns.DNSProviderFactory
-	HostService gateway.HostService
+	DNSProvider dns.Provider
 	Placement   gateway.GatewayPlacer
 }
 
@@ -94,6 +93,8 @@ func (r *DNSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if err != nil {
 					return ctrl.Result{}, err
 				}
+				// nothingmore to do now dnspolicy is an orphan
+				return ctrl.Result{}, nil
 			}
 			return ctrl.Result{}, err
 		}
@@ -245,5 +246,9 @@ func (r *DNSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&source.Kind{Type: &clusterv1.ManagedCluster{}},
 			handler.EnqueueRequestsFromMapFunc(clusterEventMapper.MapToDNSPolicy),
 		).
+		// Watches(
+		// 	&source.Kind{Type: &v1alpha1.DNSRecord{}},
+		// 	handler.EnqueueRequestsFromMapFunc(clusterEventMapper.MapToDNSPolicy),
+		// ).
 		Complete(r)
 }

--- a/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
@@ -3,9 +3,18 @@ package dnspolicy
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/slice"
+	"golang.org/x/net/publicsuffix"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -13,7 +22,19 @@ import (
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns"
-	"github.com/Kuadrant/multicluster-gateway-controller/pkg/traffic"
+)
+
+const (
+	DefaultTTL             = 60
+	DefaultCnameTTL        = 300
+	LabelGatewayReference  = "kuadrant.io/Gateway-uid"
+	LabelListenerReference = "kuadrant.io/listener-name"
+	LabelPolicyReference   = "kuadrant.io/policy-id"
+)
+
+var (
+	ErrNoManagedZoneForHost = fmt.Errorf("no managed zone for host")
+	ErrAlreadyAssigned      = fmt.Errorf("managed host already assigned")
 )
 
 func (r *DNSPolicyReconciler) reconcileDNSRecords(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy, gwDiffObj *reconcilers.GatewayDiff) error {
@@ -36,41 +57,64 @@ func (r *DNSPolicyReconciler) reconcileDNSRecords(ctx context.Context, dnsPolicy
 	return nil
 }
 
-func (r *DNSPolicyReconciler) reconcileGatewayDNSRecords(ctx context.Context, gateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) error {
+// removeDNSForDeletedListeners remove any DNSRecords that are associated with listeners that no longer exist in this gateway
+func (r *DNSPolicyReconciler) removeDNSForDeletedListeners(ctx context.Context, upstreamGateway *gatewayv1beta1.Gateway) error {
 	log := crlog.FromContext(ctx)
-
-	gatewayAccessor := traffic.NewGateway(gateway)
-
-	managedHosts, err := r.HostService.GetManagedHosts(ctx, gatewayAccessor)
-	if err != nil {
+	log.Info("DNSPolicyReconciler.removeDNSForDeletedListeners", "gateway", upstreamGateway.Name)
+	dnsList := &v1alpha1.DNSRecordList{}
+	labelSelector := &client.MatchingLabels{
+		LabelGatewayReference: string(upstreamGateway.GetUID()),
+	}
+	if err := r.Client().List(ctx, dnsList, labelSelector); err != nil {
 		return err
 	}
 
-	placed, err := r.Placement.GetPlacedClusters(ctx, gateway)
+	for _, dns := range dnsList.Items {
+		listenerExists := false
+		for _, listener := range upstreamGateway.Spec.Listeners {
+			if listener.Name == gatewayv1beta1.SectionName(dns.Labels[LabelListenerReference]) {
+				listenerExists = true
+			}
+		}
+		if !listenerExists {
+			if err := r.Client().Delete(ctx, &dns, &client.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
+				return err
+			}
+		}
+	}
+	return nil
+
+}
+
+func (r *DNSPolicyReconciler) reconcileGatewayDNSRecords(ctx context.Context, upstreamGateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) error {
+	log := crlog.FromContext(ctx)
+	if err := r.removeDNSForDeletedListeners(ctx, upstreamGateway); err != nil {
+		return err
+	}
+
+	placed, err := r.Placement.GetPlacedClusters(ctx, upstreamGateway)
 	if err != nil {
 		return err
 	}
 	clusters := placed.UnsortedList()
-	log.Info("DNSPolicyReconciler.reconcileResources", "clusters", clusters, "managedHosts", managedHosts)
+	log.Info("DNSPolicyReconciler.reconcileResources", "clusters", clusters)
 
-	log.V(3).Info("checking gateway for attached routes ", "gateway", gateway.Name, "clusters", placed, "managed hosts", len(managedHosts))
+	log.V(3).Info("checking gateway for attached routes ", "gateway", upstreamGateway.Name, "clusters", placed)
 	if len(placed) == 0 {
 		//nothing to do
 		log.V(3).Info("reconcileDNSRecords gateway has not been placed on to any downstream clusters nothing to do")
 		return nil
 	}
 
-	for _, mh := range managedHosts {
+	for _, listener := range upstreamGateway.Spec.Listeners {
 		var clusterGateways []dns.ClusterGateway
+		var mz, err = r.getManagedZoneForListener(ctx, upstreamGateway.Namespace, listener)
+		if err != nil {
+			return err
+		}
 		for _, downstreamCluster := range clusters {
-			// Only consider host for dns if there's at least 1 attached route to the listener for this host in *any* gateway
-			listener := gatewayAccessor.GetListenerByHost(mh.Host)
-			if listener == nil {
-				log.V(3).Info("no downstream listener found", "host ", mh.Host)
-				continue
-			}
 			log.V(3).Info("checking downstream", "listener ", listener.Name)
-			attached, err := r.Placement.ListenerTotalAttachedRoutes(ctx, gateway, string(listener.Name), downstreamCluster)
+			attached, err := r.Placement.ListenerTotalAttachedRoutes(ctx, upstreamGateway, string(listener.Name), downstreamCluster)
 			if err != nil {
 				log.Error(err, "failed to get total attached routes for listener ", "listener", listener.Name)
 				continue
@@ -79,42 +123,253 @@ func (r *DNSPolicyReconciler) reconcileGatewayDNSRecords(ctx context.Context, ga
 				log.V(3).Info("no attached routes for ", "listener", listener.Name, "cluster ", downstreamCluster)
 				continue
 			}
-			log.V(3).Info("hostHasAttachedRoutes", "host", mh.Host, "hostHasAttachedRoutes", attached)
-			cg, err := r.Placement.GetClusterGateway(ctx, gateway, downstreamCluster)
+			cg, err := r.Placement.GetClusterGateway(ctx, upstreamGateway, downstreamCluster)
 			if err != nil {
 				return fmt.Errorf("get cluster gateway failed: %s", err)
 			}
 			clusterGateways = append(clusterGateways, cg)
-		}
-
-		if len(clusterGateways) == 0 {
-			// delete record
-			log.V(3).Info("no cluster gateways, deleting DNS record", " for host ", mh.Host)
-			if mh.DnsRecord != nil {
-				if err := r.Client().Delete(ctx, mh.DnsRecord); client.IgnoreNotFound(err) != nil {
-					return fmt.Errorf("failed to deleted dns record for managed host %s : %s", mh.Host, err)
+			if len(clusterGateways) == 0 {
+				// delete record
+				log.V(3).Info("no cluster gateways, deleting DNS record", " for gateway ", upstreamGateway.Name, "and listener", listener.Name)
+				if err := r.deleteDNSRecordForListener(upstreamGateway.Namespace, listener); client.IgnoreNotFound(err) != nil {
+					return fmt.Errorf("failed to deleted dns record for managed host %s : %s", listener.Name, err)
 				}
+				return nil
 			}
-			return nil
 		}
-		var dnsRecord, err = r.HostService.CreateDNSRecord(ctx, mh.Subdomain, mh.ManagedZone, gateway)
+		dnsRecord, err := r.createListenerDNSRecord(ctx, dnsPolicy.GetObjectMeta().GetUID(), upstreamGateway, mz, listener)
 		if err := client.IgnoreAlreadyExists(err); err != nil {
-			return fmt.Errorf("failed to create dns record for host %s : %s ", mh.Host, err)
+			return fmt.Errorf("failed to create dns record for listener %s : %s ", listener.Name, err)
 		}
 		if k8serrors.IsAlreadyExists(err) {
-			dnsRecord, err = r.HostService.GetDNSRecord(ctx, mh.Subdomain, mh.ManagedZone, gateway)
-			if err != nil {
-				return fmt.Errorf("failed to get dns record for host %s : %s ", mh.Host, err)
+			if err := r.Client().Get(ctx, client.ObjectKeyFromObject(dnsRecord), dnsRecord); err != nil {
+				return fmt.Errorf("failed to get dns record for listener %s : %s ", listener.Name, err)
 			}
 		}
 
-		mcgTarget := dns.NewMultiClusterGatewayTarget(gateway, clusterGateways, dnsPolicy.Spec.LoadBalancing)
-		log.Info("setting dns dnsTargets for gateway listener", "listener", dnsRecord.Name, "values", mcgTarget)
+		mcgTarget := dns.NewMultiClusterGatewayTarget(upstreamGateway, clusterGateways, dnsPolicy.Spec.LoadBalancing)
+		log.Info("setting dns dnsTargets for gateway listener", "listener", listener.Name, "values", mcgTarget)
 
-		if err := r.HostService.SetEndpoints(ctx, mcgTarget, dnsRecord); err != nil {
+		if err := r.SetEndpoints(ctx, mcgTarget, dnsRecord, &listener); err != nil {
 			return fmt.Errorf("failed to add dns record dnsTargets %s %v", err, mcgTarget)
 		}
-
 	}
 	return nil
+}
+
+func (r *DNSPolicyReconciler) SetEndpoints(ctx context.Context, mcgTarget *dns.MultiClusterGatewayTarget, dnsRecord *v1alpha1.DNSRecord, listener *gatewayv1beta1.Listener) error {
+
+	old := dnsRecord.DeepCopy()
+	gwListenerHost := string(*listener.Hostname)
+	cnameHost := gwListenerHost
+	if isWildCardListener(*listener) {
+		fmt.Println("is a wildcard ***")
+		cnameHost = strings.Replace(gwListenerHost, "*.", "", -1)
+	}
+
+	//Health Checks currently modify endpoints so we have to keep existing ones in order to not lose health check ids
+	currentEndpoints := make(map[string]*v1alpha1.Endpoint, len(dnsRecord.Spec.Endpoints))
+	for _, endpoint := range dnsRecord.Spec.Endpoints {
+		currentEndpoints[endpoint.SetID()] = endpoint
+	}
+
+	var (
+		newEndpoints []*v1alpha1.Endpoint
+		endpoint     *v1alpha1.Endpoint
+	)
+
+	lbName := strings.ToLower(fmt.Sprintf("lb-%s.%s", mcgTarget.GetShortCode(), cnameHost))
+	//Create gwListenerHost CNAME (shop.example.com -> lb-a1b2.shop.example.com)
+	endpoint = createOrUpdateEndpoint(gwListenerHost, []string{lbName}, v1alpha1.CNAMERecordType, "", DefaultCnameTTL, currentEndpoints)
+	newEndpoints = append(newEndpoints, endpoint)
+
+	for geoCode, cgwTargets := range mcgTarget.GroupTargetsByGeo() {
+		geoLbName := strings.ToLower(fmt.Sprintf("%s.%s", geoCode, lbName))
+		//Create lbName CNAME (lb-a1b2.shop.example.com -> default.lb-a1b2.shop.example.com)
+		endpoint = createOrUpdateEndpoint(lbName, []string{geoLbName}, v1alpha1.CNAMERecordType, string(geoCode), DefaultCnameTTL, currentEndpoints)
+		newEndpoints = append(newEndpoints, endpoint)
+
+		switch {
+		case geoCode.IsDefaultCode():
+			endpoint.SetProviderSpecific(dns.ProviderSpecificGeoCountryCode, "*")
+		case geoCode.IsContinentCode():
+			endpoint.SetProviderSpecific(dns.ProviderSpecificGeoContinentCode, string(geoCode))
+		case geoCode.IsCountryCode():
+			endpoint.SetProviderSpecific(dns.ProviderSpecificGeoCountryCode, string(geoCode))
+		}
+
+		//Create the default geo if this geo matches the default policy geo and we haven't just created it
+		if !geoCode.IsDefaultCode() && geoCode == mcgTarget.GetDefaultGeo() {
+			endpoint = createOrUpdateEndpoint(lbName, []string{geoLbName}, v1alpha1.CNAMERecordType, "default", DefaultCnameTTL, currentEndpoints)
+			newEndpoints = append(newEndpoints, endpoint)
+			endpoint.SetProviderSpecific(dns.ProviderSpecificGeoCountryCode, "*")
+		}
+
+		for _, cgwTarget := range cgwTargets {
+			var ipValues []string
+			var hostValues []string
+			for _, gwa := range cgwTarget.GatewayAddresses {
+				if *gwa.Type == gatewayv1beta1.IPAddressType {
+					ipValues = append(ipValues, gwa.Value)
+				} else {
+					hostValues = append(hostValues, gwa.Value)
+				}
+			}
+
+			if len(ipValues) > 0 {
+				clusterLbName := strings.ToLower(fmt.Sprintf("%s.%s", cgwTarget.GetShortCode(), lbName))
+				endpoint = createOrUpdateEndpoint(clusterLbName, ipValues, v1alpha1.ARecordType, "", DefaultTTL, currentEndpoints)
+				newEndpoints = append(newEndpoints, endpoint)
+				hostValues = append(hostValues, clusterLbName)
+			}
+
+			for _, hostValue := range hostValues {
+				endpoint = createOrUpdateEndpoint(geoLbName, []string{hostValue}, v1alpha1.CNAMERecordType, hostValue, DefaultTTL, currentEndpoints)
+				endpoint.SetProviderSpecific(dns.ProviderSpecificWeight, strconv.Itoa(cgwTarget.GetWeight()))
+				newEndpoints = append(newEndpoints, endpoint)
+			}
+
+		}
+	}
+
+	dnsRecord.Spec.Endpoints = newEndpoints
+
+	if equality.Semantic.DeepEqual(old.Spec, dnsRecord.Spec) {
+		return nil
+	}
+
+	return r.Client().Update(ctx, dnsRecord, &client.UpdateOptions{})
+}
+
+func createOrUpdateEndpoint(dnsName string, targets v1alpha1.Targets, recordType v1alpha1.DNSRecordType, setIdentifier string,
+	recordTTL v1alpha1.TTL, currentEndpoints map[string]*v1alpha1.Endpoint) (endpoint *v1alpha1.Endpoint) {
+	ok := false
+	endpointID := dnsName + setIdentifier
+	if endpoint, ok = currentEndpoints[endpointID]; !ok {
+		endpoint = &v1alpha1.Endpoint{}
+		if setIdentifier != "" {
+			endpoint.SetIdentifier = setIdentifier
+		}
+	}
+	endpoint.DNSName = dnsName
+	endpoint.RecordType = string(recordType)
+	endpoint.Targets = targets
+	endpoint.RecordTTL = recordTTL
+	return endpoint
+}
+
+func dnsRecordName(owner metav1.Object, l gatewayv1beta1.Listener) string {
+	return fmt.Sprintf("%s-%s", owner.GetName(), l.Name)
+}
+
+func (r *DNSPolicyReconciler) createListenerDNSRecord(ctx context.Context, policyID types.UID, owner metav1.Object, mz *v1alpha1.ManagedZone, listener gatewayv1beta1.Listener) (*v1alpha1.DNSRecord, error) {
+	//managedHost := strings.ToLower(fmt.Sprintf("%s.%s", subDomain, managedZone.Spec.DomainName))
+
+	log := crlog.FromContext(ctx)
+	recordName := dnsRecordName(owner, listener)
+	log.Info("creating dns for gateway listener", "listener", listener.Name)
+	dnsRecord := v1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      recordName,
+			Namespace: owner.GetNamespace(),
+			Labels: map[string]string{
+				LabelListenerReference: string(listener.Name),
+				LabelGatewayReference:  string(owner.GetUID()),
+				LabelPolicyReference:   string(policyID),
+			},
+		},
+		Spec: v1alpha1.DNSRecordSpec{
+			ManagedZoneRef: &v1alpha1.ManagedZoneReference{
+				Name: mz.Name,
+			},
+		},
+	}
+	if err := controllerutil.SetOwnerReference(owner, &dnsRecord, r.Client().Scheme()); err != nil {
+		return &dnsRecord, err
+	}
+	if err := controllerutil.SetControllerReference(mz, &dnsRecord, r.Client().Scheme()); err != nil {
+		return &dnsRecord, err
+	}
+
+	err := r.Client().Create(ctx, &dnsRecord, &client.CreateOptions{})
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return &dnsRecord, err
+	}
+	//host may already be present
+	if err != nil && k8serrors.IsAlreadyExists(err) {
+		err = r.Client().Get(ctx, client.ObjectKeyFromObject(&dnsRecord), &dnsRecord)
+		if err != nil {
+			return &dnsRecord, err
+		}
+	}
+	return &dnsRecord, nil
+}
+
+func (r *DNSPolicyReconciler) getManagedZoneForListener(ctx context.Context, ns string, listener gatewayv1beta1.Listener) (*v1alpha1.ManagedZone, error) {
+	var managedZones v1alpha1.ManagedZoneList
+	if err := r.Client().List(ctx, &managedZones, client.InNamespace(ns)); err != nil {
+		log.FromContext(ctx).Error(err, "unable to list managed zones for gateway ", "in ns", ns)
+		return nil, err
+	}
+	host := string(*listener.Hostname)
+	return FindMatchingManagedZone(host, host, managedZones.Items)
+}
+
+func (r *DNSPolicyReconciler) deleteDNSRecordForListener(namespace string, listner gatewayv1beta1.Listener) error {
+
+	return nil
+
+}
+
+func (r *DNSPolicyReconciler) getDNSRecordForListener(ctx context.Context, namespace string, listener gatewayv1beta1.Listener) (*v1alpha1.DNSRecord, error) {
+	dnsrecord := &v1alpha1.DNSRecordList{}
+	labelSelector := &client.MatchingLabels{
+		LabelListenerReference: string(listener.Name),
+	}
+	if err := r.Client().List(ctx, dnsrecord, labelSelector); err != nil {
+		return nil, err
+	}
+	if len(dnsrecord.Items) == 0 {
+		return nil, fmt.Errorf("no dns record found for listener %s", listener.Name)
+	}
+	if len(dnsrecord.Items) > 1 {
+		return nil, fmt.Errorf("more than one dnsrecord found for a listener")
+	}
+	return &dnsrecord.Items[0], nil
+
+}
+
+// FindMatchingManagedZone recursively looks for a matching zone in the same ns as the gateway
+func FindMatchingManagedZone(originalHost, host string, zones []v1alpha1.ManagedZone) (*v1alpha1.ManagedZone, error) {
+	if len(zones) == 0 {
+		return nil, fmt.Errorf("%w : %s", ErrNoManagedZoneForHost, host)
+	}
+	host = strings.ToLower(host)
+	//get the TLD from this host
+	tld, _ := publicsuffix.PublicSuffix(host)
+
+	//The host is just the TLD, or the detected TLD is not an ICANN TLD
+	if host == tld {
+		return nil, fmt.Errorf("no valid zone found for host: %v", originalHost)
+	}
+
+	hostParts := strings.SplitN(host, ".", 2)
+	if len(hostParts) < 2 {
+		return nil, fmt.Errorf("no valid zone found for host: %s", originalHost)
+	}
+
+	zone, ok := slice.Find(zones, func(zone v1alpha1.ManagedZone) bool {
+		return strings.ToLower(zone.Spec.DomainName) == host
+	})
+
+	if ok {
+		return &zone, nil
+	}
+	parentDomain := hostParts[1]
+	return FindMatchingManagedZone(originalHost, parentDomain, zones)
+
+}
+
+func isWildCardListener(l gatewayv1beta1.Listener) bool {
+	return strings.HasPrefix(string(*l.Hostname), "*")
 }

--- a/pkg/controllers/gateway/gateway_controller.go
+++ b/pkg/controllers/gateway/gateway_controller.go
@@ -319,11 +319,6 @@ func (r *GatewayReconciler) reconcileDownstreamFromUpstreamGateway(ctx context.C
 		if err != nil {
 			return false, metav1.ConditionFalse, clusters, err
 		}
-		log.V(3).Info("cleaning up associated DNSRecords")
-		if err := r.HostService.CleanupDNSRecords(ctx, accessor); err != nil {
-			log.Error(err, "Error deleting DNS record")
-			return false, metav1.ConditionFalse, clusters, err
-		}
 
 		// Cleanup certificates
 		err = r.Certificates.CleanupCertificates(ctx, accessor)

--- a/pkg/controllers/gateway/gateway_controller.go
+++ b/pkg/controllers/gateway/gateway_controller.go
@@ -286,7 +286,6 @@ func (r *GatewayReconciler) reconcileDownstreamFromUpstreamGateway(ctx context.C
 	downstream := upstreamGateway.DeepCopy()
 	downstreamNS := fmt.Sprintf("%s-%s", "kuadrant", downstream.Namespace)
 	downstream.Status = gatewayv1beta1.GatewayStatus{}
-	upstreamAccessor := traffic.NewGateway(upstreamGateway)
 
 	// reset this for the sync as we don't want control plane level UID, creation etc etc
 	downstream.ObjectMeta = metav1.ObjectMeta{

--- a/pkg/dns/service.go
+++ b/pkg/dns/service.go
@@ -179,7 +179,7 @@ func (s *Service) SetEndpoints(ctx context.Context, mcgTarget *MultiClusterGatew
 			defaultEndpoint = endpoint
 			// continue here as we will add the `defaultEndpoint` later
 			continue
-		} else if (geoCode == mcgTarget.getDefaultGeo()) || defaultEndpoint == nil {
+		} else if (geoCode == mcgTarget.GetDefaultGeo()) || defaultEndpoint == nil {
 			// Ensure that a `defaultEndpoint` is always set, but the expected default takes precedence
 			defaultEndpoint = createOrUpdateEndpoint(lbName, []string{geoLbName}, v1alpha1.CNAMERecordType, "default", DefaultCnameTTL, currentEndpoints)
 		}

--- a/pkg/dns/service_test.go
+++ b/pkg/dns/service_test.go
@@ -4,7 +4,6 @@ package dns_test
 
 import (
 	"context"
-	"reflect"
 	"sort"
 	"testing"
 
@@ -393,121 +392,121 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 	}
 }
 
-func TestService_CleanupDNSRecords(t *testing.T) {
+// func TestService_CleanupDNSRecords(t *testing.T) {
 
-	tests := []struct {
-		name    string
-		gateway *gatewayv1beta1.Gateway
-		record  *v1alpha1.DNSRecord
-		wantErr bool
-	}{
-		{
-			name: "DNS record gets deleted",
-			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
-					UID: types.UID("test"),
-				},
-			},
-			record: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{
-						dns.LabelGatewayReference: "test",
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "no DNS records do be deleted",
-			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
-					UID: types.UID("test"),
-				},
-			},
-			record:  &v1alpha1.DNSRecord{},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gw := traffic.NewGateway(tt.gateway)
-			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(tt.record).Build()
-			s := dns.NewService(f)
-			if err := s.CleanupDNSRecords(context.TODO(), gw); (err != nil) != tt.wantErr {
-				t.Errorf("CleanupDNSRecords() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
+// 	tests := []struct {
+// 		name    string
+// 		gateway *gatewayv1beta1.Gateway
+// 		record  *v1alpha1.DNSRecord
+// 		wantErr bool
+// 	}{
+// 		{
+// 			name: "DNS record gets deleted",
+// 			gateway: &gatewayv1beta1.Gateway{
+// 				ObjectMeta: v1.ObjectMeta{
+// 					UID: types.UID("test"),
+// 				},
+// 			},
+// 			record: &v1alpha1.DNSRecord{
+// 				ObjectMeta: v1.ObjectMeta{
+// 					Labels: map[string]string{
+// 						dns.LabelGatewayReference: "test",
+// 					},
+// 				},
+// 			},
+// 			wantErr: false,
+// 		},
+// 		{
+// 			name: "no DNS records do be deleted",
+// 			gateway: &gatewayv1beta1.Gateway{
+// 				ObjectMeta: v1.ObjectMeta{
+// 					UID: types.UID("test"),
+// 				},
+// 			},
+// 			record:  &v1alpha1.DNSRecord{},
+// 			wantErr: false,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			gw := traffic.NewGateway(tt.gateway)
+// 			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(tt.record).Build()
+// 			s := dns.NewService(f)
+// 			if err := s.CleanupDNSRecords(context.TODO(), gw); (err != nil) != tt.wantErr {
+// 				t.Errorf("CleanupDNSRecords() error = %v, wantErr %v", err, tt.wantErr)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestService_GetManagedZoneForHost(t *testing.T) {
-	tests := []struct {
-		name          string
-		host          string
-		gateway       *gatewayv1beta1.Gateway
-		mz            *v1alpha1.ManagedZoneList
-		scheme        *runtime.Scheme
-		wantSubdomain string
-		wantErr       bool
-	}{
-		{
-			name: "found MZ",
-			host: "example.com",
-			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-				},
-			},
-			mz: &v1alpha1.ManagedZoneList{
-				Items: []v1alpha1.ManagedZone{
-					{
-						ObjectMeta: v1.ObjectMeta{
-							Name:      "example.com",
-							Namespace: "test",
-						},
-						Spec: v1alpha1.ManagedZoneSpec{
-							DomainName: "example.com",
-						},
-					},
-				},
-			},
-			scheme:        testScheme(t),
-			wantSubdomain: "example.com",
-			wantErr:       false,
-		},
-		{
-			name: "unable to list MZ",
-			host: "example.com",
-			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-				},
-			},
-			mz:      &v1alpha1.ManagedZoneList{},
-			scheme:  runtime.NewScheme(),
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gw := traffic.NewGateway(tt.gateway)
-			f := fake.NewClientBuilder().WithScheme(tt.scheme).WithLists(tt.mz).Build()
-			s := dns.NewService(f)
+// func TestService_GetManagedZoneForHost(t *testing.T) {
+// 	tests := []struct {
+// 		name          string
+// 		host          string
+// 		gateway       *gatewayv1beta1.Gateway
+// 		mz            *v1alpha1.ManagedZoneList
+// 		scheme        *runtime.Scheme
+// 		wantSubdomain string
+// 		wantErr       bool
+// 	}{
+// 		{
+// 			name: "found MZ",
+// 			host: "example.com",
+// 			gateway: &gatewayv1beta1.Gateway{
+// 				ObjectMeta: v1.ObjectMeta{
+// 					Namespace: "test",
+// 				},
+// 			},
+// 			mz: &v1alpha1.ManagedZoneList{
+// 				Items: []v1alpha1.ManagedZone{
+// 					{
+// 						ObjectMeta: v1.ObjectMeta{
+// 							Name:      "example.com",
+// 							Namespace: "test",
+// 						},
+// 						Spec: v1alpha1.ManagedZoneSpec{
+// 							DomainName: "example.com",
+// 						},
+// 					},
+// 				},
+// 			},
+// 			scheme:        testScheme(t),
+// 			wantSubdomain: "example.com",
+// 			wantErr:       false,
+// 		},
+// 		{
+// 			name: "unable to list MZ",
+// 			host: "example.com",
+// 			gateway: &gatewayv1beta1.Gateway{
+// 				ObjectMeta: v1.ObjectMeta{
+// 					Namespace: "test",
+// 				},
+// 			},
+// 			mz:      &v1alpha1.ManagedZoneList{},
+// 			scheme:  runtime.NewScheme(),
+// 			wantErr: true,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			gw := traffic.NewGateway(tt.gateway)
+// 			f := fake.NewClientBuilder().WithScheme(tt.scheme).WithLists(tt.mz).Build()
+// 			s := dns.NewService(f)
 
-			gotMZ, gotSubdomain, err := s.GetManagedZoneForHost(context.TODO(), tt.host, gw)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetManagedZoneForHost() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !tt.wantErr && !reflect.DeepEqual(gotMZ.ObjectMeta, tt.mz.Items[0].ObjectMeta) {
-				t.Errorf("GetManagedZoneForHost() gotMZ = %v, want %v", gotMZ, tt.mz.Items[0])
-			}
-			if gotSubdomain != tt.wantSubdomain {
-				t.Errorf("GetManagedZoneForHost() gotSubdomain = %v, want %v", gotSubdomain, tt.wantSubdomain)
-			}
-		})
-	}
-}
+// 			gotMZ, gotSubdomain, err := s.GetManagedZoneForHost(context.TODO(), tt.host, gw)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("GetManagedZoneForHost() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
+// 			if !tt.wantErr && !reflect.DeepEqual(gotMZ.ObjectMeta, tt.mz.Items[0].ObjectMeta) {
+// 				t.Errorf("GetManagedZoneForHost() gotMZ = %v, want %v", gotMZ, tt.mz.Items[0])
+// 			}
+// 			if gotSubdomain != tt.wantSubdomain {
+// 				t.Errorf("GetManagedZoneForHost() gotSubdomain = %v, want %v", gotSubdomain, tt.wantSubdomain)
+// 			}
+// 		})
+// 	}
+// }
 
 func TestService_SetEndpoints(t *testing.T) {
 
@@ -835,245 +834,6 @@ func TestService_SetEndpoints(t *testing.T) {
 				}
 			}
 
-		})
-	}
-}
-
-func TestService_CreateDNSRecord(t *testing.T) {
-	type args struct {
-		subDomain   string
-		managedZone *v1alpha1.ManagedZone
-		owner       v1.Object
-	}
-	tests := []struct {
-		name       string
-		args       args
-		recordList *v1alpha1.DNSRecordList
-		wantRecord *v1alpha1.DNSRecord
-		wantErr    bool
-	}{
-		{
-			name: "DNS record gets created",
-			args: args{
-				subDomain: "sub",
-				managedZone: &v1alpha1.ManagedZone{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "mz",
-						Namespace: "test",
-					},
-					Spec: v1alpha1.ManagedZoneSpec{
-						DomainName: "domain.com",
-					},
-				},
-				owner: &gatewayv1beta1.Gateway{
-					ObjectMeta: v1.ObjectMeta{
-						UID: types.UID("gatewayUID"),
-					},
-				},
-			},
-			recordList: &v1alpha1.DNSRecordList{},
-			wantRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "sub.domain.com",
-					Namespace: "test",
-					Labels: map[string]string{
-						dns.LabelRecordID:         "sub",
-						dns.LabelGatewayReference: "gatewayUID",
-					},
-					OwnerReferences: []v1.OwnerReference{
-						{
-							APIVersion: "gateway.networking.k8s.io/v1beta1",
-							Kind:       "Gateway",
-							UID:        types.UID("gatewayUID"),
-						},
-						{
-							APIVersion:         "kuadrant.io/v1alpha1",
-							Kind:               "ManagedZone",
-							Name:               "mz",
-							Controller:         testutil.Pointer(true),
-							BlockOwnerDeletion: testutil.Pointer(true),
-						},
-					},
-					ResourceVersion: "1",
-				},
-				Spec: v1alpha1.DNSRecordSpec{
-					ManagedZoneRef: &v1alpha1.ManagedZoneReference{
-						Name: "mz",
-					},
-				},
-			},
-		},
-		{
-			name: "DNS record already exists",
-			args: args{
-				subDomain: "sub",
-				managedZone: &v1alpha1.ManagedZone{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "mz",
-						Namespace: "test",
-					},
-					Spec: v1alpha1.ManagedZoneSpec{
-						DomainName: "domain.com",
-					},
-				},
-				owner: &gatewayv1beta1.Gateway{
-					ObjectMeta: v1.ObjectMeta{
-						UID: types.UID("gatewayUID"),
-					},
-				},
-			},
-			recordList: &v1alpha1.DNSRecordList{
-				Items: []v1alpha1.DNSRecord{
-					{
-						ObjectMeta: v1.ObjectMeta{
-							Name:      "sub.domain.com",
-							Namespace: "test",
-						},
-					},
-				},
-			},
-			wantRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
-					Name:            "sub.domain.com",
-					Namespace:       "test",
-					ResourceVersion: "999",
-				},
-				TypeMeta: v1.TypeMeta{
-					Kind:       "DNSRecord",
-					APIVersion: "kuadrant.io/v1alpha1",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithLists(tt.recordList).Build()
-			s := dns.NewService(f)
-
-			gotRecord, err := s.CreateDNSRecord(context.TODO(), tt.args.subDomain, tt.args.managedZone, tt.args.owner)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateDNSRecord() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !equality.Semantic.DeepEqual(gotRecord, tt.wantRecord) {
-				t.Errorf("CreateDNSRecord() gotRecord = \n%v, want \n%v", gotRecord, tt.wantRecord)
-			}
-		})
-	}
-}
-
-func TestService_GetManagedHosts(t *testing.T) {
-	tests := []struct {
-		name      string
-		gateway   *gatewayv1beta1.Gateway
-		initLists []client.ObjectList
-		want      []v1alpha1.ManagedHost
-		wantErr   bool
-	}{
-		{
-			name: "got managed hosts",
-			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-					UID:       types.UID("gatewayUID"),
-				},
-				Spec: gatewayv1beta1.GatewaySpec{
-					Listeners: []gatewayv1beta1.Listener{
-						{
-							Hostname: testutil.Pointer(gatewayv1beta1.Hostname("sub.domain.com")),
-						},
-					},
-				},
-			},
-			initLists: []client.ObjectList{
-				&v1alpha1.ManagedZoneList{
-					Items: []v1alpha1.ManagedZone{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Namespace: "test",
-							},
-							Spec: v1alpha1.ManagedZoneSpec{
-								DomainName: "domain.com",
-							},
-						},
-					},
-				},
-				&v1alpha1.DNSRecordList{
-					Items: []v1alpha1.DNSRecord{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "sub.domain.com",
-								Namespace: "test",
-								Labels: map[string]string{
-									dns.LabelGatewayReference: "gatewayUID",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: []v1alpha1.ManagedHost{
-				{
-					Subdomain: "sub",
-					Host:      "sub.domain.com",
-					ManagedZone: &v1alpha1.ManagedZone{
-						ObjectMeta: v1.ObjectMeta{
-							Namespace:       "test",
-							ResourceVersion: "999",
-						},
-						Spec: v1alpha1.ManagedZoneSpec{
-							DomainName: "domain.com",
-						},
-					},
-					DnsRecord: &v1alpha1.DNSRecord{
-						ObjectMeta: v1.ObjectMeta{
-							Name:            "sub.domain.com",
-							Namespace:       "test",
-							ResourceVersion: "999",
-							Labels: map[string]string{
-								dns.LabelGatewayReference: "gatewayUID",
-							},
-						},
-						TypeMeta: v1.TypeMeta{
-							Kind:       "DNSRecord",
-							APIVersion: "kuadrant.io/v1alpha1",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "No hosts retrieved for CNAME or externaly managed host",
-			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-					UID:       types.UID("gatewayUID"),
-				},
-				Spec: gatewayv1beta1.GatewaySpec{
-					Listeners: []gatewayv1beta1.Listener{
-						{
-							Hostname: testutil.Pointer(gatewayv1beta1.Hostname("sub.domain.com")),
-						},
-					},
-				},
-			},
-			initLists: []client.ObjectList{},
-			want:      []v1alpha1.ManagedHost{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithLists(tt.initLists...).Build()
-			s := dns.NewService(f)
-
-			got, err := s.GetManagedHosts(context.TODO(), traffic.NewGateway(tt.gateway))
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetManagedHosts() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if len(got) != len(tt.want) && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetManagedHosts() got = \n%v, want \n%v", got, tt.want)
-			}
 		})
 	}
 }

--- a/pkg/dns/target.go
+++ b/pkg/dns/target.go
@@ -51,7 +51,7 @@ func (t *MultiClusterGatewayTarget) GroupTargetsByGeo() map[GeoCode][]ClusterGat
 	return geoTargets
 }
 
-func (t *MultiClusterGatewayTarget) getDefaultGeo() GeoCode {
+func (t *MultiClusterGatewayTarget) GetDefaultGeo() GeoCode {
 	if t.LoadBalancing != nil && t.LoadBalancing.Geo != nil {
 		geoCode := GeoCode(t.LoadBalancing.Geo.DefaultGeo)
 		if geoCode.IsValid() {
@@ -61,7 +61,7 @@ func (t *MultiClusterGatewayTarget) getDefaultGeo() GeoCode {
 	return DefaultGeo
 }
 
-func (t *MultiClusterGatewayTarget) getDefaultWeight() int {
+func (t *MultiClusterGatewayTarget) GetDefaultWeight() int {
 	if t.LoadBalancing != nil && t.LoadBalancing.Weighted != nil {
 		return int(t.LoadBalancing.Weighted.DefaultWeight)
 	}
@@ -75,7 +75,7 @@ func (t *MultiClusterGatewayTarget) setClusterGatewayTargets(clusterGateways []C
 		if t.LoadBalancing != nil && t.LoadBalancing.Weighted != nil {
 			customWeights = t.LoadBalancing.Weighted.Custom
 		}
-		cgt := NewClusterGatewayTarget(cg, t.getDefaultGeo(), t.getDefaultWeight(), customWeights)
+		cgt := NewClusterGatewayTarget(cg, t.GetDefaultGeo(), t.GetDefaultWeight(), customWeights)
 		cgTargets = append(cgTargets, cgt)
 	}
 	t.ClusterGatewayTargets = cgTargets

--- a/test/mockInterfaces.go
+++ b/test/mockInterfaces.go
@@ -5,10 +5,8 @@ package test
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,7 +15,7 @@ import (
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/traffic"
-	"github.com/Kuadrant/multicluster-gateway-controller/test/util"
+	testutil "github.com/Kuadrant/multicluster-gateway-controller/test/util"
 )
 
 type FakeCertificateService struct {
@@ -65,95 +63,27 @@ func (h *FakeHostService) GetDNSRecordsFor(_ context.Context, _ traffic.Interfac
 	return nil, nil
 }
 
-func (h *FakeHostService) CleanupDNSRecords(_ context.Context, _ traffic.Interface) error {
-	return nil
-}
+// func (h *FakeHostService) CleanupDNSRecords(_ context.Context, _ traffic.Interface) error {
+// 	return nil
+// }
 
-func (h *FakeHostService) GetManagedHosts(ctx context.Context, traffic traffic.Interface) ([]v1alpha1.ManagedHost, error) {
-	managed := []v1alpha1.ManagedHost{}
-	for _, host := range traffic.GetHosts() {
-		managedZone, subDomain, err := h.GetManagedZoneForHost(ctx, host, traffic)
-		if err != nil {
-			return nil, err
-		}
-		if managedZone == nil {
-			// its ok for no managedzone to be present as this could be a CNAME or externally managed host
-			continue
-		}
-		dnsRecord, err := h.GetDNSRecord(ctx, subDomain, managedZone, traffic)
-		if err != nil && !k8serrors.IsNotFound(err) {
-			return nil, err
-		}
-		managedHost := v1alpha1.ManagedHost{
-			Host:        host,
-			Subdomain:   subDomain,
-			ManagedZone: managedZone,
-			DnsRecord:   dnsRecord,
-		}
+// func (h *FakeHostService) GetManagedZoneForHost(ctx context.Context, host string, t traffic.Interface) (*v1alpha1.ManagedZone, string, error) {
+// 	hostParts := strings.SplitN(host, ".", 2)
+// 	if len(hostParts) < 2 {
+// 		return nil, "", fmt.Errorf("unable to parse host : %s on traffic resource : %s", host, t.GetName())
+// 	}
+// 	subDomain := hostParts[0]
+// 	zone := v1alpha1.ManagedZoneList{}
 
-		managed = append(managed, managedHost)
-	}
-	return managed, nil
-}
-
-func (h *FakeHostService) CreateDNSRecord(_ context.Context, subDomain string, _ *v1alpha1.ManagedZone, _ v1.Object) (*v1alpha1.DNSRecord, error) {
-	if subDomain == testutil.FailCreateDNSSubdomain {
-		return nil, fmt.Errorf(testutil.FailCreateDNSSubdomain)
-	}
-	record := v1alpha1.DNSRecord{}
-	return &record, nil
-}
-
-func (h *FakeHostService) GetDNSRecord(ctx context.Context, subDomain string, managedZone *v1alpha1.ManagedZone, _ v1.Object) (*v1alpha1.DNSRecord, error) {
-	if subDomain == testutil.FailFetchDANSSubdomain {
-		return &v1alpha1.DNSRecord{}, fmt.Errorf(testutil.FailFetchDANSSubdomain)
-	}
-	record := &v1alpha1.DNSRecord{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      managedZone.Spec.DomainName,
-			Namespace: managedZone.GetNamespace(),
-		},
-	}
-
-	if err := h.controlClient.Get(ctx, client.ObjectKeyFromObject(record), record); err != nil {
-		return nil, err
-	}
-	return record, nil
-}
-
-func (h *FakeHostService) GetDNSRecordManagedZone(ctx context.Context, dnsRecord *v1alpha1.DNSRecord) (*v1alpha1.ManagedZone, error) {
-
-	if dnsRecord.Spec.ManagedZoneRef == nil {
-		return nil, fmt.Errorf("no managed zone configured for : %s", dnsRecord.Name)
-	}
-
-	managedZone := &v1alpha1.ManagedZone{}
-
-	err := h.controlClient.Get(ctx, client.ObjectKey{Namespace: dnsRecord.Namespace, Name: dnsRecord.Spec.ManagedZoneRef.Name}, managedZone)
-	if err != nil {
-		return nil, err
-	}
-
-	return managedZone, nil
-}
-
-func (h *FakeHostService) GetManagedZoneForHost(ctx context.Context, host string, t traffic.Interface) (*v1alpha1.ManagedZone, string, error) {
-	hostParts := strings.SplitN(host, ".", 2)
-	if len(hostParts) < 2 {
-		return nil, "", fmt.Errorf("unable to parse host : %s on traffic resource : %s", host, t.GetName())
-	}
-	subDomain := hostParts[0]
-	zone := v1alpha1.ManagedZoneList{}
-
-	err := h.controlClient.List(ctx, &zone, client.InNamespace(t.GetNamespace()))
-	if err != nil {
-		return nil, "", err
-	}
-	if len(zone.Items) == 0 {
-		return nil, subDomain, nil
-	}
-	return &zone.Items[0], subDomain, nil
-}
+// 	err := h.controlClient.List(ctx, &zone, client.InNamespace(t.GetNamespace()))
+// 	if err != nil {
+// 		return nil, "", err
+// 	}
+// 	if len(zone.Items) == 0 {
+// 		return nil, subDomain, nil
+// 	}
+// 	return &zone.Items[0], subDomain, nil
+// }
 
 func (h *FakeHostService) AddEndpoints(_ context.Context, gateway traffic.Interface, _ *v1alpha1.DNSRecord) error {
 	hosts := gateway.GetHosts()


### PR DESCRIPTION
**What**

adds support for wildcard hostnames in gateway listeners. Also adds support for cleaning up DNS records when a listener is removed. 

As part of this work the code is moving to focus around listeners rather than host names and logic for DNS is being focused in just the DNSPolicy controller


While TLS is still handled by the gateway controller, if we end up with a TLSPolicy I can imagine we would also want to follow the same pattern as DNSPolicy