### PR TITLE
Health Probe fixes for TLS

### DIFF
--- a/config/crd/bases/kuadrant.io_dnshealthcheckprobes.yaml
+++ b/config/crd/bases/kuadrant.io_dnshealthcheckprobes.yaml
@@ -45,6 +45,8 @@ spec:
           spec:
             description: DNSHealthCheckProbeSpec defines the desired state of DNSHealthCheckProbe
             properties:
+              AllowInsecureCertificate:
+                type: boolean
               additionalHeaders:
                 items:
                   properties:

--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -45,6 +45,8 @@ spec:
                   By default this health check will be applied to each unique DNS
                   A Record for the listeners assigned to the target gateway
                 properties:
+                  AllowInsecureCertificates:
+                    type: boolean
                   additionalHeaders:
                     items:
                       properties:

--- a/pkg/apis/v1alpha1/dnshealthcheckprobe_types.go
+++ b/pkg/apis/v1alpha1/dnshealthcheckprobe_types.go
@@ -22,15 +22,16 @@ import (
 
 // DNSHealthCheckProbeSpec defines the desired state of DNSHealthCheckProbe
 type DNSHealthCheckProbeSpec struct {
-	Port              int               `json:"port,omitempty"`
-	Host              string            `json:"host,omitempty"`
-	Address           string            `json:"address,omitempty"`
-	Path              string            `json:"path,omitempty"`
-	Protocol          HealthProtocol    `json:"protocol,omitempty"`
-	Interval          metav1.Duration   `json:"interval,omitempty"`
-	AdditionalHeaders AdditionalHeaders `json:"additionalHeaders,omitempty"`
-	FailureThreshold  *int              `json:"failureThreshold,omitempty"`
-	ExpectedReponses  []int             `json:"expectedReponses,omitempty"`
+	Port                     int               `json:"port,omitempty"`
+	Host                     string            `json:"host,omitempty"`
+	Address                  string            `json:"address,omitempty"`
+	Path                     string            `json:"path,omitempty"`
+	Protocol                 HealthProtocol    `json:"protocol,omitempty"`
+	Interval                 metav1.Duration   `json:"interval,omitempty"`
+	AdditionalHeaders        AdditionalHeaders `json:"additionalHeaders,omitempty"`
+	FailureThreshold         *int              `json:"failureThreshold,omitempty"`
+	ExpectedReponses         []int             `json:"expectedReponses,omitempty"`
+	AllowInsecureCertificate bool              `json:"AllowInsecureCertificate,omitempty"`
 }
 
 type AdditionalHeaders []AdditionalHeader

--- a/pkg/apis/v1alpha1/dnspolicy_types.go
+++ b/pkg/apis/v1alpha1/dnspolicy_types.go
@@ -151,12 +151,13 @@ type DNSPolicyList struct {
 // By default this health check will be applied to each unique DNS A Record for
 // the listeners assigned to the target gateway
 type HealthCheckSpec struct {
-	Endpoint          string            `json:"endpoint,omitempty"`
-	Port              *int              `json:"port,omitempty"`
-	Protocol          *HealthProtocol   `json:"protocol,omitempty"`
-	FailureThreshold  *int              `json:"failureThreshold,omitempty"`
-	AdditionalHeaders AdditionalHeaders `json:"additionalHeaders,omitempty"`
-	ExpectedResponses []int             `json:"expectedResponses,omitempty"`
+	Endpoint                  string            `json:"endpoint,omitempty"`
+	Port                      *int              `json:"port,omitempty"`
+	Protocol                  *HealthProtocol   `json:"protocol,omitempty"`
+	FailureThreshold          *int              `json:"failureThreshold,omitempty"`
+	AdditionalHeaders         AdditionalHeaders `json:"additionalHeaders,omitempty"`
+	ExpectedResponses         []int             `json:"expectedResponses,omitempty"`
+	AllowInsecureCertificates bool              `json:"AllowInsecureCertificates,omitempty"`
 }
 
 type HealthCheckStatus struct {

--- a/pkg/controllers/dnshealthcheckprobe/dnshealthcheckprobe_controller.go
+++ b/pkg/controllers/dnshealthcheckprobe/dnshealthcheckprobe_controller.go
@@ -87,21 +87,23 @@ func (r *DNSHealthCheckProbeReconciler) Reconcile(ctx context.Context, req ctrl.
 			p.Protocol = protocol
 			p.AdditionalHeaders = previous.Spec.AdditionalHeaders
 			p.ExpectedReponses = previous.Spec.ExpectedReponses
+			p.AllowInsecureCertificate = previous.Spec.AllowInsecureCertificate
 		})
 	} else {
 		notifier := NewStatusUpdateProbeNotifier(r.Client, previous)
 		r.HealthMonitor.AddProbeQueuer(&health.ProbeQueuer{
-			ID:                probeId,
-			Interval:          interval,
-			Host:              previous.Spec.Host,
-			Path:              previous.Spec.Path,
-			Port:              previous.Spec.Port,
-			Protocol:          protocol,
-			IPAddress:         previous.Spec.Address,
-			AdditionalHeaders: previous.Spec.AdditionalHeaders,
-			ExpectedReponses:  previous.Spec.ExpectedReponses,
-			Notifier:          notifier,
-			Queue:             r.Queue,
+			ID:                       probeId,
+			Interval:                 interval,
+			Host:                     previous.Spec.Host,
+			Path:                     previous.Spec.Path,
+			Port:                     previous.Spec.Port,
+			Protocol:                 protocol,
+			IPAddress:                previous.Spec.Address,
+			AdditionalHeaders:        previous.Spec.AdditionalHeaders,
+			ExpectedReponses:         previous.Spec.ExpectedReponses,
+			AllowInsecureCertificate: previous.Spec.AllowInsecureCertificate,
+			Notifier:                 notifier,
+			Queue:                    r.Queue,
 		})
 	}
 

--- a/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
@@ -136,20 +136,21 @@ func (r *DNSPolicyReconciler) expectedProbesForGateway(ctx context.Context, gw c
 				log.V(1).Info("reconcileHealthChecks: adding health check for target", "target", target)
 				healthCheck := &v1alpha1.DNSHealthCheckProbe{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("%s-%s", target, endpoint.DNSName),
+						Name:      fmt.Sprintf("%s-%s", target, dnsRecord.Name),
 						Namespace: gw.Namespace,
 						Labels:    dnsRecordLabels(client.ObjectKeyFromObject(gw), client.ObjectKeyFromObject(dnsPolicy)),
 					},
 					Spec: v1alpha1.DNSHealthCheckProbeSpec{
-						Port:              *port,
-						Host:              endpoint.DNSName,
-						Address:           target,
-						Path:              dnsPolicy.Spec.HealthCheck.Endpoint,
-						Protocol:          *dnsPolicy.Spec.HealthCheck.Protocol,
-						Interval:          metav1.Duration{Duration: 60 * time.Second},
-						AdditionalHeaders: dnsPolicy.Spec.HealthCheck.AdditionalHeaders,
-						FailureThreshold:  dnsPolicy.Spec.HealthCheck.FailureThreshold,
-						ExpectedReponses:  dnsPolicy.Spec.HealthCheck.ExpectedResponses,
+						Port:                     *port,
+						Host:                     dnsRecord.Name,
+						Address:                  target,
+						Path:                     dnsPolicy.Spec.HealthCheck.Endpoint,
+						Protocol:                 *dnsPolicy.Spec.HealthCheck.Protocol,
+						Interval:                 metav1.Duration{Duration: 60 * time.Second},
+						AdditionalHeaders:        dnsPolicy.Spec.HealthCheck.AdditionalHeaders,
+						FailureThreshold:         dnsPolicy.Spec.HealthCheck.FailureThreshold,
+						ExpectedReponses:         dnsPolicy.Spec.HealthCheck.ExpectedResponses,
+						AllowInsecureCertificate: dnsPolicy.Spec.HealthCheck.AllowInsecureCertificates,
 					},
 				}
 				healthChecks = append(healthChecks, healthCheck)

--- a/pkg/controllers/gateway/gateway_controller.go
+++ b/pkg/controllers/gateway/gateway_controller.go
@@ -314,7 +314,7 @@ func (r *GatewayReconciler) reconcileDownstreamFromUpstreamGateway(ctx context.C
 	}
 
 	log.Info("Gateway Placed ", "gateway", upstreamGateway.Name, "namespace", upstreamGateway.Namespace, "targets", targets.UnsortedList())
-	//get updatd list of clusters where this gateway has been successfully placed
+	//get updated list of clusters where this gateway has been successfully placed
 	placed, err := r.Placement.GetPlacedClusters(ctx, upstreamGateway)
 	if err != nil {
 		return false, metav1.ConditionUnknown, targets.UnsortedList(), fmt.Errorf("failed to get placed clusters : %s", err)

--- a/pkg/health/probeQueuer.go
+++ b/pkg/health/probeQueuer.go
@@ -14,14 +14,15 @@ import (
 type ProbeQueuer struct {
 	ID string
 
-	Interval          time.Duration
-	Protocol          v1alpha1.HealthProtocol
-	Path              string
-	IPAddress         string
-	Host              string
-	Port              int
-	AdditionalHeaders v1alpha1.AdditionalHeaders
-	ExpectedReponses  []int
+	Interval                 time.Duration
+	Protocol                 v1alpha1.HealthProtocol
+	Path                     string
+	IPAddress                string
+	Host                     string
+	Port                     int
+	AdditionalHeaders        v1alpha1.AdditionalHeaders
+	ExpectedReponses         []int
+	AllowInsecureCertificate bool
 
 	Notifier ProbeNotifier
 	Queue    *QueuedProbeWorker
@@ -60,14 +61,15 @@ func (p *ProbeQueuer) Start() {
 			select {
 			case <-time.After(p.Interval):
 				p.Queue.EnqueueCheck(HealthRequest{
-					Host:              p.Host,
-					Path:              p.Path,
-					Protocol:          p.Protocol,
-					Address:           p.IPAddress,
-					Port:              p.Port,
-					AdditionalHeaders: p.AdditionalHeaders,
-					ExpectedResponses: p.ExpectedReponses,
-					Notifier:          p.Notifier,
+					Host:                     p.Host,
+					Path:                     p.Path,
+					Protocol:                 p.Protocol,
+					Address:                  p.IPAddress,
+					Port:                     p.Port,
+					AdditionalHeaders:        p.AdditionalHeaders,
+					ExpectedResponses:        p.ExpectedReponses,
+					Notifier:                 p.Notifier,
+					AllowInsecureCertificate: p.AllowInsecureCertificate,
 				})
 			case <-ctx.Done():
 				return


### PR DESCRIPTION
Fix health probes for TLS endpoints and allow ignoring bad certificates.