### PR TITLE
DNSPolicy geo and weight validation updates

### DIFF
--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -59,13 +59,11 @@ spec:
                   geo:
                     properties:
                       defaultGeo:
-                        description: "defaultGeo is the country or continent code
+                        description: "defaultGeo is the country/continent/region code
                           to use when no other can be determined for a dns target
-                          cluster. \n 2 digit iso3166 alpha-2 country code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
-                          or continent code. C-AF: Africa; C-AN: Antarctica; C-AS:
-                          Asia; C-EU: Europe; C-OC: Oceania; C-NA: North America;
-                          C-SA: South America"
-                        pattern: ^([A-Z]{2}|C-AF|C-AN|C-AS|C-EU|C-OS|C-NA|C-SA)$
+                          cluster. \n The values accepted are determined by the target
+                          dns provider, please refer to the appropriate docs below.
+                          \n Route53: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-geo.html"
                         type: string
                     type: object
                   weighted:
@@ -76,16 +74,17 @@ spec:
                             value:
                               type: string
                             weight:
-                              maximum: 255
                               minimum: 0
                               type: integer
                           type: object
                         type: array
                       defaultWeight:
                         default: 120
-                        description: defaultWeight is the record weight to use when
-                          no other can be determined for a dns target cluster.
-                        maximum: 255
+                        description: "defaultWeight is the record weight to use when
+                          no other can be determined for a dns target cluster. \n
+                          The maximum value accepted is determined by the target dns
+                          provider, please refer to the appropriate docs below. \n
+                          Route53: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-weighted.html"
                         minimum: 0
                         type: integer
                     type: object
@@ -128,7 +127,6 @@ spec:
                 - name
                 type: object
             required:
-            - loadBalancing
             - targetRef
             type: object
           status:

--- a/docs/proposals/DNSPolicy.md
+++ b/docs/proposals/DNSPolicy.md
@@ -48,8 +48,8 @@ spec:
   health:
    ...
   loadBalancing:
-    weighted: # always required
-     defaultWeight: 10  #always required
+    weighted:
+     defaultWeight: 10
      custom: #optional
      - value: AWS  #optional with both GEO and weighted. With GEO the custom weight is applied to gateways within a Geographic region
        weight: 10
@@ -105,7 +105,7 @@ spec:
 
 The attributes provide the key and value we need in order to understand how to define records for a given LB address based on the DNSPolicy targeting the gateway.
 
-The `kuadrant.io/lb-attribute-geo-code` attribute value must be a two digit ISO3166 Alpha-2 country code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) or a one of the following four digit continent codes: (`C-AF`: Africa; `C-AN`: Antarctica; `C-AS`: Asia; `C-EU`: Europe; `C-OC`: Oceania; `C-NA`: North America; `C-SA`: South America) 
+The `kuadrant.io/lb-attribute-geo-code` attribute value is provider specific, using an invalid code will result in an error status condition in the DNSrecord resource. 
 
 ### DNS Record Structure
 

--- a/pkg/apis/v1alpha1/dnspolicy_types.go
+++ b/pkg/apis/v1alpha1/dnspolicy_types.go
@@ -34,20 +34,18 @@ type DNSPolicySpec struct {
 	// +optional
 	HealthCheck *HealthCheckSpec `json:"healthCheck,omitempty"`
 
-	// +kubebuilder:validation:Required
-	// +required
+	// +optional
 	LoadBalancing *LoadBalancingSpec `json:"loadBalancing"`
 }
 
 type LoadBalancingSpec struct {
-	// +required
+	// +optional
 	Weighted *LoadBalancingWeighted `json:"weighted,omitempty"`
 	// +optional
 	Geo *LoadBalancingGeo `json:"geo,omitempty"`
 }
 
 // +kubebuilder:validation:Minimum=0
