### PR TITLE
DNSPolicy improve default behaviour

### DIFF
--- a/docs/dns-policy.md
+++ b/docs/dns-policy.md
@@ -250,8 +250,10 @@ spec:
     kind: Gateway
   loadBalancing:
     weighted:
-      defaultWeight: 120 # <--- New Default Weight being added
+      defaultWeight: 100 # <--- New Default Weight being added
 ```
+
+The weight of all records is adjusted to reflect the new `defaultWeight` value of `100`. This will still produce the same Round Robin routing strategy as before since all records still have equal weight values.
 
 #### Custom Weights
  

--- a/docs/how-to/ocm-control-plane-walkthrough.md
+++ b/docs/how-to/ocm-control-plane-walkthrough.md
@@ -251,8 +251,6 @@ So what about DNS how do we bring traffic to these gateways?
 
 ### Create and attach a HTTPRoute
 
-We only configure DNS once a HTTPRoute has been attached to a listener in the gateway. 
-
 1. In `T1`, using the following command in the hub cluster, you will see we currently have no DNSRecord resources.
 
     ```bash
@@ -319,7 +317,26 @@ We only configure DNS once a HTTPRoute has been attached to a listener in the ga
     EOF
     ```
 
-    Once this is done, the Kuadrant multi-cluster gateway controller will pick up that a HTTPRoute has been attached to the Gateway it is managing from the hub and it will setup a DNS record to start bringing traffic to that gateway for the host defined in that listener.
+### Enable DNS
+
+1. In `T1`, create a DNSPolicy and attach it to your Gateway:
+
+    ```bash
+    kubectl apply -f - <<EOF
+    apiVersion: kuadrant.io/v1alpha1
+    kind: DNSPolicy
+    metadata:
+      name: prod-web
+      namespace: multi-cluster-gateways
+    spec:
+      targetRef:
+        name: prod-web
+        group: gateway.networking.k8s.io
+        kind: Gateway     
+    EOF
+    ```
+
+   Once this is done, the Kuadrant multi-cluster gateway controller will pick up that a HTTPRoute has been attached to the Gateway it is managing from the hub and it will setup a DNS record to start bringing traffic to that gateway for the host defined in that listener.
 
 1. You should now see a DNSRecord resource in the hub cluster. In `T1`, run:
 

--- a/docs/how-to/submariner-poc-2-gateways-resiliency-walkthrough.md
+++ b/docs/how-to/submariner-poc-2-gateways-resiliency-walkthrough.md
@@ -223,6 +223,25 @@ spec:
 EOF
 ```
 
+### Enable DNS
+
+1. In `T1`, create a DNSPolicy and attach it to your Gateway:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: kuadrant.io/v1alpha1
+kind: DNSPolicy
+metadata:
+  name: prod-web
+  namespace: multi-cluster-gateways
+spec:
+  targetRef:
+    name: prod-web
+    group: gateway.networking.k8s.io
+    kind: Gateway     
+EOF
+```
+
 Once this is done, the Kuadrant multi-cluster Gateway controller will pick up that a HTTPRoute has been attached to the Gateway it is managing from the hub and it will setup a DNS record to start bringing traffic to that Gateway for the host defined in that listener.
 
 You should now see a DNSRecord and only 1 endpoint added which corresponds to address assigned to the Gateway where the HTTPRoute was created. In `T1`, run:

--- a/docs/how-to/submariner-poc-hub-gateway-walkthrough.md
+++ b/docs/how-to/submariner-poc-hub-gateway-walkthrough.md
@@ -309,6 +309,25 @@ spec:
 EOF
 ```
 
