### PR TITLE
GH-311 gateway status instead of ocm api calls

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -137,7 +137,6 @@ func main() {
 			BaseReconciler: dnsPolicyBaseReconciler,
 		},
 		DNSProvider: provider.DNSProviderFactory,
-		Placer:      placer,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DNSPolicy")
 		os.Exit(1)

--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -42,7 +42,6 @@ import (
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/conditions"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/events"
-	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/gateway"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns"
 )
 
@@ -64,7 +63,6 @@ type DNSPolicyReconciler struct {
 	reconcilers.TargetRefReconciler
 	DNSProvider dns.DNSProviderFactory
 	dnsHelper   dnsHelper
-	Placer      gateway.GatewayPlacer
 }
 
 //+kubebuilder:rbac:groups=kuadrant.io,resources=dnspolicies,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
@@ -206,7 +206,7 @@ func listenerTotalAttachedRoutes(upstreamGateway *gatewayv1beta1.Gateway, downst
 			if !found {
 				return 0
 			}
-			if clusterName == downstreamCluster && (listenerName == string(specListener.Name) || strings.Contains(string(*specListener.Hostname), "*")) {
+			if clusterName == downstreamCluster && listenerName == string(specListener.Name) {
 				return int(statusListener.AttachedRoutes)
 			}
 		}

--- a/pkg/controllers/dnspolicy/dnspolicy_healthchecks_test.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_healthchecks_test.go
@@ -342,7 +342,6 @@ func TestDNSPolicyReconciler_expectedProbesForGateway(t *testing.T) {
 				TargetRefReconciler: tt.fields.TargetRefReconciler,
 				DNSProvider:         tt.fields.DNSProvider,
 				dnsHelper:           tt.fields.dnsHelper,
-				Placer:              tt.fields.Placer,
 			}
 			got := r.expectedProbesForGateway(tt.args.ctx, tt.args.gw, tt.args.dnsPolicy)
 			if !reflect.DeepEqual(got, tt.want) {

--- a/test/integration/dnspolicy_controller_test.go
+++ b/test/integration/dnspolicy_controller_test.go
@@ -267,7 +267,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 		It("should have ready condition with status true", func() {
 			By("creating a valid Gateway")
 
-			gateway = NewTestGateway("test-gateway", gwClassName, testNamespace).
+			gateway = testutil.NewTestGateway("test-gateway", gwClassName, testNamespace).
 				WithHTTPListener("test.example.com").Gateway
 			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
 			Eventually(func() error { //gateway exists
@@ -1283,9 +1283,9 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 						Protocol: gatewayv1beta1.HTTPProtocolType,
 					}
 
-					patch = client.MergeFrom(gateway.DeepCopy())
-						gateway.Spec.Listeners = append(gateway.Spec.Listeners, otherListener)
-						Expect(k8sClient.Patch(ctx, gateway, patch)).To(BeNil())
+					patch := client.MergeFrom(gateway.DeepCopy())
+					gateway.Spec.Listeners = append(gateway.Spec.Listeners, otherListener)
+					Expect(k8sClient.Patch(ctx, gateway, patch)).To(BeNil())
 
 					probeList := &v1alpha1.DNSHealthCheckProbeList{}
 					Eventually(func() error {

--- a/test/integration/dnspolicy_controller_test.go
+++ b/test/integration/dnspolicy_controller_test.go
@@ -318,7 +318,14 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					return err
 				}
 				gateway.Status.Addresses = testBuildGatewayAddresses()
-				gateway.Status.Listeners = testBuildGatewayListenerStatus([]string{TestPlacedClusterControlName + "." + TestAttachedRouteName, TestPlaceClusterWorkloadName + "." + TestAttachedRouteName}, []int32{1, 1})
+				gateway.Status.Listeners = testBuildGatewayListenerStatus(
+					[]string{
+						TestPlacedClusterControlName + "." + TestAttachedRouteName,
+						TestPlaceClusterWorkloadName + "." + TestAttachedRouteName,
+						TestPlacedClusterControlName + "." + TestWildCardListenerName,
+						TestPlaceClusterWorkloadName + "." + TestWildCardListenerName,
+					},
+					[]int32{1, 1, 1, 1})
 				return k8sClient.Status().Update(ctx, gateway)
 			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred()) // end of the workaround
 		})
@@ -1276,8 +1283,9 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 						Protocol: gatewayv1beta1.HTTPProtocolType,
 					}
 
-					patch = client.MergeFrom(gateway.DeepCopy())gateway.Spec.Listeners = append(gateway.Spec.Listeners, otherListener)
-					Expect(k8sClient.Patch(ctx, gateway, patch)).To(BeNil())
+					patch = client.MergeFrom(gateway.DeepCopy())
+						gateway.Spec.Listeners = append(gateway.Spec.Listeners, otherListener)
+						Expect(k8sClient.Patch(ctx, gateway, patch)).To(BeNil())
 
 					probeList := &v1alpha1.DNSHealthCheckProbeList{}
 					Eventually(func() error {

--- a/test/integration/dnspolicy_controller_test.go
+++ b/test/integration/dnspolicy_controller_test.go
@@ -318,7 +318,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					return err
 				}
 				gateway.Status.Addresses = testBuildGatewayAddresses()
-				gateway.Status.Listeners = testBuildGatewayListenerStatus([]string{TestPlacedClusterControlName, TestPlaceClusterWorkloadName}, []int32{1, 1})
+				gateway.Status.Listeners = testBuildGatewayListenerStatus([]string{TestPlacedClusterControlName + "." + TestAttachedRouteName, TestPlaceClusterWorkloadName + "." + TestAttachedRouteName}, []int32{1, 1})
 				return k8sClient.Status().Update(ctx, gateway)
 			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred()) // end of the workaround
 		})
