### PR TITLE
Remove check for no placed clusters in dnspolicy

### DIFF
--- a/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
@@ -54,11 +54,6 @@ func (r *DNSPolicyReconciler) reconcileGatewayDNSRecords(ctx context.Context, ga
 	log.Info("DNSPolicyReconciler.reconcileResources", "clusters", clusters, "managedHosts", managedHosts)
 
 	log.V(3).Info("checking gateway for attached routes ", "gateway", gateway.Name, "clusters", placed, "managed hosts", len(managedHosts))
-	if len(placed) == 0 {
-		//nothing to do
-		log.V(3).Info("reconcileDNSRecords gateway has not been placed on to any downstream clusters nothing to do")
-		return nil
-	}
 
 	for _, mh := range managedHosts {
 		var clusterGateways []dns.ClusterGateway


### PR DESCRIPTION
Removes the logic in the dnspolicy reconcile to break out immediately if there are no placed clusters. This is incorrectly preventing DNSRecords that are already created from being removed if the target Gateway is removed from all clusters, or all clusters are deleted.