### PR TITLE
add doc for configuring dns provider

### DIFF
--- a/config/crd/bases/kuadrant.io_managedzones.yaml
+++ b/config/crd/bases/kuadrant.io_managedzones.yaml
@@ -65,12 +65,9 @@ spec:
                     type: string
                   namespace:
                     type: string
-                  type:
-                    type: string
                 required:
                 - name
                 - namespace
-                - type
                 type: object
               domainName:
                 description: Domain name of this ManagedZone

--- a/config/local-setup/controller/aws/managed_zone.yaml
+++ b/config/local-setup/controller/aws/managed_zone.yaml
@@ -9,5 +9,4 @@ spec:
   dnsProviderSecretRef:
     name: mgc-aws-credentials
     namespace: multi-cluster-gateways
-    type: AWS
 

--- a/config/local-setup/controller/gcp/managed_zone.yaml
+++ b/config/local-setup/controller/gcp/managed_zone.yaml
@@ -9,5 +9,4 @@ spec:
   dnsProviderSecretRef:
     name: mgc-gcp-credentials
     namespace: multi-cluster-gateways
-    type: GCP
 

--- a/docs/dns-policy.md
+++ b/docs/dns-policy.md
@@ -578,7 +578,7 @@ If an unsupported value is given to a provider, DNS records will **not** be crea
 
 :**Note:** :exclamation: For more information please the official AWS documentation 
 
-To see all regions supported by AWS Route 53 please see the official (documtation)[https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-geo.html]
+To see all regions supported by AWS Route 53, please see the official (documentation)[https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-geo.html]
 
 ##### Regions supported by GCP CLoud DNS
 

--- a/docs/dns-policy.md
+++ b/docs/dns-policy.md
@@ -563,7 +563,7 @@ In the above scenario any requests made in Spain will be returned the IP address
 Weighting of records is still enforced between clusters in the same geo group, in the case above however they are having no effect since there is only one cluster in each group.
 
 :exclamation:
-If a unsupported value is given to a provider, DNS records will **not** be created. Please choose carefully. For more information of what location is right for your needs please read said providers documentation. 
+If an unsupported value is given to a provider, DNS records will **not** be created. Please choose carefully. For more information on what location is right for your needs please, read that provider's documentation (see links below). 
 
 ##### Locations supported per DNS provider
 

--- a/docs/dns-policy.md
+++ b/docs/dns-policy.md
@@ -66,7 +66,6 @@ spec:
   dnsProviderSecretRef:
     name: my-aws-credentials
     namespace: multi-cluster-gateways
-    type: AWS
 ```
 
 ## DNSPolicy creation and attachment
@@ -484,7 +483,7 @@ lrnse3.lb-2903yb.echo.apps.hcpapps.net.
 #### Configuring Cluster Geo Locations
 
 The `defaultGeo` as described above puts all clusters into the same geo group, but for geo to be useful we need to mark our clusters as being in different locations.
-We can do this though by adding `geo-code` attributes on the ManagedCluster to show which county each cluster is in. The values that can be used are determined by the dns provider, in the case of Route53 any two digit ISO3166 alpha-2 country code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
+We can do this though by adding `geo-code` attributes on the ManagedCluster to show which county each cluster is in. The values that can be used are determined by the dns provider (See Below). 
 
 Apply `geo-code` labels to each of our managed cluster resources:
 ```bash
@@ -562,3 +561,27 @@ kubectl get dnsrecord echo.apps.hcpapps.net -n multi-cluster-gateways -o yaml | 
 
 In the above scenario any requests made in Spain will be returned the IP address of `kind-mgc-workload-2` and requests made from anywhere else in the world will be returned the IP address of `kind-mgc-workload-1`.
 Weighting of records is still enforced between clusters in the same geo group, in the case above however they are having no effect since there is only one cluster in each group.