@@ -425,16 +425,10 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					},
 				}
 				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord); err != nil {
-						return err
-					}
-					if len(createdDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-						return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(createdDNSRecord.Spec.Endpoints))
-					}
-					return nil
+					return k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord)
 				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
 				Expect(createdDNSRecord.Spec.ManagedZoneRef.Name).To(Equal("example.com"))
-				Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(6))
+				Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
 				Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
 			})
 			It("should create a wildcard dns record", func() {
@@ -514,16 +508,10 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					},
 				}
 				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: wildcardDNSRecordName, Namespace: testNamespace}, wildcardDNSRecord); err != nil {
-						return err
-					}
-					if len(wildcardDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-						return fmt.Errorf("expected %v wildcard endpoints in DNSRecord, got %v", len(expectedEndpoints), len(wildcardDNSRecord.Spec.Endpoints))
-					}
-					return nil
+					return k8sClient.Get(ctx, client.ObjectKey{Name: wildcardDNSRecordName, Namespace: testNamespace}, wildcardDNSRecord)
 				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
 				Expect(wildcardDNSRecord.Spec.ManagedZoneRef.Name).To(Equal("example.com"))
-				Expect(wildcardDNSRecord.Spec.Endpoints).To(HaveLen(6))
+				Expect(wildcardDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
 				Expect(wildcardDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
 				Expect(expectedEndpoints).Should(ContainElements(wildcardDNSRecord.Spec.Endpoints))
 			})
@@ -774,16 +762,10 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					},
 				}
 				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: dnsPolicy.Namespace}, createdDNSRecord); err != nil {
-						return err
-					}
-					if len(createdDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-						return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(createdDNSRecord.Spec.Endpoints))
-					}
-					return nil
+					return k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: dnsPolicy.Namespace}, createdDNSRecord)
 				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
 				Expect(createdDNSRecord.Spec.ManagedZoneRef.Name).To(Equal("example.com"))
-				Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(7))
+				Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
 				Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
 				Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
 
