### PR TITLE
data-plane components installation guide

### DIFF
--- a/config/kuadrant/redis/limitador/kustomization.yaml
+++ b/config/kuadrant/redis/limitador/kustomization.yaml
@@ -6,4 +6,4 @@ secretGenerator:
     literals:
       -  URL=redis://172.31.0.3:30611
     options:
-      disableNameSuffixHash: true   
+      disableNameSuffixHash: true

--- a/config/service-protection-install-guide/kustomization.yaml
+++ b/config/service-protection-install-guide/kustomization.yaml
@@ -1,3 +1,2 @@
 resources:
-  - ../default
   - managed-cluster-addon.yaml

--- a/config/service-protection-install-guide/kustomization.yaml
+++ b/config/service-protection-install-guide/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../default
+  - managed-cluster-addon.yaml

--- a/config/service-protection-install-guide/managed-cluster-addon.yaml
+++ b/config/service-protection-install-guide/managed-cluster-addon.yaml
@@ -1,0 +1,7 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+ name: kuadrant-addon
+spec:
+ installNamespace: open-cluster-management-agent-addon
+ 

--- a/docs/how-to/kuadrant-hub-install.md
+++ b/docs/how-to/kuadrant-hub-install.md
@@ -163,4 +163,4 @@ clusterissuer.cert-manager.io/mgc-ca condition met
 
 Now that you have MGC installed and configured in your hub cluster, you can now continue with any of these follow-on guides:
 
-- Installing the Kuadrant data-plane pieces [TODO: link to this]
+- Installing the [Kuadrant Service Protection components](./service-protection-setup.md)

--- a/docs/how-to/ratelimiting-shared-redis.md
+++ b/docs/how-to/ratelimiting-shared-redis.md
@@ -66,4 +66,3 @@ Open three windows, which we'll refer to throughout this walkthrough as:
     while true; do curl -k -s -o /dev/null -w "%{http_code}\n"  replace.this.with.host && sleep 1; done
     ```
 2. You should see your host be limited to whatever limit you've chosen. This will be across **all** clusters. Meaning if you are trying to make a curl request to both clusters at the same time, it will maintain the limit and won't reset, allowing successful requests when it should be limited.
-

--- a/docs/how-to/service-protection-setup.md
+++ b/docs/how-to/service-protection-setup.md
@@ -15,8 +15,7 @@ This walkthrough will show you how to install and setup the Kuadrant Operator in
   * We recommend installing Istio 1.17.0, including Gateway API v0.6.2
   * ```bash
     # On the Hub cluster:
