### PR TITLE
Gh 324 policy affected condition

### DIFF
--- a/pkg/_internal/conditions/conditions.go
+++ b/pkg/_internal/conditions/conditions.go
@@ -1,5 +1,50 @@
 package conditions
 
-const (
-	ConditionTypeReady string = "Ready"
+import (
+	"fmt"
+
+	k8smeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
+
+type ConditionType string
+type ConditionReason string
+
+const (
+	ConditionTypeReady ConditionType = "Ready"
+
+	//common policy reasons for policy affected conditions
+
+	PolicyReasonAccepted   ConditionReason = "Accepted"
+	PolicyReasonInvalid    ConditionReason = "Invalid"
+	PolicyReasonUnknown    ConditionReason = "Unknown"
+	PolicyReasonConflicted ConditionReason = "Conflicted"
+)
+
+func BuildPolicyAffectedCondition(conditionType ConditionType, policyObject runtime.Object, targetRef metav1.Object, reason ConditionReason, err error) metav1.Condition {
+
+	condition := metav1.Condition{
+		Type:               string(conditionType),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(reason),
+		ObservedGeneration: targetRef.GetGeneration(),
+	}
+
+	objectMeta, metaErr := k8smeta.Accessor(policyObject)
+	if metaErr != nil {
+		condition.Status = metav1.ConditionFalse
+		condition.Message = fmt.Sprintf("failed to get metadata about policy object %s", policyObject.GetObjectKind().GroupVersionKind().String())
+		condition.Reason = string(PolicyReasonUnknown)
+		return condition
+	}
+	if err != nil {
+		condition.Status = metav1.ConditionFalse
+		condition.Message = fmt.Sprintf("policy failed. Object unaffected by policy %s in namespace %s with name %s with error %s", policyObject.GetObjectKind().GroupVersionKind().String(), objectMeta.GetNamespace(), objectMeta.GetName(), err)
+		return condition
+	}
+
+	condition.Message = fmt.Sprintf("policy success. Object affected by policy %s in namespace %s with name %s ", policyObject.GetObjectKind().GroupVersionKind().String(), objectMeta.GetNamespace(), objectMeta.GetName())
+
+	return condition
+}

--- a/pkg/_internal/conditions/conditions_test.go
+++ b/pkg/_internal/conditions/conditions_test.go
@@ -1,0 +1,89 @@
+package conditions_test
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/conditions"
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
+)
+
+const (
+	testConditionType conditions.ConditionType = "testCondition"
+)
+
+func TestBuildPolicyCondition(t *testing.T) {
+	runtimeObject := func() runtime.Object {
+		return &v1alpha1.DNSPolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "DNSPolicy",
+				APIVersion: "kuadrant.io/v1alpha1",
+			},
+		}
+	}
+
+	targetRef := func() *gatewayv1beta1.Gateway {
+		return &gatewayv1beta1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: int64(2),
+			},
+		}
+	}
+	testCases := []struct {
+		Name            string
+		ConditionReason conditions.ConditionReason
+		Err             error
+		Validate        func(t *testing.T, cond metav1.Condition)
+	}{
+		{
+			Name:            "test condition accepted",
+			ConditionReason: conditions.PolicyReasonAccepted,
+			Validate: func(t *testing.T, cond metav1.Condition) {
+				if cond.Reason != string(conditions.PolicyReasonAccepted) {
+					t.Fatalf("expected condition reason %s but got %s ", conditions.PolicyReasonAccepted, cond.Reason)
+				}
+				if cond.ObservedGeneration != targetRef().Generation {
+					t.Fatalf("expected observed generation %d but got %d", targetRef().Generation, cond.ObservedGeneration)
+				}
+			},
+		},
+		{
+			Name:            "test condition invalid",
+			ConditionReason: conditions.PolicyReasonInvalid,
+			Validate: func(t *testing.T, cond metav1.Condition) {
+				if cond.Reason != string(conditions.PolicyReasonInvalid) {
+					t.Fatalf("expected condition reason %s but got %s ", conditions.PolicyReasonAccepted, cond.Reason)
+				}
+				if cond.ObservedGeneration != targetRef().Generation {
+					t.Fatalf("expected observed generation %d but got %d", targetRef().Generation, cond.ObservedGeneration)
+				}
+			},
+			Err: fmt.Errorf("fatal error"),
+		},
+		{
+			Name:            "test condition conflicted",
+			ConditionReason: conditions.PolicyReasonConflicted,
+			Validate: func(t *testing.T, cond metav1.Condition) {
+				if cond.Reason != string(conditions.PolicyReasonConflicted) {
+					t.Fatalf("expected condition reason %s but got %s ", conditions.PolicyReasonConflicted, cond.Reason)
+				}
+				if cond.ObservedGeneration != targetRef().Generation {
+					t.Fatalf("expected observed generation %d but got %d", targetRef().Generation, cond.ObservedGeneration)
+				}
+			},
+			Err: fmt.Errorf("fatal error"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			cond := conditions.BuildPolicyAffectedCondition(testConditionType, runtimeObject(), targetRef(), testCase.ConditionReason, testCase.Err)
+			testCase.Validate(t, cond)
+		})
+	}
+
+}

