### PR TITLE
Add goimports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,20 @@ jobs:
       - name: Run make verify-manifests
         run: |
           make verify-manifests
+  verify-imports:
+    name: Verify imports
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.19.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make verify-manifests
+        run: |
+          make verify-imports
   integration_test_suite:
     name: Integration Test Suite
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ vet: ## Run go vet against code.
 lint: ## Run golangci-lint against code.
 	golangci-lint run ./...
 
+.PHONY: imports
+imports: openshift-goimports ## Run openshift goimports against code.
+	$(OPENSHIFT_GOIMPORTS) -m github.com/Kuadrant/multicluster-gateway-controller -i github.com/kuadrant/kuadrant-operator
+
 .PHONY: test-unit
 test-unit: manifests generate fmt vet envtest ## Run unit tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -tags=unit -coverprofile cover-unit.out -v

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,25 +20,22 @@ import (
 	"flag"
 	"os"
 
+	certmanv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta1"
+	workv1 "open-cluster-management.io/api/work/v1"
+
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	certmanv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
-
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta1"
-	workv1 "open-cluster-management.io/api/work/v1"
+	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/dnspolicy"
@@ -48,7 +45,6 @@ import (
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns/dnsprovider"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/placement"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/tls"
-	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -7,15 +7,17 @@ import (
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 
-	hub "github.com/Kuadrant/multicluster-gateway-controller/pkg/ocm/hub"
-	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
-	"open-cluster-management.io/addon-framework/pkg/addonfactory"
-	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+
+	hub "github.com/Kuadrant/multicluster-gateway-controller/pkg/ocm/hub"
 )
 
 //go:embed addon-manager/manifests

--- a/hack/make/check.make
+++ b/hack/make/check.make
@@ -8,3 +8,7 @@ verify-code: vet ## Verify code formatting
 verify-manifests: manifests ## Verify manifests update.
 	git diff --exit-code ./config
 	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./config)" ]
+
+.PHONY: verify-imports
+verify-imports: ## Verify go imports are sorted and grouped correctly.
+	hack/verify-imports.sh

--- a/hack/make/dependencies.make
+++ b/hack/make/dependencies.make
@@ -21,7 +21,7 @@ CLUSTERADM ?= $(LOCALBIN)/clusteradm
 SUBCTL ?= $(LOCALBIN)/subctl
 GINKGO ?= $(LOCALBIN)/ginkgo
 YQ ?= $(LOCALBIN)/yq
-
+OPENSHIFT_GOIMPORTS ?= $(LOCALBIN)/openshift-goimports
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.4
@@ -34,6 +34,7 @@ OPERATOR_SDK_VERSION ?= 1.28.0
 CLUSTERADM_VERSION ?= 0.6.0
 SUBCTL_VERSION ?= release-0.15
 GINKGO_VERSION ?= v2.6.1
+OPENSHIFT_GOIMPORTS_VERSION ?= c70783e636f2213cac683f6865d88c5edace3157
 
 .PHONY: dependencies
 dependencies: kustomize operator-sdk controller-gen envtest kind helm yq istioctl clusteradm subctl ginkgo
@@ -111,3 +112,8 @@ $(SUBCTL):
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary
 $(GINKGO):
 	test -s $(GINKGO) || GOBIN=$(LOCALBIN) go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+
+.PHONY: openshift-goimports
+openshift-goimports: $(OPENSHIFT_GOIMPORTS) ## Download openshift-goimports locally if necessary
+$(OPENSHIFT_GOIMPORTS):
+	GOBIN=$(LOCALBIN) go install github.com/openshift-eng/openshift-goimports@$(OPENSHIFT_GOIMPORTS_VERSION)

--- a/hack/verify-imports.sh
+++ b/hack/verify-imports.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+make -C "$( dirname "${BASH_SOURCE[0]}")/../" imports
+if ! git diff --quiet --exit-code ; then
+	cat << EOF
+ERROR: This check enforces that import statements are ordered correctly.
+ERROR: The import statements are out of order. Run the following command
+ERROR: to regenerate the statements:
+ERROR: $ make imports
+ERROR: The following differences were found:
+EOF
+	git diff
+	exit 1
+fi

--- a/pkg/_internal/gracePeriod/gracePeriod_test.go
+++ b/pkg/_internal/gracePeriod/gracePeriod_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	workv1 "open-cluster-management.io/api/work/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 

--- a/pkg/_internal/metadata/annotations_test.go
+++ b/pkg/_internal/metadata/annotations_test.go
@@ -3,10 +3,11 @@
 package metadata
 
 import (
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_addAnnotation(t *testing.T) {

--- a/pkg/_internal/metadata/labels_test.go
+++ b/pkg/_internal/metadata/labels_test.go
@@ -3,9 +3,10 @@
 package metadata
 
 import (
+	"testing"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func Test_hasLabel(t *testing.T) {

--- a/pkg/_internal/policy/policy_test.go
+++ b/pkg/_internal/policy/policy_test.go
@@ -5,10 +5,9 @@ package policy
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 )

--- a/pkg/controllers/dnspolicy/dns_helper.go
+++ b/pkg/controllers/dnspolicy/dns_helper.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"golang.org/x/net/publicsuffix"
+
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/pkg/controllers/gateway/cluster_eventhandler.go
+++ b/pkg/controllers/gateway/cluster_eventhandler.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/clusterSecret"

--- a/pkg/controllers/gateway/gateway_controller.go
+++ b/pkg/controllers/gateway/gateway_controller.go
@@ -24,6 +24,9 @@ import (
 	"reflect"
 	"time"
 
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta1"
+	workv1 "open-cluster-management.io/api/work/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -33,8 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
-	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta1"
-	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/controllers/gateway/gatewayclass_controller_test.go
+++ b/pkg/controllers/gateway/gatewayclass_controller_test.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/test/util"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestGatewayClassReconciler_Reconcile(t *testing.T) {

--- a/pkg/controllers/managedzone/managedzone_controller.go
+++ b/pkg/controllers/managedzone/managedzone_controller.go
@@ -24,9 +24,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"

--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -22,12 +22,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/go-logr/logr"
 
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/pkg/dns/aws/health.go
+++ b/pkg/dns/aws/health.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/rs/xid"
+
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"

--- a/pkg/dns/aws/metrics.go
+++ b/pkg/dns/aws/metrics.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 

--- a/pkg/ocm/hub/addon.go
+++ b/pkg/ocm/hub/addon.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"open-cluster-management.io/addon-framework/pkg/agent"
-
 	workapiv1 "open-cluster-management.io/api/work/v1"
 )
 

--- a/pkg/placement/ocm.go
+++ b/pkg/placement/ocm.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 	"strings"
 
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	placement "open-cluster-management.io/api/cluster/v1beta1"
+	workv1 "open-cluster-management.io/api/work/v1"
+
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -16,9 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	placement "open-cluster-management.io/api/cluster/v1beta1"
-	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -7,13 +7,14 @@ import (
 	"encoding/json"
 	"testing"
 
+	pd "open-cluster-management.io/api/cluster/v1beta1"
+	workv1 "open-cluster-management.io/api/work/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
-	pd "open-cluster-management.io/api/cluster/v1beta1"
-	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"

--- a/pkg/tls/service.go
+++ b/pkg/tls/service.go
@@ -7,6 +7,7 @@ import (
 
 	certman "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/e2e/gateway_single_spoke_test.go
+++ b/test/e2e/gateway_single_spoke_test.go
@@ -10,18 +10,19 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/Kuadrant/multicluster-gateway-controller/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	ocm_cluster_v1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/conditions"
 	mgcv1alpha1 "github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ocm_cluster_v1beta1 "open-cluster-management.io/api/cluster/v1beta1"
-	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
+	. "github.com/Kuadrant/multicluster-gateway-controller/test/util"
 )
 
 var _ = Describe("Gateway single target cluster", func() {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -5,11 +5,13 @@ package e2e
 import (
 	"testing"
 
-	. "github.com/Kuadrant/multicluster-gateway-controller/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	. "github.com/Kuadrant/multicluster-gateway-controller/test/util"
 )
 
 var tconfig SuiteConfig

--- a/test/integration/gateway_controller_test.go
+++ b/test/integration/gateway_controller_test.go
@@ -21,19 +21,17 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	ocmclusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	ocmworkv1 "open-cluster-management.io/api/work/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	ocmclusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
-	ocmworkv1 "open-cluster-management.io/api/work/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"

--- a/test/integration/helper_test.go
+++ b/test/integration/helper_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"

--- a/test/integration/managedzone_controller_test.go
+++ b/test/integration/managedzone_controller_test.go
@@ -18,6 +18,7 @@ package integration
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -21,23 +21,23 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
+	certman "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	ocmclusterv1 "open-cluster-management.io/api/cluster/v1"
+	ocmclusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	ocmworkv1 "open-cluster-management.io/api/work/v1"
+
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-
-	certman "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	ocmclusterv1 "open-cluster-management.io/api/cluster/v1"
-	ocmclusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
-	ocmworkv1 "open-cluster-management.io/api/work/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 	. "github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/dnspolicy"

--- a/test/util/suite_config.go
+++ b/test/util/suite_config.go
@@ -10,20 +10,20 @@ import (
 	"strconv"
 
 	"github.com/goombaio/namegenerator"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	mgcv1alpha1 "github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ocm_cluster_v1 "open-cluster-management.io/api/cluster/v1"
 	ocm_cluster_v1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	ocm_cluster_v1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	mgcv1alpha1 "github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 )
 
 const (


### PR DESCRIPTION
Adds new Make targets to sort and group project imports `make imports` and verify imports are sorted and grouped `make verify-imports`. 

```
make help | grep imports
  imports          Run openshift goimports against code.
  verify-imports   Verify go imports are sorted and grouped correctly.
  openshift-goimports  Download openshift-goimports locally if necessary
```

Sorting and grouping based on [openshift-goimports]( https://github.com/openshift-eng/openshift-goimports) defaults, with kuadrant-operator added as an intermediate so it's grouped nearer the modules imports. Script inspired by KCP and other openshift projects.

From openshift-goimports docs:
```
Organizes Go imports into the following groups:
  
  standard - Any of the Go standard library packages
  other - Anything not specifically called out in this list
  kubernetes - Anything that starts with k8s.io
  openshift - Anything that starts with github.com/openshift
  intermediates - Optional list of groups
  module - Anything that is part of the current module
```

Also adds job to CI GH action to execute the `verify-imports` command on all PRs.