### PR TITLE
Handle MangedCluster delete events

### DIFF
--- a/pkg/_internal/gracePeriod/gracePeriod.go
+++ b/pkg/_internal/gracePeriod/gracePeriod.go
@@ -20,7 +20,7 @@ const (
 
 var ErrGracePeriodNotExpired = fmt.Errorf("grace period has not yet expired")
 
-func GracefulDelete(ctx context.Context, c client.Client, obj client.Object) error {
+func GracefulDelete(ctx context.Context, c client.Client, obj client.Object, ignoreGrace bool) error {
 	log := log.Log
 	at := time.Now().Add(DefaultGracePeriod)
 	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
@@ -28,8 +28,8 @@ func GracefulDelete(ctx context.Context, c client.Client, obj client.Object) err
 		return err
 	}
 
-	// if At is before the current time, just delete it
-	if at.Before(time.Now()) || at.Equal(time.Now()) {
+	// If ignored the grace, of if At is before the current time, just delete it
+	if ignoreGrace || at.Before(time.Now()) || at.Equal(time.Now()) {
 		return c.Delete(ctx, obj)
 	}
 

--- a/pkg/_internal/gracePeriod/gracePeriod_test.go
+++ b/pkg/_internal/gracePeriod/gracePeriod_test.go
@@ -60,7 +60,7 @@ func TestGracefulDelete(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			fc := fake.NewClientBuilder().WithObjects(tc.Object).Build()
-			err := GracefulDelete(context.TODO(), fc, tc.Object)
+			err := GracefulDelete(context.TODO(), fc, tc.Object, false)
 			mw := &workv1.ManifestWork{}
 			getErr := fc.Get(context.TODO(), client.ObjectKeyFromObject(tc.Object), mw)
 			tc.Verify(t, mw, err, getErr)


### PR DESCRIPTION
Fixes #303

When a ManagedCluster is deleted, don't attempt to update the DNSPolicy straight away.
Instead, reconcile the Gateway first, which will trigger a DNSPolicy reconcile if there are any changes related to placement changes e.g.
IPAddresses changing.

When a ManagedCluster is deleted, don't wait for the grace period before deleting a Gateway (via ManifestWork).
Instead, delete the ManifestWork straight away.
Due to a known issue in OCM, https://github.com/open-cluster-management-io/ocm/issues/140 the ManifestWork is not removed after the deletionTimestamp is added in this sceanrio.
To allow for this, the gateway placement logic will filter out any ManifestWork resources that have a deletionTimestamp set.

To verify:

* Follow through the full ocm walkthrough
* Delete 1 of the ManagedClusters e.g. `kubectl delete managedcluster kind-mgc-workload-1`
* Verify the DNSPolicy status is `Ready` and doesn't have an error like [this](https://gist.github.com/david-martin/49421cde1fd12ac4d94fd3a9cfade228#file-dnspolicies-yaml-L24-L30)
* Verify the Gateway (and the kuadrant-multi-cluster-gateways namespacae) no longer exists in the `kind-mgc-workload-1` cluster
* Verify the [dnspolicy errors](https://gist.github.com/david-martin/49421cde1fd12ac4d94fd3a9cfade228#file-mgc_controller-log-L21-L27) are no longer happening in the logs
* Verify the DNSRecord only has 1 set of endpoints for 1 IPAddress [instead of 2](https://gist.github.com/david-martin/49421cde1fd12ac4d94fd3a9cfade228#file-dnsrecords-yaml-L29-L71).