### PR TITLE
Add mgc metric dashboard

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -33,4 +33,4 @@ resources:
 - ../rbac
 - ../manager
 patches:
-- path: manager_auth_proxy_patch.yaml
+- path: manager_metrics_patch.yaml

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        args:
+        - "--metrics-bind-address=0.0.0.0:8080"
+        - "--leader-elect"
+        ports:
+        - containerPort: 8080
+          name: metrics

--- a/config/prometheus-for-federation/grafana-dashboard-mgc-metrics.json
+++ b/config/prometheus-for-federation/grafana-dashboard-mgc-metrics.json
@@ -24,8 +24,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 19,
-  "iteration": 1691663562703,
+  "id": 25,
+  "iteration": 1692087230577,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -272,7 +272,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (pod) (rate(kube_pod_container_status_restarts_total[30m]) > 0 )",
+          "expr": "sum by (pod) (rate(kube_pod_container_status_restarts_total{namespace=~\"$namespace\"}[30m]) > 0 )",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 2,
@@ -369,7 +369,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "sum(go_goroutines{namespace=~\"$namespace\",node=~\"$node\"}) by(pod)",
+          "expr": "go_goroutines{namespace=~\"$namespace\"}",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -461,7 +461,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", node=~\"$node\"}[1m])) by(pod)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\"}[1m])) by(pod)",
           "legendFormat": "CPU Usage {{pod}}",
           "range": true,
           "refId": "A"
@@ -472,7 +472,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"cpu\", node=~\"$node\"}",
+          "expr": "kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"cpu\"}",
           "hide": false,
           "legendFormat": "CPU Requests {{pod}}",
           "range": true,
@@ -484,7 +484,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"cpu\", node=~\"$node\"}",
+          "expr": "kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"cpu\"}",
           "hide": false,
           "legendFormat": "CPU Limits {{pod}}",
           "range": true,
@@ -576,7 +576,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "sum(container_memory_rss{namespace=~\"$namespace\", node=~\"$node\"}) by (pod)",
+          "expr": "sum(container_memory_rss{namespace=~\"$namespace\"}) by (pod)",
           "legendFormat": "Pod Memory {{pod}}",
           "range": true,
           "refId": "A"
@@ -587,7 +587,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"memory\", node=~\"$node\"}",
+          "expr": "kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"memory\"}",
           "hide": false,
           "legendFormat": "Pod Memory Requests {{pod}}",
           "range": true,
@@ -599,7 +599,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"memory\", node=~\"$node\"}",
+          "expr": "kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"memory\"}",
           "hide": false,
           "legendFormat": "Pod Memory Limits {{pod}}",
           "range": true,
@@ -614,7 +614,7 @@
         "type": "prometheus",
         "uid": "P8D9ADF90DB2E3ECF"
       },
-      "description": "Shows the rate of resources being queued for processing by each controller.",
+      "description": "Shows the rate of resources being queued for processing by each controller in the selected namespace.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -677,11 +677,11 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
+          "displayMode": "list",
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
@@ -692,7 +692,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "sum(rate(workqueue_adds_total{}[5m])) by (instance, name)",
+          "expr": "sum(rate(workqueue_adds_total{namespace=~\"$namespace\"}[5m])) by (name)",
           "legendFormat": "{{instance}} {{name}}",
           "range": true,
           "refId": "A"
@@ -706,7 +706,7 @@
         "type": "prometheus",
         "uid": "P8D9ADF90DB2E3ECF"
       },
-      "description": "Shows the queue size for each resource controller.",
+      "description": "Shows the queue size for each resource controller in the selected namespace.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -769,11 +769,11 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
+          "displayMode": "list",
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
@@ -784,7 +784,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "sum(rate(workqueue_depth{}[5m])) by (instance, name)",
+          "expr": "sum(rate(workqueue_depth{namespace=~\"$namespace\"}[5m])) by (name)",
           "legendFormat": "{{instance}} {{name}}",
           "range": true,
           "refId": "A"
@@ -798,7 +798,7 @@
         "type": "prometheus",
         "uid": "P8D9ADF90DB2E3ECF"
       },