+### Enable DNS
+
+1. In `T1`, create a DNSPolicy and attach it to your Gateway:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: kuadrant.io/v1alpha1
+kind: DNSPolicy
+metadata:
+  name: prod-web
+  namespace: multi-cluster-gateways
+spec:
+  targetRef:
+    name: prod-web
+    group: gateway.networking.k8s.io
+    kind: Gateway     
+EOF
+```
+
 Once this is done, the Kuadrant multi-cluster Gateway controller will pick up that a HTTPRoute has been attached to the Gateway it is managing from the hub and it will setup a DNS record to start bringing traffic to that Gateway for the host defined in that listener.
 
 You should now see a DNSRecord and only 1 endpoint added which corresponds to address assigned to the Gateway where the HTTPRoute was created. In `T1`, run:

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/miekg/dns v1.1.34
 	github.com/onsi/ginkgo/v2 v2.6.1
 	github.com/onsi/gomega v1.24.2
-	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
 	github.com/operator-framework/api v0.17.5
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rs/xid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -276,7 +276,6 @@ github.com/onsi/ginkgo/v2 v2.6.1/go.mod h1:yjiuMwPokqY1XauOgju45q3sJt6VzQ/Fict1L
 github.com/onsi/gomega v1.24.2 h1:J/tulyYK6JwBldPViHJReihxxZ+22FHs0piGjQAvoUE=
 github.com/onsi/gomega v1.24.2/go.mod h1:gs3J10IS7Z7r7eXRoNJIrNqU4ToQukCJhFtKrWgHWnk=
 github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=
-github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/operator-framework/api v0.17.5 h1:9d0pc6m1Vp4QeS8i5dhl/B0nifhKQdtw+iFsNx0An0Q=
 github.com/operator-framework/api v0.17.5/go.mod h1:l/cuwtPxkVUY7fzYgdust2m9tlmb8I4pOvbsUufRb24=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/test/integration/dnspolicy_controller_test.go
+++ b/test/integration/dnspolicy_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/conditions"
@@ -75,26 +76,56 @@ func testBuildGateway(gwName, gwClassName, hostname, ns string) *gatewayv1beta1.
 	}
 }
 
-func testModifyPolicyAddHealthCheckAndLoadBalancing(policy *v1alpha1.DNSPolicy) {
+func testBuildDNSPolicyWithHealthCheck(policyName, gwName, ns string) *v1alpha1.DNSPolicy {
+	typedNamespace := gatewayv1beta1.Namespace(ns)
 	protocol := v1alpha1.HttpProtocol
-	policy.Spec.HealthCheck = &v1alpha1.HealthCheckSpec{
-		Endpoint: "/",
-		Protocol: &protocol,
-	}
-	policy.Spec.LoadBalancing = &v1alpha1.LoadBalancingSpec{
-		Weighted: &v1alpha1.LoadBalancingWeighted{
-			DefaultWeight: 120,
+	return &v1alpha1.DNSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: ns,
+		},
+		Spec: v1alpha1.DNSPolicySpec{
+			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "Gateway",
+				Name:      gatewayv1beta1.ObjectName(gwName),
+				Namespace: &typedNamespace,
+			},
+			HealthCheck: &v1alpha1.HealthCheckSpec{
+				Endpoint: "/",
+				Protocol: &protocol,
+			},
+			LoadBalancing: &v1alpha1.LoadBalancingSpec{
+				Weighted: &v1alpha1.LoadBalancingWeighted{
+					DefaultWeight: 120,
+				},
+			},
 		},
 	}
 }
 
-func testModifyPolicyAddGeo(policy *v1alpha1.DNSPolicy) {
-	policy.Spec.LoadBalancing = &v1alpha1.LoadBalancingSpec{
-		Weighted: &v1alpha1.LoadBalancingWeighted{
-			DefaultWeight: 120,
+func testBuildDNSPolicyWithGeo(policyName, gwName, ns string) *v1alpha1.DNSPolicy {
+	typedNamespace := gatewayv1beta1.Namespace(ns)
+	return &v1alpha1.DNSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: ns,
 		},
-		Geo: &v1alpha1.LoadBalancingGeo{
-			DefaultGeo: "IE",
+		Spec: v1alpha1.DNSPolicySpec{
+			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "Gateway",
+				Name:      gatewayv1beta1.ObjectName(gwName),
+				Namespace: &typedNamespace,
+			},
+			LoadBalancing: &v1alpha1.LoadBalancingSpec{
+				Weighted: &v1alpha1.LoadBalancingWeighted{
+					DefaultWeight: 120,
+				},
+				Geo: &v1alpha1.LoadBalancingGeo{
+					DefaultGeo: "IE",
+				},
+			},
 		},
 	}
 }
@@ -171,21 +202,19 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 		})
 
 		Context("weighted dnspolicy", func() {
-			dnsPolicy := &v1alpha1.DNSPolicy{}
+			var dnsPolicy *v1alpha1.DNSPolicy
 
 			BeforeEach(func() {
-
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKey{testNamespace, TestPlacedGatewayName}, dnsPolicy); err != nil {
-						return false
-					}
-					testModifyPolicyAddHealthCheckAndLoadBalancing(dnsPolicy)
-					if err := k8sClient.Update(ctx, dnsPolicy); err != nil {
+				dnsPolicy = testBuildDNSPolicyWithHealthCheck("test-dns-policy", TestPlacedGatewayName, testNamespace)
+				Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
+				Eventually(func() bool { //dns policy exists
+					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
 						return false
 					}
 					return true
 				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeTrue())
 			})
+
 			It("should create a dns record", func() {
 				createdDNSRecord := &v1alpha1.DNSRecord{}
 				expectedEndpoints := []*v1alpha1.Endpoint{
@@ -251,7 +280,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 			It("should have ready status", func() {
 				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: TestPlacedGatewayName, Namespace: testNamespace}, dnsPolicy); err != nil {
+					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
 						return false
 					}
 
@@ -261,13 +290,13 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 			It("should set gateway back reference", func() {
 				existingGateway := &gatewayv1beta1.Gateway{}
-				policyBackRefValue := testNamespace + "/" + TestPlacedGatewayName
-				refs, _ := json.Marshal([]client.ObjectKey{{Name: TestPlacedGatewayName, Namespace: testNamespace}})
+				policyBackRefValue := testNamespace + "/" + dnsPolicy.Name
+				refs, _ := json.Marshal([]client.ObjectKey{{Name: dnsPolicy.Name, Namespace: testNamespace}})
 				policiesBackRefValue := string(refs)
 
 				Eventually(func() map[string]string {
 					// Check gateway back references
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: TestPlacedGatewayName, Namespace: testNamespace}, existingGateway)
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
 					// must exist
 					Expect(err).ToNot(HaveOccurred())
 					return existingGateway.GetAnnotations()
@@ -283,8 +312,8 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 			It("should remove gateway back reference on policy deletion", func() {
 				existingGateway := &gatewayv1beta1.Gateway{}
-				policyBackRefValue := testNamespace + "/" + TestPlacedGatewayName
-				refs, _ := json.Marshal([]client.ObjectKey{{Name: TestPlacedGatewayName, Namespace: testNamespace}})
+				policyBackRefValue := testNamespace + "/" + dnsPolicy.Name
+				refs, _ := json.Marshal([]client.ObjectKey{{Name: dnsPolicy.Name, Namespace: testNamespace}})
 				policiesBackRefValue := string(refs)
 
 				Eventually(func() map[string]string {
@@ -305,7 +334,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 				//finalizer should exist
 				Eventually(func() bool {
 					existingDNSPolicy := &v1alpha1.DNSPolicy{}
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: TestPlacedGatewayName, Namespace: testNamespace}, existingDNSPolicy)
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: testNamespace}, existingDNSPolicy)
 					// must exist
 					Expect(err).ToNot(HaveOccurred())
 					return metadata.HasFinalizer(existingDNSPolicy, DNSPolicyFinalizer)
@@ -332,16 +361,13 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 		})
 
 		Context("geo dnspolicy", func() {
-			dnsPolicy := &v1alpha1.DNSPolicy{}
+			var dnsPolicy *v1alpha1.DNSPolicy
 
 			BeforeEach(func() {
-
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKey{testNamespace, TestPlacedGatewayName}, dnsPolicy); err != nil {
-						return false
-					}
-					testModifyPolicyAddGeo(dnsPolicy)
-					if err := k8sClient.Update(ctx, dnsPolicy); err != nil {
+				dnsPolicy = testBuildDNSPolicyWithGeo("test-dns-policy", TestPlacedGatewayName, testNamespace)
+				Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
+				Eventually(func() bool { //dns policy exists
+					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
 						return false
 					}
 					return true
@@ -416,7 +442,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					},
 				}
 				Eventually(func() bool { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: TestAttachedRouteName, Namespace: testNamespace}, createdDNSRecord); err != nil {
+					if err := k8sClient.Get(ctx, client.ObjectKey{Name: TestAttachedRouteName, Namespace: dnsPolicy.Namespace}, createdDNSRecord); err != nil {
 						return false
 					}
 					return len(createdDNSRecord.Spec.Endpoints) == 5
@@ -430,19 +456,18 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 	Context("gateway not placed", func() {
 		var gateway *gatewayv1beta1.Gateway
-		dnsPolicy := &v1alpha1.DNSPolicy{}
+		var dnsPolicy *v1alpha1.DNSPolicy
 		testGatewayName := "test-not-placed-gateway"
 
 		BeforeEach(func() {
 			gateway = testBuildGateway(testGatewayName, gatewayClass.Name, TestAttachedRouteName, testNamespace)
+			dnsPolicy = testBuildDNSPolicyWithHealthCheck("test-dns-policy", testGatewayName, testNamespace)
+
 			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
+			Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
 
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, client.ObjectKey{testNamespace, testGatewayName}, dnsPolicy); err != nil {
-					return false
-				}
-				testModifyPolicyAddHealthCheckAndLoadBalancing(dnsPolicy)
-				if err := k8sClient.Update(ctx, dnsPolicy); err != nil {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
 					return false
 				}
 				return true
@@ -456,7 +481,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 			}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeTrue())
 
 			Eventually(func() bool { //dns policy exists
-				if err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, dnsPolicy); err != nil {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
 					return false
 				}
 				return true
@@ -479,7 +504,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 		It("should have ready status", func() {
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, dnsPolicy); err != nil {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
 					return false
 				}
 
@@ -489,8 +514,8 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 		It("should set gateway back reference", func() {
 			existingGateway := &gatewayv1beta1.Gateway{}
-			policyBackRefValue := testNamespace + "/" + testGatewayName
-			refs, _ := json.Marshal([]client.ObjectKey{{Name: testGatewayName, Namespace: testNamespace}})
+			policyBackRefValue := testNamespace + "/" + dnsPolicy.Name
+			refs, _ := json.Marshal([]client.ObjectKey{{Name: dnsPolicy.Name, Namespace: testNamespace}})
 			policiesBackRefValue := string(refs)
 			Eventually(func() map[string]string {
 				// Check gateway back references


### PR DESCRIPTION
/closes #359

Removes the default DNSPolicy creation from the gateway controller.

Update labelling of resources created by the DNSPolicy. Brings it in-line with how the other kuadrant polices work, and makes it easier to find resources created by a policy.

```bash
kubectl get dnsrecords -A --show-labels
NAMESPACE                NAME                   READY   LABELS
multi-cluster-gateways   myapp.mn.hcpapps.net   True    gateway-namespace=multi-cluster-gateways,gateway=prod-web,kuadrant.io/dnspolicy-namespace=multi-cluster-gateways,kuadrant.io/dnspolicy=prod-web
```