-    kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-    { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.2" | kubectl apply -f -; }
+    kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.2"
     ```
   * See also: https://istio.io/v1.17/blog/2022/getting-started-gtwapi/
 
@@ -31,7 +30,7 @@ Alternatively, if you'd like to quickly get started locally, without having to w
 
 To install the Kuadrant Service Protection components into a `ManagedCluster`, target your OCM hub cluster with `kubectl` and run:
 
-`kubectl apply -k "github.com/kuadrant/multicluster-gateway-controller.git/config/service-protection-install-guide" -n <your-managed-cluster>`
+`kubectl apply -k "github.com/kuadrant/multicluster-gateway-controller.git/config/service-protection-install-guide?ref=main" -n <your-managed-cluster>`
 
 The above command will install the `ManagedClusterAddOn` resource needed to install the Kuadrant addon into the specified namespace, and install the Kuadrant data-plane components into the `open-cluster-management-agent-addon` namespace. 
 
@@ -44,7 +43,7 @@ The Kuadrant addon will install:
 For more details, see the Kuadrant components installed by the (kuadrant-operator)[https://github.com/Kuadrant/kuadrant-operator#kuadrant-components]
 
 ### Existing Istio installations and changing the default Istio Operator name
-In the case where you have an existing Istio installation to a cluster you may encounter an issue where the Kuadrant Operator expects Istio's Operator to be named `istiocontrolplane`.
+In the case where you have an existing Istio installation on a cluster, you may encounter an issue where the Kuadrant Operator expects Istio's Operator to be named `istiocontrolplane`.
 
 The `istioctl` command saves the IstioOperator CR that was used to install Istio in a copy of the CR named `installed-state`.
 
@@ -59,7 +58,7 @@ This will propogate down and update the Kuadrant Operator, used by the Kuadrant 
 To verify the Kuadrant OCM addon has installed currently, run:
 
 ```bash
-kubectl wait --timeout=5m -n kuadrant-system deployment/authorino-operator deployment/kuadrant-operator-controller-manager deployment/limitador-operator-controller-manager --for=condition=Available
+kubectl wait --timeout=5m -n kuadrant-system kuadrant/kuadrant-sample --for=condition=Ready
 ```
 
 You should see the namespace `kuadrant-system`, and the following pods come up:

--- a/docs/how-to/service-protection-setup.md
+++ b/docs/how-to/service-protection-setup.md
@@ -1,0 +1,81 @@
+# Installing Kuadrant Service Protection into an existing OCM Managed Cluster
+
+## Introduction
+This walkthrough will show you how to install and setup the Kuadrant Operator into an [OCM](https://open-cluster-management.io/) [Managed Cluster](https://open-cluster-management.io/concepts/managedcluster/).
+
+## Prerequisites
+* Access to an Open Cluster Management (>= v0.11.0) Managed Cluster, which has already been bootstrapped and registered with a hub cluster
+  * We have [a guide](./kuadrant-hub-install.md) which covers this in detail
+  * Also see:
+    * https://open-cluster-management.io/getting-started/quick-start/
+    * https://open-cluster-management.io/concepts/managedcluster/
+* OLM will need to be installed into the ManagedCluster where you want to run the Kuadrant Service Protection components
+  * See https://olm.operatorframework.io/docs/getting-started/
+* Kuadrant uses Istio as a Gateway API provider - this will need to be installed into the data plane clusters
+  * We recommend installing Istio 1.17.0, including Gateway API v0.6.2
+  * ```bash
+    # On the Hub cluster:
+    kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
+    { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.2" | kubectl apply -f -; }
+    ```
+  * See also: https://istio.io/v1.17/blog/2022/getting-started-gtwapi/
+
+
+Alternatively, if you'd like to quickly get started locally, without having to worry to much about the pre-requisites, take a look our [Quickstart Guide](./ocm-control-plane-walkthrough.md). It will get you setup with Kind, OLM, OCM & Kuadrant in a few short steps.
+
+
+## Install the Kuadrant OCM Add-On
+
+
+**Note:** if you've run our [Quickstart Guide](./ocm-control-plane-walkthrough.md), you'll be set to run this command as-is.
+
+To install the Kuadrant Service Protection components into a `ManagedCluster`, target your OCM hub cluster with `kubectl` and run:
+
+`kubectl apply -k "github.com/kuadrant/multicluster-gateway-controller.git/config/service-protection-install-guide" -n <your-managed-cluster>`
+
+The above command will install the `ManagedClusterAddOn` resource needed to install the Kuadrant addon into the specified namespace, and install the Kuadrant data-plane components into the `open-cluster-management-agent-addon` namespace. 
+
+The Kuadrant addon will install:
+
+* the Kuadrant Operator
+* Limitador (and its associated operator)
+* Authorino  (and its associated operator)
+
+For more details, see the Kuadrant components installed by the (kuadrant-operator)[https://github.com/Kuadrant/kuadrant-operator#kuadrant-components]
+
+### Existing Istio installations and changing the default Istio Operator name
+In the case where you have an existing Istio installation to a cluster you may encounter an issue where the Kuadrant Operator expects Istio's Operator to be named `istiocontrolplane`.
+
+The `istioctl` command saves the IstioOperator CR that was used to install Istio in a copy of the CR named `installed-state`.
+
+To let the Kuadrant operator use this existing installation, set the following:
+
+`kubectl annotate managedclusteraddon kuadrant-addon "addon.open-cluster-management.io/values"='{"IstioOperator":"installed-state"}' -n <managed spoke cluster>`
+
+This will propogate down and update the Kuadrant Operator, used by the Kuadrant OCM Addon.
+
+## Verify the Kuadrant addon installation
+
+To verify the Kuadrant OCM addon has installed currently, run:
+
+```bash
+kubectl wait --timeout=5m -n kuadrant-system deployment/authorino-operator deployment/kuadrant-operator-controller-manager deployment/limitador-operator-controller-manager --for=condition=Available
+```
+
+You should see the namespace `kuadrant-system`, and the following pods come up:
+* authorino-*value*
+* authorino-operator-*value*
+* kuadrant-operator-controller-manager-*value*
+* limitador-*value*
+* limitador-operator-controller-manager-*value*
+
+# Further Reading
+With the Kuadrant data plane components installed, here is some further reading material to help you utilise Authorino and Limitador:
+
+[Getting started with Authorino](https://docs.kuadrant.io/authorino/)
+[Getting started With Limitador](https://docs.kuadrant.io/limitador-operator/)
+
+
+
+
+

--- a/docs/how-to/service-protection-setup.md
+++ b/docs/how-to/service-protection-setup.md
@@ -14,7 +14,6 @@ This walkthrough will show you how to install and setup the Kuadrant Operator in
 * Kuadrant uses Istio as a Gateway API provider - this will need to be installed into the data plane clusters
   * We recommend installing Istio 1.17.0, including Gateway API v0.6.2
   * ```bash
-    # On the Hub cluster:
     kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.2"
     ```
   * See also: https://istio.io/v1.17/blog/2022/getting-started-gtwapi/


### PR DESCRIPTION
Closes: https://github.com/Kuadrant/multicluster-gateway-controller/issues/427

Added a new Kuadrant data plane components guide, detailing how to install the data-plane components with an existing OCM ManagedCluster.

Use-case: `As a cluster admin , with an existing cluster I want to use to try Kuadrant, how can I install the data-plane components into my workload/ManagedCluster cluster.`

Note: we can likely remove/drop the existing kuadrant-addon-walkthrough doc. We should replace it with a small guide on how to use the data-plane pieces.