-// +kubebuilder:validation:Maximum=255
 type Weight int
 
 type CustomWeight struct {
@@ -60,6 +58,9 @@ type CustomWeight struct {
 type LoadBalancingWeighted struct {
 	// defaultWeight is the record weight to use when no other can be determined for a dns target cluster.
 	//
+	// The maximum value accepted is determined by the target dns provider, please refer to the appropriate docs below.
+	//
+	// Route53: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-weighted.html
 	// +kubebuilder:default=120
 	DefaultWeight Weight `json:"defaultWeight,omitempty"`
 	// +optional
@@ -67,12 +68,12 @@ type LoadBalancingWeighted struct {
 }
 
 type LoadBalancingGeo struct {
-	// defaultGeo is the country or continent code to use when no other can be determined for a dns target cluster.
+	// defaultGeo is the country/continent/region code to use when no other can be determined for a dns target cluster.
 	//
-	// 2 digit iso3166 alpha-2 country code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) or continent code.
-	// C-AF: Africa; C-AN: Antarctica; C-AS: Asia; C-EU: Europe; C-OC: Oceania; C-NA: North America; C-SA: South America
+	// The values accepted are determined by the target dns provider, please refer to the appropriate docs below.
 	//
-	// +kubebuilder:validation:Pattern="^([A-Z]{2}|C-AF|C-AN|C-AS|C-EU|C-OS|C-NA|C-SA)$"
+	// Route53: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-geo.html
+	// +required
 	DefaultGeo string `json:"defaultGeo,omitempty"`
 }
 

--- a/pkg/controllers/dnspolicy/dns_helper.go
+++ b/pkg/controllers/dnspolicy/dns_helper.go
@@ -293,17 +293,13 @@ func (dh *dnsHelper) setEndpoints(ctx context.Context, mcgTarget *dns.MultiClust
 			defaultEndpoint = createOrUpdateEndpoint(lbName, []string{geoLbName}, v1alpha1.CNAMERecordType, "default", dns.DefaultCnameTTL, currentEndpoints)
 		}
 
-		if geoCode.IsContinentCode() {
-			endpoint.SetProviderSpecific(dns.ProviderSpecificGeoContinentCode, string(geoCode))
-		} else if geoCode.IsCountryCode() {
-			endpoint.SetProviderSpecific(dns.ProviderSpecificGeoCountryCode, string(geoCode))
-		}
+		endpoint.SetProviderSpecific(dns.ProviderSpecificGeoCode, string(geoCode))
 		newEndpoints = append(newEndpoints, endpoint)
 	}
 
 	if len(newEndpoints) > 0 {
 		// Add the `defaultEndpoint`, this should always be set by this point if `newEndpoints` isn't empty
-		defaultEndpoint.SetProviderSpecific(dns.ProviderSpecificGeoCountryCode, "*")
+		defaultEndpoint.SetProviderSpecific(dns.ProviderSpecificGeoCode, string(dns.WildcardGeo))
 		newEndpoints = append(newEndpoints, defaultEndpoint)
 		//Create gwListenerHost CNAME (shop.example.com -> lb-a1b2.shop.example.com)
 		endpoint = createOrUpdateEndpoint(gwListenerHost, []string{lbName}, v1alpha1.CNAMERecordType, "", dns.DefaultCnameTTL, currentEndpoints)

--- a/pkg/controllers/dnspolicy/dns_helper_test.go
+++ b/pkg/controllers/dnspolicy/dns_helper_test.go
@@ -430,7 +430,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						RecordTTL:     dns.DefaultCnameTTL,
 						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
 							{
-								Name:  "geo-country-code",
+								Name:  "geo-code",
 								Value: "*",
 							},
 						},
@@ -470,7 +470,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 								},
 							},
 						},
-						Geo:    testutil.Pointer(dns.GeoCode("C-NA")),
+						Geo:    testutil.Pointer(dns.GeoCode("NA")),
 						Weight: testutil.Pointer(120),
 					},
 					{
@@ -490,7 +490,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 				},
 				LoadBalancing: &v1alpha1.LoadBalancingSpec{
 					Geo: &v1alpha1.LoadBalancingGeo{
-						DefaultGeo: "C-NA",
+						DefaultGeo: "NA",
 					},
 				},
 			},
@@ -508,7 +508,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						RecordTTL:  dns.DefaultTTL,
 					},
 					{
-						DNSName:       "c-na.lb-0ecjaw.test.example.com",
+						DNSName:       "na.lb-0ecjaw.test.example.com",
 						Targets:       []string{"20qri0.lb-0ecjaw.test.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "20qri0.lb-0ecjaw.test.example.com",
@@ -535,27 +535,27 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 					},
 					{
 						DNSName:       "lb-0ecjaw.test.example.com",
-						Targets:       []string{"c-na.lb-0ecjaw.test.example.com"},
+						Targets:       []string{"na.lb-0ecjaw.test.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "default",
 						RecordTTL:     dns.DefaultCnameTTL,
 						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
 							{
-								Name:  "geo-country-code",
+								Name:  "geo-code",
 								Value: "*",
 							},
 						},
 					},
 					{
 						DNSName:       "lb-0ecjaw.test.example.com",
-						Targets:       []string{"c-na.lb-0ecjaw.test.example.com"},
+						Targets:       []string{"na.lb-0ecjaw.test.example.com"},
 						RecordType:    "CNAME",
-						SetIdentifier: "C-NA",
+						SetIdentifier: "NA",
 						RecordTTL:     dns.DefaultCnameTTL,
 						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
 							{
-								Name:  "geo-continent-code",
-								Value: "C-NA",
+								Name:  "geo-code",
+								Value: "NA",
 							},
 						},
 					},
@@ -567,7 +567,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						RecordTTL:     dns.DefaultCnameTTL,
 						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
 							{
-								Name:  "geo-country-code",
+								Name:  "geo-code",
 								Value: "IE",
 							},
 						},
@@ -598,7 +598,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 							ClusterName:      "test-cluster-1",
 							GatewayAddresses: []gatewayv1beta1.GatewayAddress{},
 						},