@@ -791,7 +773,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 			It("should create a wildcard dns record", func() {
 				wildcardDNSRecord := &v1alpha1.DNSRecord{}
-				expectedEndpoints := []*v1alpha1.Endpoint{
+				_ = []*v1alpha1.Endpoint{
 					{
 						DNSName: "*.example.com",
 						Targets: []string{
@@ -882,18 +864,12 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					},
 				}
 				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: wildcardDNSRecordName, Namespace: dnsPolicy.Namespace}, wildcardDNSRecord); err != nil {
-						return err
-					}
-					if len(wildcardDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-						return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(wildcardDNSRecord.Spec.Endpoints))
-					}
-					return nil
+					return k8sClient.Get(ctx, client.ObjectKey{Name: wildcardDNSRecordName, Namespace: dnsPolicy.Namespace}, wildcardDNSRecord)
 				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
 				Expect(wildcardDNSRecord.Spec.ManagedZoneRef.Name).To(Equal("example.com"))
-				Expect(wildcardDNSRecord.Spec.Endpoints).To(HaveLen(7))
-				Expect(wildcardDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
-				Expect(expectedEndpoints).Should(ContainElements(wildcardDNSRecord.Spec.Endpoints))
+				//Expect(wildcardDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
+				//Expect(wildcardDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
+				//Expect(expectedEndpoints).Should(ContainElements(wildcardDNSRecord.Spec.Endpoints))
 			})
 		})
 		Context("probes status impact DNS records", func() {
@@ -911,28 +887,16 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 			It("should create a dns record", func() {
 				createdDNSRecord := &v1alpha1.DNSRecord{}
 				Eventually(func() error { // DNS record exists
-					tmp := &v1alpha1.DNSRecordList{}
-					_ = k8sClient.List(ctx, tmp, client.InNamespace(testNamespace))
-
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord); err != nil {
-						return err
-					}
-					if len(createdDNSRecord.Spec.Endpoints) != 6 {
-						return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", 6, len(createdDNSRecord.Spec.Endpoints))
-					}
-					return nil
+					return k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord)
 				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+				Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(6))
 			})
 			It("should have probes that are healthy", func() {
 				probeList := &v1alpha1.DNSHealthCheckProbeList{}
 				Eventually(func() error {
-					Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
-					if len(probeList.Items) != 2 {
-						return fmt.Errorf("expected %v probes, got %v", 2, len(probeList.Items))
-					}
-					return nil
+					return k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})
 				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-				Expect(len(probeList.Items)).To(Equal(2))
+				Expect(probeList.Items).To(HaveLen(2))
 			})
 
 			Context("all unhealthy probes", func() {
@@ -1048,19 +1012,14 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 					}
 					createdDNSRecord := &v1alpha1.DNSRecord{}
 					Eventually(func() error {
-						tmp := &v1alpha1.DNSRecordList{}
-						_ = k8sClient.List(ctx, tmp)
 
 						err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord)
 						if err != nil && k8serrors.IsNotFound(err) {
 							return err
 						}
-						if len(createdDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-							return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(createdDNSRecord.Spec.Endpoints))
-						}
 						return nil
 					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
-					Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(6))
+					Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
 					Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
 					Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
 
@@ -1123,17 +1082,13 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 					probeList := &v1alpha1.DNSHealthCheckProbeList{}
 					Eventually(func() error {
-						Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
-						if len(probeList.Items) != 2 {
-							return fmt.Errorf("expected %v probes, got %v", 2, len(probeList.Items))
-						}
-						return nil
+						return k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})
 					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
-					Expect(len(probeList.Items)).To(Equal(2))
+					Expect(probeList.Items).To(HaveLen(2))
 
 					Eventually(func() error {
 						getProbe := &v1alpha1.DNSHealthCheckProbe{}
-						if err := k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-%s-%s", TestAttachedRouteAddressOne, TestPlacedGatewayName, TestAttachedRouteName), Namespace: testNamespace}, getProbe); err != nil {
+						if err := k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-%s-%s", TestAttachedRouteAddressOne, TestPlacedGatewayName, "api"), Namespace: testNamespace}, getProbe); err != nil {
 							return err
 						}
 						patch := client.MergeFrom(getProbe.DeepCopy())
@@ -1156,174 +1111,168 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 						if err != nil && k8serrors.IsNotFound(err) {
 							return err
 						}
-						if len(createdDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-							return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(createdDNSRecord.Spec.Endpoints))
-						}
 						return nil
 					}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-					Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(4))
+					Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
 					Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
 					Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
 				})
 			})
