### PR TITLE
#314 Metrics for health check probe failures

### DIFF
--- a/pkg/controllers/dnspolicy/dns_helper.go
+++ b/pkg/controllers/dnspolicy/dns_helper.go
@@ -117,6 +117,17 @@ func (dh *dnsHelper) getDNSRecordForListener(ctx context.Context, listener gatew
 	return dnsRecord, nil
 }
 
+func withDNSRecord[T metav1.Object](dnsRecord *v1alpha1.DNSRecord, obj T) T {
+	if obj.GetAnnotations() == nil {
+		obj.SetAnnotations(map[string]string{})
+	}
+
+	obj.GetAnnotations()["dnsrecord-name"] = dnsRecord.Name
+	obj.GetAnnotations()["dnsrecord-namespace"] = dnsRecord.Namespace
+
+	return obj
+}
+
 // setEndpoints sets the endpoints for the given MultiClusterGatewayTarget
 //
 // Builds an array of v1alpha1.Endpoint resources and sets them on the given DNSRecord. The endpoints expected are calculated

--- a/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
@@ -150,7 +150,7 @@ func (r *DNSPolicyReconciler) expectedProbesForGateway(ctx context.Context, gw c
 						AllowInsecureCertificate: dnsPolicy.Spec.HealthCheck.AllowInsecureCertificates,
 					},
 				}
-				healthChecks = append(healthChecks, healthCheck)
+				healthChecks = append(healthChecks, withDNSRecord(dnsRecord, healthCheck))
 			}
 		}
 	}

--- a/pkg/health/metrics.go
+++ b/pkg/health/metrics.go
@@ -1,0 +1,61 @@
+package health
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	healthCheckAttempts = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mgc_dns_health_check_attempts_total",
+			Help: "MGC DNS Health Check Probe total number of attempts",
+		},
+		[]string{"gateway_name", "gateway_namespace", "listener"},
+	)
+
+	healthCheckFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mgc_dns_health_check_failures_total",
+			Help: "MGC DNS Health Check Probe total number of failures",
+		},
+		[]string{"gateway_name", "gateway_namespace", "listener"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		healthCheckAttempts,
+		healthCheckFailures,
+	)
+}
+
+// InstrumentedProbeNotifier wraps a notifier by incrementing the failure counter
+// when the result is unhealthy
+type InstrumentedProbeNotifier struct {
+	gatewayName, gatewayNamespace, listener string
+	notifier                                ProbeNotifier
+}
+
+func NewInstrumentedProbeNotifier(gatewayName, gatewayNamespace, listener string, notifier ProbeNotifier) *InstrumentedProbeNotifier {
+	return &InstrumentedProbeNotifier{
+		gatewayName:      gatewayName,
+		gatewayNamespace: gatewayNamespace,
+		listener:         listener,
+		notifier:         notifier,
+	}
+}
+
+func (n *InstrumentedProbeNotifier) Notify(ctx context.Context, result ProbeResult) (NotificationResult, error) {
+	healthCheckAttempts.WithLabelValues(n.gatewayName, n.gatewayNamespace, n.listener).Inc()
+	if !result.Healthy {
+		healthCheckFailures.WithLabelValues(n.gatewayName, n.gatewayNamespace, n.listener).Inc()
+	}
+
+	return n.notifier.Notify(ctx, result)
+}
+
+var _ ProbeNotifier = &InstrumentedProbeNotifier{}


### PR DESCRIPTION
## Description

> Closes #314 

Create and expose a metric that counts the number of health check failures per probe

## Verification steps

1. Run the local-setup
    ```sh
    make local-setup OCM_SINGLE=true MCTC_WORKLOAD_CLUSTERS_COUNT=1
    ```
3. Run the controller
    ```sh
    (export $(cat ./controller-config.env | xargs) && export $(cat ./aws-credentials.env | xargs) && make build-controller install run-controller)
    ```
5. Create a health check probe that will fail
    ```sh
    kubectl apply -f - <<EOF                                                                                                                                                                                                          
    apiVersion: kuadrant.io/v1alpha1
    kind: DNSHealthCheckProbe
    metadata:
      name: example-probe
    spec:
      address: "127.0.0.1"
      host: localhost
      port: 3333
      interval: 30s
    EOF
    ```
7. Check the metric is updated when the health check fails
    ```sh
    curl http://localhost:8080/metrics | grep mgc_dns
    
    mgc_dns_health_check_failures_total{name="example-probe",namespace="default"} 1
    ```