--- a/pkg/controllers/dnsrecord/dnsrecord_controller.go
+++ b/pkg/controllers/dnsrecord/dnsrecord_controller.go
@@ -108,7 +108,7 @@ func (r *DNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		dnsRecord.Status.ObservedGeneration = dnsRecord.Generation
 		dnsRecord.Status.Endpoints = dnsRecord.Spec.Endpoints
 	}
-	setDNSRecordCondition(dnsRecord, conditions.ConditionTypeReady, status, reason, message)
+	setDNSRecordCondition(dnsRecord, string(conditions.ConditionTypeReady), status, reason, message)
 
 	if !equality.Semantic.DeepEqual(previous.Status, dnsRecord.Status) {
 		updateErr := r.Status().Update(ctx, dnsRecord)

--- a/pkg/controllers/managedzone/managedzone_controller.go
+++ b/pkg/controllers/managedzone/managedzone_controller.go
@@ -143,7 +143,7 @@ func (r *ManagedZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	managedZone.Status.ObservedGeneration = managedZone.Generation
-	setManagedZoneCondition(managedZone, conditions.ConditionTypeReady, status, reason, message)
+	setManagedZoneCondition(managedZone, string(conditions.ConditionTypeReady), status, reason, message)
 	err = r.Status().Update(ctx, managedZone)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -192,7 +192,7 @@ func (r *ManagedZoneReconciler) deleteManagedZone(ctx context.Context, managedZo
 		reason = "ProviderError"
 		message = fmt.Sprintf("The DNS provider creation failed: %v", err)
 		managedZone.Status.ObservedGeneration = managedZone.Generation
-		setManagedZoneCondition(managedZone, conditions.ConditionTypeReady, status, reason, message)
+		setManagedZoneCondition(managedZone, string(conditions.ConditionTypeReady), status, reason, message)
 		return err
 	}
 	err = dnsProvider.DeleteManagedZone(managedZone)
@@ -336,7 +336,7 @@ func (r *ManagedZoneReconciler) parentZoneNSRecordReady(ctx context.Context, man
 		}
 	}
 
-	nsRecordReady := meta.IsStatusConditionTrue(nsRecord.Status.Conditions, conditions.ConditionTypeReady)
+	nsRecordReady := meta.IsStatusConditionTrue(nsRecord.Status.Conditions, string(conditions.ConditionTypeReady))
 	if !nsRecordReady {
 		return fmt.Errorf("the ns record is not in a ready state : %s", nsRecord.Name)
 	}

--- a/pkg/controllers/tlspolicy/tlspolicy_controller.go
+++ b/pkg/controllers/tlspolicy/tlspolicy_controller.go
@@ -205,7 +205,7 @@ func (r *TLSPolicyReconciler) calculateStatus(tlsPolicy *v1alpha1.TLSPolicy, spe
 
 func (r *TLSPolicyReconciler) readyCondition(targetNetworkObjectectKind string, specErr error) *metav1.Condition {
 	cond := &metav1.Condition{
-		Type:    conditions.ConditionTypeReady,
+		Type:    string(conditions.ConditionTypeReady),
 		Status:  metav1.ConditionTrue,
 		Reason:  fmt.Sprintf("%sTLSEnabled", targetNetworkObjectectKind),
 		Message: fmt.Sprintf("%s is TLS Enabled", targetNetworkObjectectKind),

--- a/test/e2e/gateway_single_spoke_test.go
+++ b/test/e2e/gateway_single_spoke_test.go
@@ -280,7 +280,7 @@ var _ = Describe("Gateway single target cluster", func() {
 							GinkgoWriter.Printf("[debug] unable to get DNSRecord: '%s'\n", err)
 							return false
 						}
-						return meta.IsStatusConditionTrue(dnsrecord.Status.Conditions, conditions.ConditionTypeReady)
+						return meta.IsStatusConditionTrue(dnsrecord.Status.Conditions, string(conditions.ConditionTypeReady))
 					}).WithTimeout(300 * time.Second).WithPolling(10 * time.Second).WithContext(ctx).Should(BeTrue())
 
 					// still need to wait some seconds to the dns server to actually start

--- a/test/integration/tlspolicy_controller_test.go
+++ b/test/integration/tlspolicy_controller_test.go
@@ -95,7 +95,7 @@ var _ = Describe("TLSPolicy", Ordered, func() {
 					if err := k8sClient.Get(ctx, client.ObjectKey{Name: tlsPolicy.Name, Namespace: tlsPolicy.Namespace}, tlsPolicy); err != nil {
 						return false
 					}
-					return meta.IsStatusConditionTrue(tlsPolicy.Status.Conditions, conditions.ConditionTypeReady)
+					return meta.IsStatusConditionTrue(tlsPolicy.Status.Conditions, string(conditions.ConditionTypeReady))
 				}, time.Second*15, time.Second).Should(BeTrue())
 			})
 


### PR DESCRIPTION
updates to original https://github.com/Kuadrant/multicluster-gateway-controller/pull/433 
closes  #324 

- make the condition more generic so it can be used by tls policy
- ensure the condition is removed when policy is removed
- Improve the message so it gives clear pointer to which policy is affecting the gateway




**Verification**
Expected that you have setup the placement and managed clusters etc


1) Create a gateway excluding TLS for simplicity. Change to your own listener host

```
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: prod-web
  namespace: multi-cluster-gateways
  labels:
    cluster.open-cluster-management.io/placement: http-gateway
spec:
  gatewayClassName: kuadrant-multi-cluster-gateway-instance-per-cluster
  listeners:
  - allowedRoutes:
      namespaces:
        from: All
    name: specific
    hostname: 'specific.cb.hcpapps.net'
    port: 443
    protocol: HTTP
```

2) check no DNSPolicyAffected condition present

3) create the dnspolicy

```
apiVersion: kuadrant.io/v1alpha1
kind: DNSPolicy
metadata:
  name: prod-web
  namespace: multi-cluster-gateways
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: prod-web
    namespace: multi-cluster-gateways
```


4)

Check the status of the gateway should now have condition

```
lastTransitionTime: "2023-08-21T15:10:46Z"
message: 'policy succeeded object affected by policy kuadrant.io/v1alpha1, Kind=DNSPolicy in namespace multi-cluster-gateways with name prod-web '
reason: Accepted
status: "True"
type: DNSPolicyAffected
```
5) delete the dns policy the condition should be removed