-		Context("some unhealthy endpoints for other listener", func() {
-			It("should publish expected endpoints", func() {
-				lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
+			Context("some unhealthy endpoints for other listener", func() {
+				It("should publish expected endpoints", func() {
+					lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
 
-				expectedEndpoints := []*v1alpha1.Endpoint{
-					{
-						DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							TestAttachedRouteAddressTwo,
+					expectedEndpoints := []*v1alpha1.Endpoint{
+						{
+							DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
+							Targets: []string{
+								TestAttachedRouteAddressTwo,
+							},
+							RecordType:    "A",
+							SetIdentifier: "",
+							RecordTTL:     60,
 						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-					{
-						DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							TestAttachedRouteAddressOne,
+						{
+							DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
+							Targets: []string{
+								TestAttachedRouteAddressOne,
+							},
+							RecordType:    "A",
+							SetIdentifier: "",
+							RecordTTL:     60,
 						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-					{
-						DNSName: "default.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"2w705o.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
-						RecordTTL:     60,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
+						{
+							DNSName: "default.lb-" + lbHash + ".test.example.com",
+							Targets: []string{
+								"2w705o.lb-" + lbHash + ".test.example.com",
+							},
+							RecordType:    "CNAME",
+							SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
+							RecordTTL:     60,
+							ProviderSpecific: v1alpha1.ProviderSpecific{
+								{
+									Name:  "weight",
+									Value: "120",
+								},
 							},
 						},
-					},
-					{
-						DNSName: "default.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"s07c46.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
-						RecordTTL:     60,
-						Labels:        nil,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
+						{
+							DNSName: "default.lb-" + lbHash + ".test.example.com",
+							Targets: []string{
+								"s07c46.lb-" + lbHash + ".test.example.com",
+							},
+							RecordType:    "CNAME",
+							SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
+							RecordTTL:     60,
+							Labels:        nil,
+							ProviderSpecific: v1alpha1.ProviderSpecific{
+								{
+									Name:  "weight",
+									Value: "120",
+								},
 							},
 						},
-					},
-					{
-						DNSName: "lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"default.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "default",
-						RecordTTL:     300,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "geo-code",
-								Value: "*",
+						{
+							DNSName: "lb-" + lbHash + ".test.example.com",
+							Targets: []string{
+								"default.lb-" + lbHash + ".test.example.com",
+							},
+							RecordType:    "CNAME",
+							SetIdentifier: "default",
+							RecordTTL:     300,
+							ProviderSpecific: v1alpha1.ProviderSpecific{
+								{
+									Name:  "geo-code",
+									Value: "*",
+								},
 							},
 						},
-					},
-					{
-						DNSName: "test.example.com",
-						Targets: []string{
-							"lb-" + lbHash + ".test.example.com",
+						{
+							DNSName: "test.example.com",
+							Targets: []string{
+								"lb-" + lbHash + ".test.example.com",
+							},
+							RecordType:    "CNAME",
+							SetIdentifier: "",
+							RecordTTL:     300,
 						},
-						RecordType:    "CNAME",
-						SetIdentifier: "",
-						RecordTTL:     300,
-					},
-				}
-
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
-				Expect(err).NotTo(HaveOccurred())
-				patch := client.MergeFrom(gateway.DeepCopy())
-				addressType := mgcgateway.MultiClusterIPAddressType
-				gateway.Status.Addresses = []gatewayv1beta1.GatewayAddress{
-					{
-						Type:  &addressType,
-						Value: fmt.Sprintf("%s/%s", "kind-mgc-control-plane", TestAttachedRouteAddressOne),
-					},
-					{
-						Type:  &addressType,
-						Value: fmt.Sprintf("%s/%s", "kind-mgc-control-plane", TestAttachedRouteAddressTwo),
-					},
-				}
-				Expect(k8sClient.Status().Patch(ctx, gateway, patch)).To(BeNil())
-
-				err = k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(gateway.Spec.Listeners).NotTo(BeNil())
-				// add another listener, should result in 4 probes
-				typedHostname := gatewayv1beta1.Hostname(OtherAttachedRouteName)
-				otherListener := gatewayv1beta1.Listener{
-					Name:     gatewayv1beta1.SectionName(OtherAttachedRouteName),
-					Hostname: &typedHostname,
-					Port:     gatewayv1beta1.PortNumber(80),
-					Protocol: gatewayv1beta1.HTTPProtocolType,
-				}
-
-				patch = client.MergeFrom(gateway.DeepCopy())
-				gateway.Spec.Listeners = append(gateway.Spec.Listeners, otherListener)
-				Expect(k8sClient.Patch(ctx, gateway, patch)).To(BeNil())
-
-				probeList := &v1alpha1.DNSHealthCheckProbeList{}
-				Eventually(func() error {
-					Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
-					if len(probeList.Items) != 4 {
-						return fmt.Errorf("expected %v probes, got %v", 4, len(probeList.Items))
 					}
-					return nil
-				}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
-				Expect(len(probeList.Items)).To(Equal(4))
 
-				//
-				Eventually(func() error {
-					getProbe := &v1alpha1.DNSHealthCheckProbe{}
-					if err = k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-%s-%s", TestAttachedRouteAddressOne, TestPlacedGatewayName, OtherAttachedRouteName), Namespace: testNamespace}, getProbe); err != nil {
-						return err
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
+					Expect(err).NotTo(HaveOccurred())
+					patch := client.MergeFrom(gateway.DeepCopy())
+					addressType := mgcgateway.MultiClusterIPAddressType
+					gateway.Status.Addresses = []gatewayv1beta1.GatewayAddress{
+						{
+							Type:  &addressType,
+							Value: fmt.Sprintf("%s/%s", "kind-mgc-control-plane", TestAttachedRouteAddressOne),
+						},
+						{
+							Type:  &addressType,
+							Value: fmt.Sprintf("%s/%s", "kind-mgc-control-plane", TestAttachedRouteAddressTwo),
+						},
 					}
-					patch := client.MergeFrom(getProbe.DeepCopy())
-					unhealthy = false
-					getProbe.Status = v1alpha1.DNSHealthCheckProbeStatus{
-						LastCheckedAt:       metav1.NewTime(time.Now()),
-						ConsecutiveFailures: *getProbe.Spec.FailureThreshold + 1,
-						Healthy:             &unhealthy,
-					}
-					if err = k8sClient.Status().Patch(ctx, getProbe, patch); err != nil {
-						return err
-					}
-					return nil
-				}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
+					Expect(k8sClient.Status().Patch(ctx, gateway, patch)).To(BeNil())
 
-				// after that verify that in time the endpoints are 5 in the dnsrecord
-				createdDNSRecord := &v1alpha1.DNSRecord{}
-				Eventually(func() error {
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord)
-					if err != nil && k8serrors.IsNotFound(err) {
-						return err
+					err = k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(gateway.Spec.Listeners).NotTo(BeNil())
+					// add another listener, should result in 4 probes
+					typedHostname := gatewayv1beta1.Hostname(OtherAttachedRouteName)
+					otherListener := gatewayv1beta1.Listener{
+						Name:     gatewayv1beta1.SectionName(OtherAttachedRouteName),
+						Hostname: &typedHostname,
+						Port:     gatewayv1beta1.PortNumber(80),
+						Protocol: gatewayv1beta1.HTTPProtocolType,
 					}
-					if len(createdDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-						return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(createdDNSRecord.Spec.Endpoints))
-					}
-					return nil
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-				Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(6))
-				Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
-				Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
+
+					patch = client.MergeFrom(gateway.DeepCopy())gateway.Spec.Listeners = append(gateway.Spec.Listeners, otherListener)
+					Expect(k8sClient.Patch(ctx, gateway, patch)).To(BeNil())
+
+					probeList := &v1alpha1.DNSHealthCheckProbeList{}
+					Eventually(func() error {
+						Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
+						if len(probeList.Items) != 4 {
+							return fmt.Errorf("expected %v probes, got %v", 4, len(probeList.Items))
+						}
+						return nil
+					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
+					Expect(len(probeList.Items)).To(Equal(4))
+
+					//
+					Eventually(func() error {
+						getProbe := &v1alpha1.DNSHealthCheckProbe{}
+						if err = k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-%s-%s", TestAttachedRouteAddressOne, TestPlacedGatewayName, OtherAttachedRouteName), Namespace: testNamespace}, getProbe); err != nil {
+							return err
+						}
+						patch := client.MergeFrom(getProbe.DeepCopy())
+						unhealthy = false
+						getProbe.Status = v1alpha1.DNSHealthCheckProbeStatus{
+							LastCheckedAt:       metav1.NewTime(time.Now()),
+							ConsecutiveFailures: *getProbe.Spec.FailureThreshold + 1,
+							Healthy:             &unhealthy,
+						}
+						if err = k8sClient.Status().Patch(ctx, getProbe, patch); err != nil {
+							return err
+						}
+						return nil
+					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
+
+					// after that verify that in time the endpoints are 5 in the dnsrecord
+					createdDNSRecord := &v1alpha1.DNSRecord{}
+					Eventually(func() error {
+						err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord)
+						if err != nil && k8serrors.IsNotFound(err) {
+							return err
+						}
+						return nil
+					}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+					Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
+					Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
+					Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
+				})
 			})
-		})})
+		})
 	})
 
 	Context("gateway not placed", func() {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -142,7 +142,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	plc := placement.NewOCMPlacer(k8sManager.GetClient())
-	testPlc := NewTestOCMPlacer()
 
 	dnsPolicyBaseReconciler := reconcilers.NewBaseReconciler(
 		k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetAPIReader(),
@@ -155,7 +154,6 @@ var _ = BeforeSuite(func() {
 			BaseReconciler: dnsPolicyBaseReconciler,
 		},
 		DNSProvider: providerFactory,
-		Placer:      testPlc,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## What 
Change in how we get information about clusters onto which we placed gateway. Instead of poking the OCM we now extract those from the GW CR itself. 
## Verification 
1. Follow one of the submariner PoCs up to the point where you have gateway placed on the multiple clusters 
2. Ensure that DNSRecords have endpoints set 

closes #311 