+
+:exclamation:
+If a unsupported value is given to a provider, DNS records will **not** be created. Please choose carefully. For more information of what location is right for your needs please read said providers documentation. 
+
+##### Locations supported per DNS provider
+
+| Supported     | AWS | GCP |
+|---------------|-----|-----|
+| Continents    | :white_check_mark: |  :x: |
+| Country codes | :white_check_mark: |  :x:  |
+| States        | :white_check_mark: |  :x:  |
+| Regions       |  :x:  | :white_check_mark: |  
+
+##### Continents and country codes supported by AWS Route 53
+
+:**Note:** :exclamation: For more information please the official AWS documentation 
+
+To see all regions supported by AWS Route 53 please see the official (documtation)[https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-geo.html]
+
+##### Regions supported by GCP CLoud DNS
+
+To see all regions supported by GCP Cloud DNS please see the offical (documtation)[https://cloud.google.com/compute/docs/regions-zones]
+
+

--- a/docs/dns-policy.md
+++ b/docs/dns-policy.md
@@ -582,6 +582,6 @@ To see all regions supported by AWS Route 53, please see the official (documenta
 
 ##### Regions supported by GCP CLoud DNS
 
-To see all regions supported by GCP Cloud DNS please see the offical (documtation)[https://cloud.google.com/compute/docs/regions-zones]
+To see all regions supported by GCP Cloud DNS, please see the official (documentation)[https://cloud.google.com/compute/docs/regions-zones]
 
 

--- a/docs/how-to/dns-provider.md
+++ b/docs/how-to/dns-provider.md
@@ -1,0 +1,68 @@
+# Configuring a DNS Provider 
+
+In order to be able to interact with supported DNS providers, Kuadrant needs a credential that it can use. This credential is leveraged by the multi-cluster gateway controller in order to create and manage DNS records within zones used by the listeners defined in your gateways.
+
+
+## Supported Providers
+
+Kuadrant Supports the following DNS providers currently
+
+- AWS route 53 (aws)
+- Google DNS (gcp)
+
+
+
+## Configuring an AWS Route 53 provider
+
+Kuadant expects a secret with a credential. Below is an example for route 53. It is important to set the secret type to `aws`
+
+```
+apiVersion: v1
+data:
+  AWS_ACCESS_KEY_ID: XXXXX
+  AWS_REGION: XXXXX
+  AWS_SECRET_ACCESS_KEY: XXXXX
+kind: Secret
+metadata:
+  name: aws-credentials
+  namespace: multicluster-gateway-controller-system
+type: kuadrant.io/aws
+```
+
+
+## IAM permissions required 
+We have tested using the available policy `AmazonRoute53FullAccess` however it should also be possible to restrict the credential down to a particular zone. More info can be found in the AWS docs 
+https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/access-control-managing-permissions.html
+
+## Configuring a Google DNS provider
+
+Kuadant expects a secret with a credential. Below is an example for Google DNS. It is important to set the secret type to `gcp`
+
+```
+apiVersion: v1
+data:
+  GOOGLE: {"client_id": "00000000-00000000000000.apps.googleusercontent.com","client_secret": "d-FL95Q00000000000000","refresh_token": "00000aaaaa00000000-AAAAAAAAAAAAKFGJFJDFKDK","type": "authorized_user"}
+  PROJECT_ID: "my-project"
+kind: Secret
+metadata:
+  name: gcp-credentials
+  namespace: multicluster-gateway-controller-system
+type: kuadrant.io/gcp
+```
+
+
+### Access permissions required
+https://cloud.google.com/dns/docs/access-control#dns.admin
+
+
+### Where to create the secret.
+
+It is recommended that you create the secret in the same namespace as your `ManagedZones`
+Now that we have the credential created we have a DNS provdier ready to go and can start using it.
+
+## Using a credential
+
+Once a secret like the one shown above is created, in order for it to be used, it needs to be associated with a `ManagedZone`. 
+
+See [ManagedZone](managedZone.md)
+

--- a/docs/how-to/dns-provider.md
+++ b/docs/how-to/dns-provider.md
@@ -14,7 +14,7 @@ Kuadrant Supports the following DNS providers currently
 
 ## Configuring an AWS Route 53 provider
 
-Kuadant expects a secret with a credential. Below is an example for route 53. It is important to set the secret type to `aws`
+Kuadant expects a secret with a credential. Below is an example for AWS Route 53. It is important to set the secret type to `aws`
 
 ```
 apiVersion: v1

--- a/docs/how-to/managedZone.md
+++ b/docs/how-to/managedZone.md
@@ -46,7 +46,14 @@ metadata:
   name: testmz.hcpapps.net
 spec:
   domainName: testmz.hcapps.net
+  dnsProviderSecretRef:
+    Name: my-credential
+    NameSpace: ns
 ```
+
+### Secret Ref
+
+This is a reference to a secret that contains a credential for accessing the DNS Provider. See [dns-provider](./dns-provider.md) for more details.
 
 ### Optional fields
 The following fields are optional:

--- a/docs/how-to/mgc-setup.md
+++ b/docs/how-to/mgc-setup.md
@@ -115,7 +115,6 @@ spec:
   dnsProviderSecretRef:
     name: mgc-aws-credentials
     namespace: multi-cluster-gateways
-    type: AWS
 EOF
 ```
 

--- a/docs/how-to/providers/providers.md
+++ b/docs/how-to/providers/providers.md
@@ -7,31 +7,7 @@ The following document tells you everything you need to know about the DNS Provi
 
 In the current iteration of the multi-cluster gateway controller we support both **AWS (Amazon web services) Route 53** and **GCP (Google cloud provider) cloud DNS**. 
 
-### Geolocation
 
-Geolocation is a feature available in both DNS providers we support. A location is needed for both DNS Providers, please see below for the supported location for the provider you require.
-
-:exclamation:
-If a unsupported value is given to a provider, DNS records will **not** be created. Please choose carefully. For more information of what location is right for your needs please read said providers documentation. 
-
-## Locations supported per DNS provider
-
-| Supported     | AWS | GCP |
-|---------------|-----|-----|
-| Continents    | :white_check_mark: |  :x: |
-| Country codes | :white_check_mark: |  :x:  |
-| States        | :white_check_mark: |  :x:  |
-| Regions       |  :x:  | :white_check_mark: |  
-
-## Continents and country codes supported by AWS Route 53
-
-:**Note:** :exclamation: For more information please the official AWS documentation 
-
-To see all regions supported by AWS Route 53 please see the offical (documtation)[https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-geo.html]
-
-## Regions supported by GCP CLoud DNS
-
-To see all regions supported by GCP Cloud DNS please see the offical (documtation)[https://cloud.google.com/compute/docs/regions-zones]
 ## Setting up DNS provider
 
 ### AWS Route 53

--- a/hack/.deployUtils
+++ b/hack/.deployUtils
@@ -365,7 +365,6 @@ spec:
   dnsProviderSecretRef:
     name: ${KIND_CLUSTER_PREFIX}aws-credentials
     namespace: multicluster-gateway-controller-system
-    type: AWS
 EOF
 }
 

--- a/pkg/apis/v1alpha1/managedzone_types.go
+++ b/pkg/apis/v1alpha1/managedzone_types.go
@@ -48,7 +48,6 @@ type SecretRef struct {
 	//+required
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
-	Type      string `json:"type"`
 }
 
 // ManagedZoneStatus defines the observed state of a Zone


### PR DESCRIPTION
Add doc showing how to configure a DNS Provider for use with MZ for example. Separate doc as we will also likely want to move to using this secret directly with DNSPolicy.

Note This also removes the unused `Type` field from the MZ. It does not look to be used anywhere in the code or have any real value given the secret has the provider as part of it.