### PR TITLE
some code cleanup suggestions

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/dnspolicy"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/dnsrecord"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/gateway"
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/gatewayclass"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/managedzone"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns/dnsprovider"
@@ -107,7 +108,7 @@ func main() {
 	dnsService := dns.NewService(mgr.GetClient())
 	certService := tls.NewService(mgr.GetClient(), certProvider)
 
-	if err = (&dnsrecord.DNSRecordReconciler{
+	if err = (&dnsrecord.Reconciler{
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),
 		DNSProvider: provider.DNSProviderFactory,
@@ -123,7 +124,7 @@ func main() {
 		mgr.GetEventRecorderFor("DNSPolicy"),
 	)
 
-	if err = (&dnspolicy.DNSPolicyReconciler{
+	if err = (&dnspolicy.Reconciler{
 		TargetRefReconciler: reconcilers.TargetRefReconciler{
 			BaseReconciler: dnsPolicyBaseReconciler,
 		},
@@ -143,7 +144,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "ManagedZone")
 		os.Exit(1)
 	}
-	if err = (&gateway.GatewayClassReconciler{
+	if err = (&gatewayclass.Reconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
@@ -151,7 +152,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&gateway.GatewayReconciler{
+	if err = (&gateway.Reconciler{
 		Client:       mgr.GetClient(),
 		Scheme:       mgr.GetScheme(),
 		Certificates: certService,

--- a/pkg/_internal/params/params.go
+++ b/pkg/_internal/params/params.go
@@ -1,4 +1,4 @@
-package gateway
+package params
 
 import (
 	"context"
@@ -43,13 +43,13 @@ func IsInvalidParamsError(err error) (is bool) {
 	return
 }
 
-type ParamsResolver func(context.Context, client.Client, gatewayv1beta1.ParametersReference) (*Params, error)
+type Resolver func(context.Context, client.Client, gatewayv1beta1.ParametersReference) (*Params, error)
 
-var paramsResolvers = map[schema.GroupKind]ParamsResolver{
+var paramsResolvers = map[schema.GroupKind]Resolver{
 	{Group: corev1.GroupName, Kind: "ConfigMap"}: fromNamespacedObject(fromConfigMap),
 }
 
-func fromNamespacedObject[T client.Object](getParams func(T) (*Params, error)) ParamsResolver {
+func fromNamespacedObject[T client.Object](getParams func(T) (*Params, error)) Resolver {
 	template := *new(T)
 	objectType := reflect.TypeOf(template).Elem()
 
@@ -86,7 +86,7 @@ func fromConfigMap(configMap *corev1.ConfigMap) (*Params, error) {
 	return result, nil
 }
 
-func getParams(ctx context.Context, c client.Client, gatewayClassName string) (*Params, error) {
+func GetGatewayClassParams(ctx context.Context, c client.Client, gatewayClassName string) (*Params, error) {
 
 	gatewayClass := &gatewayv1beta1.GatewayClass{}
 	err := c.Get(ctx, client.ObjectKey{Name: gatewayClassName}, gatewayClass)

--- a/pkg/_internal/params/params_test.go
+++ b/pkg/_internal/params/params_test.go
@@ -1,6 +1,6 @@
 //go:build unit
 
-package gateway
+package params
 
 import (
 	"context"
@@ -213,7 +213,7 @@ func TestGetParams(t *testing.T) {
 				WithObjects(testCase.gatewayClass, testCase.paramsObj).
 				Build()
 
-			params, err := getParams(context.TODO(), client, testCase.gatewayClass.Name)
+			params, err := GetGatewayClassParams(context.TODO(), client, testCase.gatewayClass.Name)
 
 			if err := testCase.assertParams(params, err); err != nil {
 				t.Error(err)

--- a/pkg/controllers/dnspolicy/cluster_eventmapper.go
+++ b/pkg/controllers/dnspolicy/cluster_eventmapper.go
@@ -27,7 +27,7 @@ type ClusterEventMapper struct {
 }
 
 func (m *ClusterEventMapper) MapToDNSPolicy(obj client.Object) []reconcile.Request {
-	return m.mapToPolicyRequest(obj, "dnspolicy", &DNSPolicyRefsConfig{})
+	return m.mapToPolicyRequest(obj, "dnspolicy", &RefsConfig{})
 }
 
 func (m *ClusterEventMapper) mapToPolicyRequest(obj client.Object, policyKind string, policyRefsConfig common.PolicyRefsConfig) []reconcile.Request {
@@ -44,7 +44,7 @@ func (m *ClusterEventMapper) mapToPolicyRequest(obj client.Object, policyKind st
 
 	requests := make([]reconcile.Request, 0)
 	for _, gw := range allGwList.Items {
-		val := metadata.GetAnnotation(&gw, gateway.GatewayClustersAnnotation)
+		val := metadata.GetAnnotation(&gw, gateway.ClustersAnnotation)
 		if val == "" {
 			continue
 		}

--- a/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/traffic"
 )
 
-func (r *DNSPolicyReconciler) reconcileDNSRecords(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy, gwDiffObj *reconcilers.GatewayDiff) error {
+func (r *Reconciler) reconcileDNSRecords(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy, gwDiffObj *reconcilers.GatewayDiff) error {
 	log := crlog.FromContext(ctx)
 
 	for _, gw := range gwDiffObj.GatewaysWithInvalidPolicyRef {
@@ -36,7 +36,7 @@ func (r *DNSPolicyReconciler) reconcileDNSRecords(ctx context.Context, dnsPolicy
 	return nil
 }
 
-func (r *DNSPolicyReconciler) reconcileGatewayDNSRecords(ctx context.Context, gateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) error {
+func (r *Reconciler) reconcileGatewayDNSRecords(ctx context.Context, gateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) error {
 	log := crlog.FromContext(ctx)
 
 	gatewayAccessor := traffic.NewGateway(gateway)

--- a/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
@@ -26,7 +26,7 @@ type healthChecksConfig struct {
 	Protocol         *dns.HealthCheckProtocol
 }
 
-func (r *DNSPolicyReconciler) reconcileHealthChecks(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy, gwDiffObj *reconcilers.GatewayDiff) error {
+func (r *Reconciler) reconcileHealthChecks(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy, gwDiffObj *reconcilers.GatewayDiff) error {
 	log := crlog.FromContext(ctx)
 
 	// Delete Health checks for each gateway no longer referred by this policy
@@ -54,7 +54,7 @@ func (r *DNSPolicyReconciler) reconcileHealthChecks(ctx context.Context, dnsPoli
 	return r.reconcileHealthCheckStatus(allResults, dnsPolicy)
 }
 
-func (r *DNSPolicyReconciler) reconcileGatewayHealthChecks(ctx context.Context, gateway *gatewayv1beta1.Gateway, config *healthChecksConfig) ([]dns.HealthCheckResult, error) {
+func (r *Reconciler) reconcileGatewayHealthChecks(ctx context.Context, gateway *gatewayv1beta1.Gateway, config *healthChecksConfig) ([]dns.HealthCheckResult, error) {
 	allResults := []dns.HealthCheckResult{}
 
 	gatewayAccessor := traffic.NewGateway(gateway)
@@ -89,13 +89,13 @@ func (r *DNSPolicyReconciler) reconcileGatewayHealthChecks(ctx context.Context, 
 	return allResults, nil
 }
 
-func (r *DNSPolicyReconciler) reconcileDNSRecordHealthChecks(ctx context.Context, dnsRecord *v1alpha1.DNSRecord, config *healthChecksConfig) ([]dns.HealthCheckResult, error) {
+func (r *Reconciler) reconcileDNSRecordHealthChecks(ctx context.Context, dnsRecord *v1alpha1.DNSRecord, config *healthChecksConfig) ([]dns.HealthCheckResult, error) {
 
-	managedzone, err := r.HostService.GetDNSRecordManagedZone(ctx, dnsRecord)
+	managedZone, err := r.HostService.GetDNSRecordManagedZone(ctx, dnsRecord)
 	if err != nil {
 		return nil, err
 	}
-	dnsProvider, err := r.DNSProvider(ctx, managedzone)
+	dnsProvider, err := r.DNSProvider(ctx, managedZone)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (r *DNSPolicyReconciler) reconcileDNSRecordHealthChecks(ctx context.Context
 	return results, nil
 }
 
-func (r *DNSPolicyReconciler) reconcileHealthCheckStatus(results []dns.HealthCheckResult, policy *v1alpha1.DNSPolicy) error {
+func (r *Reconciler) reconcileHealthCheckStatus(results []dns.HealthCheckResult, policy *v1alpha1.DNSPolicy) error {
 	for _, result := range results {
 		if result.Result == dns.HealthCheckNoop {
 			continue

--- a/pkg/controllers/dnspolicy/gateway_eventmapper.go
+++ b/pkg/controllers/dnspolicy/gateway_eventmapper.go
@@ -18,7 +18,7 @@ type GatewayEventMapper struct {
 }
 
 func (m *GatewayEventMapper) MapToDNSPolicy(obj client.Object) []reconcile.Request {
-	return m.mapToPolicyRequest(obj, "dnspolicy", &DNSPolicyRefsConfig{})
+	return m.mapToPolicyRequest(obj, "dnspolicy", &RefsConfig{})
 }
 
 func (m *GatewayEventMapper) mapToPolicyRequest(obj client.Object, policyKind string, policyRefsConfig common.PolicyRefsConfig) []reconcile.Request {

--- a/pkg/controllers/gateway/cluster_eventhandler_test.go
+++ b/pkg/controllers/gateway/cluster_eventhandler_test.go
@@ -37,7 +37,7 @@ func TestClusterEventHandler(t *testing.T) {
 						Name:      "test-gateway",
 						Namespace: "test-ns",
 						Annotations: map[string]string{
-							GatewayClusterLabelSelectorAnnotation: "type=test",
+							ClusterLabelSelectorAnnotation: "type=test",
 						},
 					},
 					Spec: gatewayv1beta1.GatewaySpec{
@@ -62,7 +62,7 @@ func TestClusterEventHandler(t *testing.T) {
 						Name:      "test-another-gateway",
 						Namespace: "test-ns",
 						Annotations: map[string]string{
-							GatewayClusterLabelSelectorAnnotation: "another",
+							ClusterLabelSelectorAnnotation: "another",
 						},
 					},
 				},
@@ -108,7 +108,7 @@ func TestClusterEventHandler(t *testing.T) {
 						Name:      "test-gateway",
 						Namespace: "test-ns",
 						Annotations: map[string]string{
-							GatewayClusterLabelSelectorAnnotation: "type=test",
+							ClusterLabelSelectorAnnotation: "type=test",
 						},
 					},
 				},
@@ -129,7 +129,7 @@ func TestClusterEventHandler(t *testing.T) {
 						Name:      "test-gateway",
 						Namespace: "test-ns",
 						Annotations: map[string]string{
-							GatewayClusterLabelSelectorAnnotation: "type=test",
+							ClusterLabelSelectorAnnotation: "type=test",
 						},
 					},
 				},

--- a/pkg/controllers/gateway/gateway_controller_test.go
+++ b/pkg/controllers/gateway/gateway_controller_test.go
@@ -4,6 +4,7 @@ package gateway
 
 import (
 	"context"
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/params"
 	"reflect"
 	"strings"
 	"testing"
@@ -47,7 +48,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 									Name:       testutil.DummyCRName,
 									Namespace:  testutil.Namespace,
 									Labels:     getTestGatewayLabels(),
-									Finalizers: []string{GatewayFinalizer},
+									Finalizers: []string{Finalizer},
 								},
 								Spec: v1beta1.GatewaySpec{
 									GatewayClassName: testutil.DummyCRName,
@@ -143,7 +144,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 								ObjectMeta: v1.ObjectMeta{
 									Name:       testutil.DummyCRName,
 									Namespace:  testutil.Namespace,
-									Finalizers: []string{GatewayFinalizer},
+									Finalizers: []string{Finalizer},
 								},
 								Spec: v1beta1.GatewaySpec{
 									GatewayClassName: testutil.DummyCRName,
@@ -175,7 +176,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 								ObjectMeta: v1.ObjectMeta{
 									Name:       testutil.DummyCRName,
 									Namespace:  testutil.Namespace,
-									Finalizers: []string{GatewayFinalizer},
+									Finalizers: []string{Finalizer},
 								},
 								Spec: v1beta1.GatewaySpec{
 									GatewayClassName: testutil.DummyCRName,
@@ -225,7 +226,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 									Name:       testutil.DummyCRName,
 									Namespace:  testutil.Namespace,
 									Labels:     getTestGatewayLabels(),
-									Finalizers: []string{GatewayFinalizer},
+									Finalizers: []string{Finalizer},
 								},
 								Spec: v1beta1.GatewaySpec{
 									GatewayClassName: testutil.DummyCRName,
@@ -263,7 +264,7 @@ func TestGatewayReconciler_Reconcile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &GatewayReconciler{
+			r := &Reconciler{
 				Client:       tt.fields.Client,
 				Scheme:       tt.fields.Scheme,
 				Certificates: test.NewTestCertificateService(tt.fields.Client),
@@ -499,14 +500,14 @@ func TestGatewayReconciler_reconcileDownstreamFromUpstreamGateway(t *testing.T) 
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &GatewayReconciler{
+			r := &Reconciler{
 				Client:       tt.fields.Client,
 				Scheme:       tt.fields.Scheme,
 				Certificates: test.NewTestCertificateService(tt.fields.Client),
 				HostService:  test.NewTestHostService(tt.fields.Client),
 				Placement:    test.NewTestGatewayPlacer(),
 			}
-			requeue, programmedStatus, clusters, err := r.reconcileDownstreamFromUpstreamGateway(context.TODO(), tt.args.gateway, &Params{})
+			requeue, programmedStatus, clusters, err := r.reconcileDownstreamFromUpstreamGateway(context.TODO(), tt.args.gateway, &params.Params{})
 			if (err != nil) != tt.wantErr || !testutil.GotExpectedError(tt.expectedError, err) {
 				t.Errorf("reconcileGateway() error = %v, wantErr %v, expectedError %v", err, tt.wantErr, tt.expectedError)
 			}
@@ -603,7 +604,7 @@ func TestGatewayReconciler_reconcileTLS(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &GatewayReconciler{
+			r := &Reconciler{
 				Client:       tt.fields.Client,
 				Scheme:       tt.fields.Scheme,
 				Certificates: test.NewTestCertificateService(tt.fields.Client),

--- a/pkg/controllers/gatewayclass/gatewayclass_controller_test.go
+++ b/pkg/controllers/gatewayclass/gatewayclass_controller_test.go
@@ -1,6 +1,6 @@
 //go:build unit
 
-package gateway
+package gatewayclass
 
 import (
 	"context"
@@ -65,7 +65,7 @@ func TestGatewayClassReconciler_Reconcile(t *testing.T) {
 						Items: []gatewayv1beta1.GatewayClass{
 							{
 								ObjectMeta: v1.ObjectMeta{
-									Name: getSupportedClasses()[0],
+									Name: GetSupportedClasses()[0],
 								},
 								Spec: gatewayv1beta1.GatewayClassSpec{
 									ParametersRef: &gatewayv1beta1.ParametersReference{
@@ -96,11 +96,11 @@ func TestGatewayClassReconciler_Reconcile(t *testing.T) {
 			args: args{
 				req: ctrl.Request{
 					NamespacedName: types.NamespacedName{
-						Name: getSupportedClasses()[0],
+						Name: GetSupportedClasses()[0],
 					},
 				},
 			},
-			verify: verifyGatewayClassAcceptance(getSupportedClasses()[0], true),
+			verify: verifyGatewayClassAcceptance(GetSupportedClasses()[0], true),
 		},
 		{
 			name: "Unsupported class name",
@@ -130,7 +130,7 @@ func TestGatewayClassReconciler_Reconcile(t *testing.T) {
 						Items: []gatewayv1beta1.GatewayClass{
 							{
 								ObjectMeta: v1.ObjectMeta{
-									Name: getSupportedClasses()[0],
+									Name: GetSupportedClasses()[0],
 								},
 								Spec: gatewayv1beta1.GatewayClassSpec{
 									ParametersRef: &gatewayv1beta1.ParametersReference{
@@ -161,11 +161,11 @@ func TestGatewayClassReconciler_Reconcile(t *testing.T) {
 			args: args{
 				req: ctrl.Request{
 					NamespacedName: types.NamespacedName{
-						Name: getSupportedClasses()[0],
+						Name: GetSupportedClasses()[0],
 					},
 				},
 			},
-			verify: verifyGatewayClassAcceptance(getSupportedClasses()[0], false),
+			verify: verifyGatewayClassAcceptance(GetSupportedClasses()[0], false),
 		},
 		{
 			name: "Gateway class not found",
@@ -175,7 +175,7 @@ func TestGatewayClassReconciler_Reconcile(t *testing.T) {
 						Items: []gatewayv1beta1.GatewayClass{
 							{
 								ObjectMeta: v1.ObjectMeta{
-									Name: getSupportedClasses()[0],
+									Name: GetSupportedClasses()[0],
 								},
 							},
 						},
@@ -194,7 +194,7 @@ func TestGatewayClassReconciler_Reconcile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &GatewayClassReconciler{
+			r := Reconciler{
 				Client: tt.fields.Client,
 				Scheme: testutil.GetValidTestScheme(),
 			}

--- a/pkg/controllers/managedzone/managedzone_controller.go
+++ b/pkg/controllers/managedzone/managedzone_controller.go
@@ -44,7 +44,7 @@ const (
 type ManagedZoneReconciler struct {
 	client.Client
 	Scheme      *runtime.Scheme
-	DNSProvider dns.DNSProviderFactory
+	DNSProvider dns.ProviderFactory
 }
 
 //+kubebuilder:rbac:groups=kuadrant.io,resources=managedzones,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/dns/aws/health.go
+++ b/pkg/dns/aws/health.go
@@ -88,13 +88,13 @@ func (r *Route53HealthCheckReconciler) Delete(ctx context.Context, endpoint *v1a
 	return dns.NewHealthCheckResult(dns.HealthCheckDeleted, ""), nil
 }
 
-func (c *Route53HealthCheckReconciler) findHealthCheck(ctx context.Context, endpoint *v1alpha1.Endpoint) (*route53.HealthCheck, bool, error) {
+func (r *Route53HealthCheckReconciler) findHealthCheck(ctx context.Context, endpoint *v1alpha1.Endpoint) (*route53.HealthCheck, bool, error) {
 	id, hasId := getHealthCheckId(endpoint)
 	if !hasId {
 		return nil, false, nil
 	}
 
-	response, err := c.client.GetHealthCheckWithContext(ctx, &route53.GetHealthCheckInput{
+	response, err := r.client.GetHealthCheckWithContext(ctx, &route53.GetHealthCheckInput{
 		HealthCheckId: &id,
 	})
 	if err != nil {
@@ -105,12 +105,12 @@ func (c *Route53HealthCheckReconciler) findHealthCheck(ctx context.Context, endp
 
 }
 
-func (c *Route53HealthCheckReconciler) createHealthCheck(ctx context.Context, spec dns.HealthCheckSpec, endpoint *v1alpha1.Endpoint) (*route53.HealthCheck, error) {
+func (r *Route53HealthCheckReconciler) createHealthCheck(ctx context.Context, spec dns.HealthCheckSpec, endpoint *v1alpha1.Endpoint) (*route53.HealthCheck, error) {
 	address, _ := endpoint.GetAddress()
 	host := endpoint.DNSName
 
 	// Create the health check
-	output, err := c.client.CreateHealthCheck(&route53.CreateHealthCheckInput{
+	output, err := r.client.CreateHealthCheck(&route53.CreateHealthCheckInput{
 
 		CallerReference: callerReference(spec.Id),
 
@@ -128,7 +128,7 @@ func (c *Route53HealthCheckReconciler) createHealthCheck(ctx context.Context, sp
 	}
 
 	// Add the tag to identify it
-	_, err = c.client.ChangeTagsForResourceWithContext(ctx, &route53.ChangeTagsForResourceInput{
+	_, err = r.client.ChangeTagsForResourceWithContext(ctx, &route53.ChangeTagsForResourceInput{
 		AddTags: []*route53.Tag{
 			{
 				Key:   aws.String(idTag),

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -28,7 +28,7 @@ const (
 	ProviderSpecificGeoCountryCode   = "geo-country-code"
 )
 
-type DNSProviderFactory func(ctx context.Context, managedZone *v1alpha1.ManagedZone) (Provider, error)
+type ProviderFactory func(ctx context.Context, managedZone *v1alpha1.ManagedZone) (Provider, error)
 
 // Provider knows how to manage DNS zones only as pertains to routing.
 type Provider interface {
@@ -39,13 +39,13 @@ type Provider interface {
 	// Delete will delete record.
 	Delete(record *v1alpha1.DNSRecord, managedZone *v1alpha1.ManagedZone) error
 
-	// Ensure will create or update a managed zone, returns an array of NameServers for that zone.
+	// EnsureManagedZone will create or update a managed zone, returns an array of NameServers for that zone.
 	EnsureManagedZone(managedZone *v1alpha1.ManagedZone) (ManagedZoneOutput, error)
 
-	// Delete will delete a managed zone.
+	// DeleteManagedZone will delete a managed zone.
 	DeleteManagedZone(managedZone *v1alpha1.ManagedZone) error
 
-	// Get an instance of HealthCheckReconciler for this provider
+	// HealthCheckReconciler Get an instance of HealthCheckReconciler for this provider
 	HealthCheckReconciler() HealthCheckReconciler
 
 	ProviderSpecific() ProviderSpecificLabels
@@ -66,16 +66,16 @@ var _ Provider = &FakeProvider{}
 
 type FakeProvider struct{}
 
-func (*FakeProvider) Ensure(dnsRecord *v1alpha1.DNSRecord, managedZone *v1alpha1.ManagedZone) error {
+func (*FakeProvider) Ensure(_ *v1alpha1.DNSRecord, _ *v1alpha1.ManagedZone) error {
 	return nil
 }
-func (*FakeProvider) Delete(dnsRecord *v1alpha1.DNSRecord, managedZone *v1alpha1.ManagedZone) error {
+func (*FakeProvider) Delete(_ *v1alpha1.DNSRecord, _ *v1alpha1.ManagedZone) error {
 	return nil
 }
-func (*FakeProvider) EnsureManagedZone(managedZone *v1alpha1.ManagedZone) (ManagedZoneOutput, error) {
+func (*FakeProvider) EnsureManagedZone(_ *v1alpha1.ManagedZone) (ManagedZoneOutput, error) {
 	return ManagedZoneOutput{}, nil
 }
-func (*FakeProvider) DeleteManagedZone(managedZone *v1alpha1.ManagedZone) error { return nil }
+func (*FakeProvider) DeleteManagedZone(_ *v1alpha1.ManagedZone) error { return nil }
 
 func (*FakeProvider) HealthCheckReconciler() HealthCheckReconciler {
 	return &FakeHealthCheckReconciler{}

--- a/pkg/dns/dnsprovider/dnsProvider.go
+++ b/pkg/dns/dnsprovider/dnsProvider.go
@@ -21,13 +21,12 @@ type providerFactory struct {
 }
 
 func NewProvider(c client.Client) *providerFactory {
-
 	return &providerFactory{
 		Client: c,
 	}
 }
 
-// depending on the provider type specified in the form of a custom secret type https://kubernetes.io/docs/concepts/configuration/secret/#secret-types in the dnsprovider secret it returns a dnsprovider.
+// DNSProviderFactory depending on the provider type specified in the form of a custom secret type https://kubernetes.io/docs/concepts/configuration/secret/#secret-types in the dnsprovider secret it returns a dnsprovider.
 func (p *providerFactory) DNSProviderFactory(ctx context.Context, managedZone *v1alpha1.ManagedZone) (dns.Provider, error) {
 	providerSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/dns/health.go
+++ b/pkg/dns/health.go
@@ -53,11 +53,11 @@ const HealthCheckProtocolHTTPS HealthCheckProtocol = "HTTPS"
 
 type FakeHealthCheckReconciler struct{}
 
-func (*FakeHealthCheckReconciler) Reconcile(ctx context.Context, _ HealthCheckSpec, _ *v1alpha1.Endpoint) (HealthCheckResult, error) {
+func (*FakeHealthCheckReconciler) Reconcile(_ context.Context, _ HealthCheckSpec, _ *v1alpha1.Endpoint) (HealthCheckResult, error) {
 	return HealthCheckResult{HealthCheckCreated, ""}, nil
 }
 
-func (*FakeHealthCheckReconciler) Delete(ctx context.Context, _ *v1alpha1.Endpoint) (HealthCheckResult, error) {
+func (*FakeHealthCheckReconciler) Delete(_ context.Context, _ *v1alpha1.Endpoint) (HealthCheckResult, error) {
 	return HealthCheckResult{HealthCheckDeleted, ""}, nil
 }
 

--- a/pkg/dns/service.go
+++ b/pkg/dns/service.go
@@ -52,7 +52,7 @@ func (s *Service) GetManagedHosts(ctx context.Context, traffic traffic.Interface
 			return nil, err
 		}
 		if managedZone == nil {
-			// its ok for no managedzone to be present as this could be a CNAME or externally managed host
+			// it's ok for no managedZone to be present as this could be a CNAME or externally managed host
 			continue
 		}
 		dnsRecord, err := s.GetDNSRecord(ctx, subDomain, managedZone, traffic)
@@ -338,7 +338,7 @@ func (s *Service) CleanupDNSRecords(ctx context.Context, owner traffic.Interface
 	return nil
 }
 
-// getDNSRecordManagedZone returns the current ManagedZone for the given DNSRecord.
+// GetDNSRecordManagedZone returns the current ManagedZone for the given DNSRecord.
 func (s *Service) GetDNSRecordManagedZone(ctx context.Context, dnsRecord *v1alpha1.DNSRecord) (*v1alpha1.ManagedZone, error) {
 
 	if dnsRecord.Spec.ManagedZoneRef == nil {

--- a/pkg/dns/service_test.go
+++ b/pkg/dns/service_test.go
@@ -10,7 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +36,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 			Name: "test get dns record returns record",
 			MZ: func() *v1alpha1.ManagedZone {
 				return &v1alpha1.ManagedZone{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "b.c.com",
 						Namespace: "test",
 					},
@@ -47,7 +47,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 			},
 			SubDomain: "a",
 			DNSRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "a.b.c.com",
 					Namespace: "test",
 					Labels: map[string]string{
@@ -56,7 +56,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 				},
 			},
 			Gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					UID: types.UID("test"),
 				},
 			},
@@ -71,7 +71,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 			Name: "test get dns error when not found",
 			MZ: func() *v1alpha1.ManagedZone {
 				return &v1alpha1.ManagedZone{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "b.c.com",
 						Namespace: "test",
 					},
@@ -82,7 +82,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 			},
 			SubDomain: "a",
 			DNSRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "other.com",
 					Namespace: "test",
 				},
@@ -101,7 +101,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 			Name: "test get dns error when referencing different Gateway",
 			MZ: func() *v1alpha1.ManagedZone {
 				return &v1alpha1.ManagedZone{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "b.c.com",
 						Namespace: "test",
 					},
@@ -112,7 +112,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 			},
 			SubDomain: "a",
 			DNSRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "a.b.c.com",
 					Namespace: "test",
 					Labels: map[string]string{
@@ -121,7 +121,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 				},
 			},
 			Gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					UID: types.UID("test"),
 				},
 			},
@@ -138,7 +138,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 			Name: "test get dns error when not owned by Gateway",
 			MZ: func() *v1alpha1.ManagedZone {
 				return &v1alpha1.ManagedZone{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "b.c.com",
 						Namespace: "test",
 					},
@@ -149,7 +149,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 			},
 			SubDomain: "a",
 			DNSRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "other.com",
 					Namespace: "test",
 					Labels: map[string]string{
@@ -158,7 +158,7 @@ func TestDNS_GetDNSRecords(t *testing.T) {
 				},
 			},
 			Gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					UID: types.UID("not"),
 				},
 			},
@@ -213,7 +213,7 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 			Host: "sub.domain.test.example.com",
 			Zones: []v1alpha1.ManagedZone{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "example.com",
 						Namespace: "test",
 					},
@@ -240,7 +240,7 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 			Host: "sub.domain.test.example.com",
 			Zones: []v1alpha1.ManagedZone{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "example.com",
 						Namespace: "test",
 					},
@@ -249,7 +249,7 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test.example.com",
 						Namespace: "test",
 					},
@@ -273,7 +273,7 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 			Host: "sub.test.example.com",
 			Zones: []v1alpha1.ManagedZone{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test.example.com",
 						Namespace: "test",
 					},
@@ -297,7 +297,7 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 			Host: "sub.test.example.com",
 			Zones: []v1alpha1.ManagedZone{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testing.example.com",
 						Namespace: "test",
 					},
@@ -325,7 +325,7 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 			Host: "sub.domain.test.example.co.uk",
 			Zones: []v1alpha1.ManagedZone{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "example.co.uk",
 						Namespace: "test",
 					},
@@ -352,7 +352,7 @@ func TestDNS_findMatchingManagedZone(t *testing.T) {
 			Host: "sub.domain.test.example.co.uk",
 			Zones: []v1alpha1.ManagedZone{
 				{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "co.uk",
 						Namespace: "test",
 					},
@@ -404,12 +404,12 @@ func TestService_CleanupDNSRecords(t *testing.T) {
 		{
 			name: "DNS record gets deleted",
 			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					UID: types.UID("test"),
 				},
 			},
 			record: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						dns.LabelGatewayReference: "test",
 					},
@@ -420,7 +420,7 @@ func TestService_CleanupDNSRecords(t *testing.T) {
 		{
 			name: "no DNS records do be deleted",
 			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					UID: types.UID("test"),
 				},
 			},
@@ -454,14 +454,14 @@ func TestService_GetManagedZoneForHost(t *testing.T) {
 			name: "found MZ",
 			host: "example.com",
 			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 				},
 			},
 			mz: &v1alpha1.ManagedZoneList{
 				Items: []v1alpha1.ManagedZone{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:      "example.com",
 							Namespace: "test",
 						},
@@ -479,7 +479,7 @@ func TestService_GetManagedZoneForHost(t *testing.T) {
 			name: "unable to list MZ",
 			host: "example.com",
 			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 				},
 			},
@@ -522,7 +522,7 @@ func TestService_SetEndpoints(t *testing.T) {
 			name: "sets weighted endpoints",
 			mcgTarget: &dns.MultiClusterGatewayTarget{
 				Gateway: &gatewayv1beta1.Gateway{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testgw",
 						Namespace: "testns",
 					},
@@ -563,7 +563,7 @@ func TestService_SetEndpoints(t *testing.T) {
 				},
 			},
 			dnsRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test.example.com",
 				},
 			},
@@ -627,7 +627,7 @@ func TestService_SetEndpoints(t *testing.T) {
 			name: "sets geo weighted endpoints",
 			mcgTarget: &dns.MultiClusterGatewayTarget{
 				Gateway: &gatewayv1beta1.Gateway{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testgw",
 						Namespace: "testns",
 					},
@@ -673,7 +673,7 @@ func TestService_SetEndpoints(t *testing.T) {
 				},
 			},
 			dnsRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test.example.com",
 				},
 			},
@@ -763,7 +763,7 @@ func TestService_SetEndpoints(t *testing.T) {
 			name: "sets no endpoints when no target addresses",
 			mcgTarget: &dns.MultiClusterGatewayTarget{
 				Gateway: &gatewayv1beta1.Gateway{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testgw",
 						Namespace: "testns",
 					},
@@ -795,7 +795,7 @@ func TestService_SetEndpoints(t *testing.T) {
 				},
 			},
 			dnsRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test.example.com",
 				},
 			},
@@ -843,7 +843,7 @@ func TestService_CreateDNSRecord(t *testing.T) {
 	type args struct {
 		subDomain   string
 		managedZone *v1alpha1.ManagedZone
-		owner       v1.Object
+		owner       metav1.Object
 	}
 	tests := []struct {
 		name       string
@@ -857,7 +857,7 @@ func TestService_CreateDNSRecord(t *testing.T) {
 			args: args{
 				subDomain: "sub",
 				managedZone: &v1alpha1.ManagedZone{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mz",
 						Namespace: "test",
 					},
@@ -866,21 +866,21 @@ func TestService_CreateDNSRecord(t *testing.T) {
 					},
 				},
 				owner: &gatewayv1beta1.Gateway{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						UID: types.UID("gatewayUID"),
 					},
 				},
 			},
 			recordList: &v1alpha1.DNSRecordList{},
 			wantRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sub.domain.com",
 					Namespace: "test",
 					Labels: map[string]string{
 						dns.LabelRecordID:         "sub",
 						dns.LabelGatewayReference: "gatewayUID",
 					},
-					OwnerReferences: []v1.OwnerReference{
+					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "gateway.networking.k8s.io/v1beta1",
 							Kind:       "Gateway",
@@ -908,7 +908,7 @@ func TestService_CreateDNSRecord(t *testing.T) {
 			args: args{
 				subDomain: "sub",
 				managedZone: &v1alpha1.ManagedZone{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mz",
 						Namespace: "test",
 					},
@@ -917,7 +917,7 @@ func TestService_CreateDNSRecord(t *testing.T) {
 					},
 				},
 				owner: &gatewayv1beta1.Gateway{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						UID: types.UID("gatewayUID"),
 					},
 				},
@@ -925,7 +925,7 @@ func TestService_CreateDNSRecord(t *testing.T) {
 			recordList: &v1alpha1.DNSRecordList{
 				Items: []v1alpha1.DNSRecord{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:      "sub.domain.com",
 							Namespace: "test",
 						},
@@ -933,12 +933,12 @@ func TestService_CreateDNSRecord(t *testing.T) {
 				},
 			},
 			wantRecord: &v1alpha1.DNSRecord{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "sub.domain.com",
 					Namespace:       "test",
 					ResourceVersion: "999",
 				},
-				TypeMeta: v1.TypeMeta{
+				TypeMeta: metav1.TypeMeta{
 					Kind:       "DNSRecord",
 					APIVersion: "kuadrant.io/v1alpha1",
 				},
@@ -973,7 +973,7 @@ func TestService_GetManagedHosts(t *testing.T) {
 		{
 			name: "got managed hosts",
 			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					UID:       types.UID("gatewayUID"),
 				},
@@ -989,7 +989,7 @@ func TestService_GetManagedHosts(t *testing.T) {
 				&v1alpha1.ManagedZoneList{
 					Items: []v1alpha1.ManagedZone{
 						{
-							ObjectMeta: v1.ObjectMeta{
+							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "test",
 							},
 							Spec: v1alpha1.ManagedZoneSpec{
@@ -1001,7 +1001,7 @@ func TestService_GetManagedHosts(t *testing.T) {
 				&v1alpha1.DNSRecordList{
 					Items: []v1alpha1.DNSRecord{
 						{
-							ObjectMeta: v1.ObjectMeta{
+							ObjectMeta: metav1.ObjectMeta{
 								Name:      "sub.domain.com",
 								Namespace: "test",
 								Labels: map[string]string{
@@ -1017,7 +1017,7 @@ func TestService_GetManagedHosts(t *testing.T) {
 					Subdomain: "sub",
 					Host:      "sub.domain.com",
 					ManagedZone: &v1alpha1.ManagedZone{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Namespace:       "test",
 							ResourceVersion: "999",
 						},
@@ -1026,7 +1026,7 @@ func TestService_GetManagedHosts(t *testing.T) {
 						},
 					},
 					DnsRecord: &v1alpha1.DNSRecord{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:            "sub.domain.com",
 							Namespace:       "test",
 							ResourceVersion: "999",
@@ -1034,7 +1034,7 @@ func TestService_GetManagedHosts(t *testing.T) {
 								dns.LabelGatewayReference: "gatewayUID",
 							},
 						},
-						TypeMeta: v1.TypeMeta{
+						TypeMeta: metav1.TypeMeta{
 							Kind:       "DNSRecord",
 							APIVersion: "kuadrant.io/v1alpha1",
 						},
@@ -1045,7 +1045,7 @@ func TestService_GetManagedHosts(t *testing.T) {
 		{
 			name: "No hosts retrieved for CNAME or externaly managed host",
 			gateway: &gatewayv1beta1.Gateway{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					UID:       types.UID("gatewayUID"),
 				},

--- a/test/integration/dnspolicy_controller_test.go
+++ b/test/integration/dnspolicy_controller_test.go
@@ -292,7 +292,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					// must exist
 					Expect(err).ToNot(HaveOccurred())
 					return existingGateway.GetAnnotations()
-				}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPolicyBackRefAnnotation, policyBackRefValue))
+				}, time.Second*5, time.Second).Should(HaveKeyWithValue(BackRefAnnotation, policyBackRefValue))
 				Eventually(func() map[string]string {
 					// Check gateway back references
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
@@ -314,7 +314,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					// must exist
 					Expect(err).ToNot(HaveOccurred())
 					return existingGateway.GetAnnotations()
-				}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPolicyBackRefAnnotation, policyBackRefValue))
+				}, time.Second*5, time.Second).Should(HaveKeyWithValue(BackRefAnnotation, policyBackRefValue))
 				Eventually(func() map[string]string {
 					// Check gateway back references
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
@@ -331,7 +331,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					// must exist
 					Expect(err).ToNot(HaveOccurred())
 					return existingGateway.GetAnnotations()
-				}, time.Second*5, time.Second).ShouldNot(HaveKey(DNSPolicyBackRefAnnotation))
+				}, time.Second*5, time.Second).ShouldNot(HaveKey(BackRefAnnotation))
 				Eventually(func() map[string]string {
 					// Check gateway back references
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
@@ -493,7 +493,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 				// must exist
 				Expect(err).ToNot(HaveOccurred())
 				return existingGateway.GetAnnotations()
-			}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPolicyBackRefAnnotation, policyBackRefValue))
+			}, time.Second*5, time.Second).Should(HaveKeyWithValue(BackRefAnnotation, policyBackRefValue))
 			Eventually(func() map[string]string {
 				// Check gateway back references
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)

--- a/test/integration/helper_test.go
+++ b/test/integration/helper_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -133,7 +133,7 @@ func DeleteNamespace(namespace *string) {
 	existingNamespace := &v1.Namespace{}
 	Eventually(func() bool {
 		err := testClient().Get(context.Background(), types.NamespacedName{Name: *namespace}, existingNamespace)
-		if err != nil && apierrors.IsNotFound(err) {
+		if err != nil && k8serrors.IsNotFound(err) {
 			return true
 		}
 		return false

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -135,7 +135,7 @@ var _ = BeforeSuite(func() {
 		k8sManager.GetEventRecorderFor("DNSPolicy"),
 	)
 
-	err = (&DNSPolicyReconciler{
+	err = (&Reconciler{
 		TargetRefReconciler: reconcilers.TargetRefReconciler{
 			BaseReconciler: dnsPolicyBaseReconciler,
 		},
@@ -145,13 +145,13 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&GatewayClassReconciler{
+	err = (&Reconciler{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&GatewayReconciler{
+	err = (&Reconciler{
 		Client:       k8sManager.GetClient(),
 		Scheme:       k8sManager.GetScheme(),
 		Certificates: certificates,

--- a/test/util/suite_config.go
+++ b/test/util/suite_config.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 
 	"github.com/goombaio/namegenerator"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -19,9 +19,9 @@ import (
 	mgcv1alpha1 "github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ocm_cluster_v1 "open-cluster-management.io/api/cluster/v1"
-	ocm_cluster_v1beta1 "open-cluster-management.io/api/cluster/v1beta1"
-	ocm_cluster_v1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+	ocmclusterv1 "open-cluster-management.io/api/cluster/v1"
+	ocmclusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	ocmclusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -34,12 +34,12 @@ const (
 	ClusterSetLabelValue  = "true"
 
 	// configuration environment variables
-	managedZoneEnvvar            = "TEST_MANAGED_ZONE"
-	hubNamespaceEnvvar           = "TEST_HUB_NAMESPACE"
-	hubKubeContextEnvvar         = "TEST_HUB_KUBE_CONTEXT"
-	spokeKubeContextPrefixEnvvar = "TEST_SPOKE_KUBE_CONTEXT_PREFIX"
-	spokeClusterCountEnvvar      = "MGC_WORKLOAD_CLUSTERS_COUNT"
-	ocmSingleEnvvar              = "OCM_SINGLE"
+	managedZoneEnvVar            = "TEST_MANAGED_ZONE"
+	hubNamespaceEnvVar           = "TEST_HUB_NAMESPACE"
+	hubKubeContextEnvVar         = "TEST_HUB_KUBE_CONTEXT"
+	spokeKubeContextPrefixEnvVar = "TEST_SPOKE_KUBE_CONTEXT_PREFIX"
+	spokeClusterCountEnvVar      = "MGC_WORKLOAD_CLUSTERS_COUNT"
+	ocmSingleEnvVar              = "OCM_SINGLE"
 )
 
 type SuiteConfig struct {
@@ -53,40 +53,40 @@ type SuiteConfig struct {
 func (cfg *SuiteConfig) Build() error {
 
 	// Load test suite configuration from the environment
-	if cfg.hubNamespace = os.Getenv(hubNamespaceEnvvar); cfg.hubNamespace == "" {
-		return fmt.Errorf("env variable '%s' must be set", hubNamespaceEnvvar)
+	if cfg.hubNamespace = os.Getenv(hubNamespaceEnvVar); cfg.hubNamespace == "" {
+		return fmt.Errorf("env variable '%s' must be set", hubNamespaceEnvVar)
 	}
-	if cfg.managedZone = os.Getenv(managedZoneEnvvar); cfg.managedZone == "" {
-		return fmt.Errorf("env variable '%s' must be set", managedZoneEnvvar)
+	if cfg.managedZone = os.Getenv(managedZoneEnvVar); cfg.managedZone == "" {
+		return fmt.Errorf("env variable '%s' must be set", managedZoneEnvVar)
 	}
 
 	var hubKubeContext string
-	if hubKubeContext = os.Getenv(hubKubeContextEnvvar); hubKubeContext == "" {
-		return fmt.Errorf("env variable '%s' must be set", hubKubeContextEnvvar)
+	if hubKubeContext = os.Getenv(hubKubeContextEnvVar); hubKubeContext == "" {
+		return fmt.Errorf("env variable '%s' must be set", hubKubeContextEnvVar)
 	}
 
 	var spokeClustersCount int
 	var spokeKubeContextPrefix string
-	if count := os.Getenv(spokeClusterCountEnvvar); count == "" {
+	if count := os.Getenv(spokeClusterCountEnvVar); count == "" {
 		spokeClustersCount = 0
-		if os.Getenv(hubNamespaceEnvvar) == "" {
-			return fmt.Errorf("%s must be set if %s is 0", ocmSingleEnvvar, spokeClusterCountEnvvar)
+		if os.Getenv(hubNamespaceEnvVar) == "" {
+			return fmt.Errorf("%s must be set if %s is 0", ocmSingleEnvVar, spokeClusterCountEnvVar)
 		}
 	} else {
 		var err error
 		if spokeClustersCount, err = strconv.Atoi(count); err != nil {
-			return fmt.Errorf("'%s' should be a number", spokeClusterCountEnvvar)
+			return fmt.Errorf("'%s' should be a number", spokeClusterCountEnvVar)
 		}
 	}
 
 	if spokeClustersCount != 0 {
-		if spokeKubeContextPrefix = os.Getenv(spokeKubeContextPrefixEnvvar); spokeKubeContextPrefix == "" {
-			return fmt.Errorf("'%s' should be set if '%s' is greater than zero", spokeKubeContextPrefixEnvvar, spokeClusterCountEnvvar)
+		if spokeKubeContextPrefix = os.Getenv(spokeKubeContextPrefixEnvVar); spokeKubeContextPrefix == "" {
+			return fmt.Errorf("'%s' should be set if '%s' is greater than zero", spokeKubeContextPrefixEnvVar, spokeClusterCountEnvVar)
 		}
 	}
 
 	// Create controlplane cluster client
-	restcfg, err := loadKubeconfig(hubKubeContext)
+	restCfg, err := loadKubeConfig(hubKubeContext)
 	if err != nil {
 		return err
 	}
@@ -94,15 +94,15 @@ func (cfg *SuiteConfig) Build() error {
 	if err != nil {
 		return err
 	}
-	err = ocm_cluster_v1beta1.AddToScheme(scheme.Scheme)
+	err = ocmclusterv1beta1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return err
 	}
-	err = ocm_cluster_v1beta2.AddToScheme(scheme.Scheme)
+	err = ocmclusterv1beta2.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return err
 	}
-	err = ocm_cluster_v1.AddToScheme(scheme.Scheme)
+	err = ocmclusterv1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (cfg *SuiteConfig) Build() error {
 		return err
 	}
 
-	cfg.cpClient, err = client.New(restcfg, client.Options{Scheme: scheme.Scheme})
+	cfg.cpClient, err = client.New(restCfg, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		log.Fatal(err)
 		return err
@@ -121,11 +121,11 @@ func (cfg *SuiteConfig) Build() error {
 	if spokeClustersCount > 0 {
 		cfg.dpClients = make([]client.Client, spokeClustersCount)
 		for i := 0; i < spokeClustersCount; i++ {
-			restcfg, err := loadKubeconfig(fmt.Sprintf("%s-%d", spokeKubeContextPrefix, i+1))
+			restCfg, err = loadKubeConfig(fmt.Sprintf("%s-%d", spokeKubeContextPrefix, i+1))
 			if err != nil {
 				return err
 			}
-			cfg.dpClients[i], err = client.New(restcfg, client.Options{Scheme: scheme.Scheme})
+			cfg.dpClients[i], err = client.New(restCfg, client.Options{Scheme: scheme.Scheme})
 			if err != nil {
 				return err
 			}
@@ -158,7 +158,7 @@ func (cfg *SuiteConfig) ApplicationNamespace() string { return "kuadrant-" + cfg
 
 func (cfg *SuiteConfig) ManagedClusterSet() string { return ManagedClusterSetName }
 
-func loadKubeconfig(context string) (*rest.Config, error) {
+func loadKubeConfig(context string) (*rest.Config, error) {
 	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{CurrentContext: context},
@@ -175,7 +175,7 @@ func (cfg *SuiteConfig) InstallPrerequisites(ctx context.Context) error {
 
 	// label the managedclusters (at the moment we just label them all)
 	// NOTE: this action won't be reverted after the suite finishes
-	clusterList := &ocm_cluster_v1.ManagedClusterList{}
+	clusterList := &ocmclusterv1.ManagedClusterList{}
 	if err := cfg.HubClient().List(ctx, clusterList); err != nil {
 		return err
 	}
@@ -211,11 +211,11 @@ func (cfg *SuiteConfig) InstallPrerequisites(ctx context.Context) error {
 
 	// ensure ManagedClusterSet
 	{
-		managedclusterset := &ocm_cluster_v1beta2.ManagedClusterSet{
+		managedClusterSet := &ocmclusterv1beta2.ManagedClusterSet{
 			ObjectMeta: metav1.ObjectMeta{Name: ManagedClusterSetName},
-			Spec: ocm_cluster_v1beta2.ManagedClusterSetSpec{
-				ClusterSelector: ocm_cluster_v1beta2.ManagedClusterSelector{
-					SelectorType: ocm_cluster_v1beta2.LabelSelector,
+			Spec: ocmclusterv1beta2.ManagedClusterSetSpec{
+				ClusterSelector: ocmclusterv1beta2.ManagedClusterSelector{
+					SelectorType: ocmclusterv1beta2.LabelSelector,
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							ClusterSetLabelKey: ClusterSetLabelValue,
@@ -224,31 +224,31 @@ func (cfg *SuiteConfig) InstallPrerequisites(ctx context.Context) error {
 				},
 			},
 		}
-		created, err := cfg.Ensure(ctx, managedclusterset)
+		created, err := cfg.Ensure(ctx, managedClusterSet)
 		if err != nil {
 			return err
 		}
 
 		if created {
-			cfg.cleanupList = append(cfg.cleanupList, managedclusterset)
+			cfg.cleanupList = append(cfg.cleanupList, managedClusterSet)
 		}
 	}
 
 	// ensure ManagedClusterSetBinding
 	{
-		managedclustersetbinding := &ocm_cluster_v1beta2.ManagedClusterSetBinding{
+		managedClusterSetBinding := &ocmclusterv1beta2.ManagedClusterSetBinding{
 			ObjectMeta: metav1.ObjectMeta{Name: ManagedClusterSetName, Namespace: cfg.HubNamespace()},
-			Spec: ocm_cluster_v1beta2.ManagedClusterSetBindingSpec{
+			Spec: ocmclusterv1beta2.ManagedClusterSetBindingSpec{
 				ClusterSet: ManagedClusterSetName,
 			},
 		}
-		created, err := cfg.Ensure(ctx, managedclustersetbinding)
+		created, err := cfg.Ensure(ctx, managedClusterSetBinding)
 		if err != nil {
 			return err
 		}
 
 		if created {
-			cfg.cleanupList = append(cfg.cleanupList, managedclustersetbinding)
+			cfg.cleanupList = append(cfg.cleanupList, managedClusterSetBinding)
 		}
 	}
 
@@ -286,7 +286,7 @@ func (cfg *SuiteConfig) Cleanup(ctx context.Context) error {
 func (cfg *SuiteConfig) Exists(ctx context.Context, o client.Object) (bool, error) {
 
 	if err := cfg.HubClient().Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
-		if apierrors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return false, nil
 		} else {
 			return false, err
@@ -306,7 +306,7 @@ func (cfg *SuiteConfig) Ensure(ctx context.Context, o client.Object) (bool, erro
 		return false, nil
 	}
 
-	if err := cfg.HubClient().Create(ctx, o); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := cfg.HubClient().Create(ctx, o); err != nil && !k8serrors.IsAlreadyExists(err) {
 		return false, err
 	}
 


### PR DESCRIPTION
These are just some suggestions and completed as part of some short upskilling. Happy for them to be rejected if they're not suitable at this time. 

- Rename of Reconcilers and associated objects so that the naming isn't duplicating the package name
- Split out gatewayclass to it's own controller
- Move params functions out to it's own package under local
- Consistent naming on package imports k8serrors metav1
- Small spelling fixes.