### PR TITLE
Run tools image in non-interactive mode

### DIFF
--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -20,7 +20,7 @@ export TOOLS_IMAGE=quay.io/kuadrant/mgc-tools:latest
 export TMP_DIR=/tmp/mgc
 
 dockerBinCmd() {
-  echo "docker run --rm -i -u $UID -v ${TMP_DIR}:/tmp/mgc:z --network mgc -e KUBECONFIG=/tmp/mgc/kubeconfig --entrypoint=$1 $TOOLS_IMAGE"
+  echo "docker run --rm -u $UID -v ${TMP_DIR}:/tmp/mgc:z --network mgc -e KUBECONFIG=/tmp/mgc/kubeconfig --entrypoint=$1 $TOOLS_IMAGE"
 }
 
 export KIND_BIN=kind


### PR DESCRIPTION
## What

Remove `-i` option from the tools image's `docker run` command to prevent quickstart script exiting early when piping it to bash.

## Verification

Verify that curling the script and piping it to bash successfully creates and configures clusters.

```
curl https://raw.githubusercontent.com/eoinfennessy/multicluster-gateway-controller/fix_quickstart_with_curl/hack/quickstart-setup.sh | bash
```