-      "description": "Shows the queue processing latency for each resource controller.",
+      "description": "Shows the queue processing latency for each resource controller in the selected namespace.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -879,7 +879,7 @@
             "uid": "P8D9ADF90DB2E3ECF"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{}[$__range])) by (instance, name, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{namespace=~\"$namespace\"}[$__range])) by (name, le))",
           "legendFormat": "{{instance}} {{name}}",
           "range": true,
           "refId": "A"
@@ -897,7 +897,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "thanos-query",
           "value": "thanos-query"
         },
@@ -915,10 +915,11 @@
         "type": "datasource"
       },
       {
+        "allValue": "multicluster-gateway-controller-system",
         "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
+          "selected": false,
+          "text": "multicluster-gateway-controller-system",
+          "value": "multicluster-gateway-controller-system"
         },
         "datasource": {
           "type": "prometheus",
@@ -933,33 +934,6 @@
         "options": [],
         "query": {
           "query": "label_values(kube_pod_info, namespace)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": true,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "label_values(node)",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Node",
-        "multi": false,
-        "name": "node",
-        "options": [],
-        "query": {
-          "query": "label_values(node)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/config/prometheus-for-federation/grafana-dashboard-mgc-metrics.json
+++ b/config/prometheus-for-federation/grafana-dashboard-mgc-metrics.json
@@ -1,0 +1,983 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 19,
+  "iteration": 1691663562703,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P8D9ADF90DB2E3ECF"
+      },
+      "description": "Shows the number of pods by status in the selected namespace. Note this is an 'Instant' value i.e. it uses the latest value instead of querying over a range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {
+          "titleSize": 18,
+          "valueSize": 18
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kube_pod_status_phase{namespace=~\"$namespace\"}) by(phase)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{label_name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Statuses",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P8D9ADF90DB2E3ECF"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "8.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(kube_pod_container_status_restarts_total{namespace=~\"$namespace\"}[30m]))",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Restarts",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "hidden",
+            "barAlignment": 0,
+            "drawStyle": "points",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byType",
+              "options": "time"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 16,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (pod) (rate(kube_pod_container_status_restarts_total[30m]) > 0 )",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "range": false,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "title": "Pods Restarted",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P8D9ADF90DB2E3ECF"
+      },
+      "description": "Shows the total number of Goroutines by pod in the selected namespace.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_goroutines{namespace=~\"$namespace\",node=~\"$node\"}) by(pod)",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P8D9ADF90DB2E3ECF"
+      },
+      "description": "Shows pod CPU usage for each pod in the namespace. If set, pod CPU requests and limits are also shown. The legend includes a suffix of the pod name.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", node=~\"$node\"}[1m])) by(pod)",
+          "legendFormat": "CPU Usage {{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"cpu\", node=~\"$node\"}",
+          "hide": false,
+          "legendFormat": "CPU Requests {{pod}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"cpu\", node=~\"$node\"}",
+          "hide": false,
+          "legendFormat": "CPU Limits {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P8D9ADF90DB2E3ECF"
+      },
+      "description": "Shows pod memory usage in MiB (based on RSS) for each pod in the namespace. If set, pod memory requests and limits are also shown. The legend includes a suffix of the pod name.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_memory_rss{namespace=~\"$namespace\", node=~\"$node\"}) by (pod)",
+          "legendFormat": "Pod Memory {{pod}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_container_resource_requests{namespace=~\"$namespace\", resource=\"memory\", node=~\"$node\"}",
+          "hide": false,
+          "legendFormat": "Pod Memory Requests {{pod}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_container_resource_limits{namespace=~\"$namespace\", resource=\"memory\", node=~\"$node\"}",
+          "hide": false,
+          "legendFormat": "Pod Memory Limits {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P8D9ADF90DB2E3ECF"
+      },
+      "description": "Shows the rate of resources being queued for processing by each controller.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(workqueue_adds_total{}[5m])) by (instance, name)",
+          "legendFormat": "{{instance}} {{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Work Queue Add Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P8D9ADF90DB2E3ECF"
+      },
+      "description": "Shows the queue size for each resource controller.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(workqueue_depth{}[5m])) by (instance, name)",
+          "legendFormat": "{{instance}} {{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Work Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P8D9ADF90DB2E3ECF"
+      },
+      "description": "Shows the queue processing latency for each resource controller.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P8D9ADF90DB2E3ECF"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{}[$__range])) by (instance, name, le))",
+          "legendFormat": "{{instance}} {{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Work Queue Latency",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "thanos-query",
+          "value": "thanos-query"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P8D9ADF90DB2E3ECF"
+        },
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(node)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Node",
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(node)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "MGC SRE Dashboard",
+  "uid": "PalQwi6Vz",
+  "version": 1,
+  "weekStart": ""
+}

--- a/config/prometheus-for-federation/grafana_deployment_patch.yaml
+++ b/config/prometheus-for-federation/grafana_deployment_patch.yaml
@@ -6,7 +6,19 @@
      defaultMode: 420
      name: grafana-istio-workload
 - op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: grafana-mgc-metrics
+    configMap:
+     defaultMode: 420
+     name: grafana-mgc-metrics
+- op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value:
     name: grafana-istio-workload
     mountPath: /grafana-dashboard-definitions/0/grafana-istio-workload
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: grafana-mgc-metrics
+    mountPath: /grafana-dashboard-definitions/0/grafana-mgc-metrics

--- a/config/prometheus-for-federation/kustomization.yaml
+++ b/config/prometheus-for-federation/kustomization.yaml
@@ -87,3 +87,7 @@ configMapGenerator:
   namespace: monitoring
   files:
   - grafana_dashboard_istio-workload.json
+- name: grafana-mgc-metrics
+  namespace: monitoring
+  files:
+  - grafana-dashboard-mgc-metrics.json

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -16,7 +16,7 @@ spec:
   endpoints:
     - path: /metrics
       port: metrics
-      scheme: https
+      scheme: http
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         insecureSkipVerify: true

--- a/config/prometheus/service.yaml
+++ b/config/prometheus/service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    control-plane: controller-manager
   name: metrics
   namespace: system
 spec:


### PR DESCRIPTION
Closes #308 

## What

- [x] Adds new dashboard for mgc metrics

## Verification
Run `make local-setup OCM_SINGLE=true METRICS_FEDERATION=true MGC_WORKLOAD_CLUSTERS_COUNT=1` and `make build-controller kind-load-controller deploy-controller METRICS=true`
The dashboard can be found on the Default dashboard page named: `MGC SRE Dashboard`

![image](https://github.com/Kuadrant/multicluster-gateway-controller/assets/6040758/8dba3f15-a462-4f86-ba8d-d164b074ab40)

## Any suggestions welcome:
- Are there any specific visualizations that should be prioritized on the dashboard? (e.g., graphs, tables, gauges, heatmaps)
- Are there additional metrics or data sources that should be included in this dashboard?
- Would it be beneficial to incorporate more variables to allow users to filter and customize the dashboard's data dynamically?
- Are there specific variables that should be used?