-						Geo:    testutil.Pointer(dns.GeoCode("C-NA")),
+						Geo:    testutil.Pointer(dns.GeoCode("NA")),
 						Weight: testutil.Pointer(120),
 					},
 					{
@@ -613,7 +613,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 				},
 				LoadBalancing: &v1alpha1.LoadBalancingSpec{
 					Geo: &v1alpha1.LoadBalancingGeo{
-						DefaultGeo: "C-NA",
+						DefaultGeo: "NA",
 					},
 				},
 			},

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -23,11 +23,10 @@ import (
 )
 
 const (
-	DefaultTTL                       = 60
-	DefaultCnameTTL                  = 300
-	ProviderSpecificWeight           = "weight"
-	ProviderSpecificGeoContinentCode = "geo-continent-code"
-	ProviderSpecificGeoCountryCode   = "geo-country-code"
+	DefaultTTL              = 60
+	DefaultCnameTTL         = 300
+	ProviderSpecificWeight  = "weight"
+	ProviderSpecificGeoCode = "geo-code"
 )
 
 type DNSProviderFactory func(ctx context.Context, managedZone *v1alpha1.ManagedZone) (Provider, error)

--- a/pkg/dns/iso3166.go
+++ b/pkg/dns/iso3166.go
@@ -1,5 +1,7 @@
 package dns
 
+import "github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/slice"
+
 type countryCodes struct {
 	numericCode int
 	countryName string
@@ -265,4 +267,9 @@ func GetISO3166Alpha2Codes() []string {
 		codes = append(codes, v.alpha2Code)
 	}
 	return codes
+}
+
+// IsISO3166Alpha2Code returns true if it's a valid ISO_3166 Alpha 2 country code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+func IsISO3166Alpha2Code(code string) bool {
+	return slice.ContainsString(GetISO3166Alpha2Codes(), code)
 }

--- a/pkg/dns/target_test.go
+++ b/pkg/dns/target_test.go
@@ -14,53 +14,6 @@ import (
 	testutil "github.com/Kuadrant/multicluster-gateway-controller/test/util"
 )
 
-func TestGeoCode_IsContinentCode(t *testing.T) {
-	tests := []struct {
-		gc   GeoCode
-		want bool
-	}{
-		{
-			gc:   "",
-			want: false,
-		},
-		{
-			gc:   "AF",
-			want: false,
-		},
-		{
-			gc:   "af",
-			want: false,
-		},
-		{
-			gc:   "C-AF",
-			want: true,
-		},
-		{
-			gc:   "C-AN",
-			want: true,
-		}, {
-			gc:   "C-AS",
-			want: true,
-		}, {
-			gc:   "C-OC",
-			want: true,
-		}, {
-			gc:   "C-NA",
-			want: true,
-		}, {
-			gc:   "C-SA",
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(string(tt.gc), func(t *testing.T) {
-			if got := tt.gc.IsContinentCode(); got != tt.want {
-				t.Errorf("IsContinentCode() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 type TestCluster struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
@@ -119,25 +72,6 @@ func TestNewClusterGateway(t *testing.T) {
 				ClusterAttributes: ClusterAttributes{
 					Geo: testutil.Pointer(GeoCode("IE")),
 				},
-			},
-		},
-		{
-			name: "ignores invalid geo code in geo code attribute label",
-			args: args{
-				cluster: &TestCluster{
-					ObjectMeta: v1.ObjectMeta{
-						Name: clusterName1,
-						Labels: map[string]string{
-							"kuadrant.io/lb-attribute-geo-code": "NOTACODE",
-						},
-					},
-				},
-				gatewayAddresses: buildGatewayAddress(testAddress1),
-			},
-			want: &ClusterGateway{
-				ClusterName:       clusterName1,
-				GatewayAddresses:  buildGatewayAddress(testAddress1),
-				ClusterAttributes: ClusterAttributes{},
 			},
 		},
 		{

--- a/test/integration/dnspolicy_controller_test.go
+++ b/test/integration/dnspolicy_controller_test.go
@@ -216,7 +216,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 						RecordTTL:     300,
 						ProviderSpecific: v1alpha1.ProviderSpecific{
 							{
-								Name:  "geo-country-code",
+								Name:  "geo-code",
 								Value: "*",
 							},
 						},
@@ -378,7 +378,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 						RecordTTL:     300,
 						ProviderSpecific: v1alpha1.ProviderSpecific{
 							{
-								Name:  "geo-country-code",
+								Name:  "geo-code",
 								Value: "IE",
 							},
 						},
@@ -393,7 +393,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 						RecordTTL:     300,
 						ProviderSpecific: v1alpha1.ProviderSpecific{
 							{
-								Name:  "geo-country-code",
+								Name:  "geo-code",
 								Value: "*",
 							},
 						},


### PR DESCRIPTION
Removes the validation on the geo and weight fields in the DNSPolicy spec in order to more easily support providers with more limited APIs. The values for these fields are now provider specific, and as such any invalid values will result in a failure in the API request resulting in a DNSRecord reconcile error. The Route53 API requires the setting of different fields in the API request depending on whether it's an ISO3166 Alpha-2 country or continent code, as such the validation of the country code is now done in the AWS provider itself, and anything that isn't a valid Alpha-2 code is assumed to be a continent.

Make the loadBalancing field in the DNSPolicy optional. If it's not set, the default weight of 120 will be applied to all weighted records. (Result of feedback after demo).