### PR TITLE
add istio system namespace

### DIFF
--- a/config/istio/istio-namespace.yaml
+++ b/config/istio/istio-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system

--- a/config/istio/kustomization.yaml
+++ b/config/istio/kustomization.yaml
@@ -1,6 +1,5 @@
-namespace: istio-operator
-
 resources:
+  - istio-namespace.yaml
   - namespace.yaml
   - istio-operator-init.yaml
   - istio-operator.yaml

--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -179,6 +179,7 @@ deployQuickStartControl() {
     kubectl -n cert-manager wait --timeout=300s --for=condition=Available deployments --all
     echo "Waiting for istio deployments to be ready"
     kubectl -n istio-operator wait --timeout=300s --for=condition=Available deployments --all
+    kubectl -n istio-system wait --timeout=300s --for=condition=Available deployments --all
 }
 
 deployQuickStartWorkload() {


### PR DESCRIPTION
Related to https://github.com/Kuadrant/multicluster-gateway-controller/issues/286
Without the istio-system namespace the kustomize wont fail but the istio components don't get deployed
Adding a check to the script as well so that the script would wait for deployments both for the operator and for the istio deployment itself. 

**Verification** 
can be done by running the script in it's existing state.
verify that no istio-system namespace is present.
also following the steps in the ocm-walkthrough will result in the gateways being stuck in this stage
```oc get gateway -A
NAMESPACE                         NAME       CLASS                                                 ADDRESS   PROGRAMMED   AGE
kuadrant-multi-cluster-gateways   prod-web   istio                                                                        4m58s
multi-cluster-gateways            prod-web   kuadrant-multi-cluster-gateway-instance-per-cluster             True         5m3s```

run the following `kustomize build config/istio --enable-helm --helm-command helm | kubectl apply -f -` agains this branch

verify the istio-system namespace is present and the gateways should then be 
```
NAMESPACE                         NAME       CLASS                                                 ADDRESS        PROGRAMMED   AGE
kuadrant-multi-cluster-gateways   prod-web   istio                                                 172.31.200.0                9s
multi-cluster-gateways            prod-web   kuadrant-multi-cluster-gateway-instance-per-cluster                  True         13s
```

and following the rest of the steps in the ocm-walthrough will result in a correct DNS on `dig $MGC_SUB_DOMAIN`