### PR TITLE
account for probes relating to multiple listeners

### DIFF
--- a/pkg/controllers/dnspolicy/dns_helper.go
+++ b/pkg/controllers/dnspolicy/dns_helper.go
@@ -268,8 +268,9 @@ func (dh *dnsHelper) setEndpoints(ctx context.Context, mcgTarget *dns.MultiClust
 	// count will track whether a new endpoint has been removed.
 	// first newEndpoints are checked based on probe status and removed if unhealthy true and the consecutive failures are greater than the threshold.
 	removedEndpoints := 0
+
 	for i := 0; i < len(newEndpoints); i++ {
-		checkProbes := getProbesForEndpoint(newEndpoints[i], probes)
+		checkProbes := getProbesForEndpoint(newEndpoints[i], probes, mcgTarget.Gateway.Name, string(listener.Name))
 		if len(checkProbes) == 0 {
 			continue
 		}
@@ -453,11 +454,11 @@ func (dh *dnsHelper) getDNSHealthCheckProbes(ctx context.Context, gateway *gatew
 	})
 }
 
-func getProbesForEndpoint(endpoint *v1alpha1.Endpoint, probes []*v1alpha1.DNSHealthCheckProbe) []*v1alpha1.DNSHealthCheckProbe {
+func getProbesForEndpoint(endpoint *v1alpha1.Endpoint, probes []*v1alpha1.DNSHealthCheckProbe, gatewayName, listenerName string) []*v1alpha1.DNSHealthCheckProbe {
 	retProbes := []*v1alpha1.DNSHealthCheckProbe{}
 	for _, probe := range probes {
 		for _, target := range endpoint.Targets {
-			if strings.Contains(probe.Name, target) {
+			if dnsHealthCheckProbeName(target, gatewayName, listenerName) == probe.Name {
 				retProbes = append(retProbes, probe)
 			}
 		}

--- a/pkg/controllers/dnspolicy/dns_helper_test.go
+++ b/pkg/controllers/dnspolicy/dns_helper_test.go
@@ -421,7 +421,9 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 			name:     "test wildcard listener weighted",
 			listener: getTestListener("*.example.com"),
 			mcgTarget: &dns.MultiClusterGatewayTarget{
-				Gateway: &gatewayv1beta1.Gateway{},
+				Gateway: &gatewayv1beta1.Gateway{
+					ObjectMeta: v1.ObjectMeta{Name: "testgw"},
+				},
 				ClusterGatewayTargets: []dns.ClusterGatewayTarget{
 					{
 						ClusterGateway: &dns.ClusterGateway{
@@ -472,29 +474,29 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 			dnsPolicy: &v1alpha1.DNSPolicy{},
 			probeOne: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testOne",
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
 			probeTwo: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testTwo",
+					Name:      dnsHealthCheckProbeName("2.2.2.2", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
 			wantSpec: &v1alpha1.DNSRecordSpec{
 				Endpoints: []*v1alpha1.Endpoint{
 					{
-						DNSName:    "20qri0.lb-oe3k96.example.com",
+						DNSName:    "20qri0.lb-ocnswx.example.com",
 						Targets:    []string{"1.1.1.1", "2.2.2.2"},
 						RecordType: "A",
 						RecordTTL:  dns.DefaultTTL,
 					},
 					{
-						DNSName:       "default.lb-oe3k96.example.com",
-						Targets:       []string{"20qri0.lb-oe3k96.example.com"},
+						DNSName:       "default.lb-ocnswx.example.com",
+						Targets:       []string{"20qri0.lb-ocnswx.example.com"},
 						RecordType:    "CNAME",
-						SetIdentifier: "20qri0.lb-oe3k96.example.com",
+						SetIdentifier: "20qri0.lb-ocnswx.example.com",
 						RecordTTL:     dns.DefaultTTL,
 						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
 							{
@@ -504,7 +506,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "default.lb-oe3k96.example.com",
+						DNSName:       "default.lb-ocnswx.example.com",
 						Targets:       []string{"mylb.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "mylb.example.com",
@@ -517,8 +519,8 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "lb-oe3k96.example.com",
-						Targets:       []string{"default.lb-oe3k96.example.com"},
+						DNSName:       "lb-ocnswx.example.com",
+						Targets:       []string{"default.lb-ocnswx.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "default",
 						RecordTTL:     dns.DefaultCnameTTL,
@@ -531,7 +533,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 					},
 					{
 						DNSName:    "*.example.com",
-						Targets:    []string{"lb-oe3k96.example.com"},
+						Targets:    []string{"lb-ocnswx.example.com"},
 						RecordType: "CNAME",
 						RecordTTL:  dns.DefaultCnameTTL,
 					},
@@ -542,7 +544,9 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 			name:     "sets geo weighted endpoints wildcard",
 			listener: getTestListener("*.example.com"),
 			mcgTarget: &dns.MultiClusterGatewayTarget{
-				Gateway: &gatewayv1beta1.Gateway{},
+				Gateway: &gatewayv1beta1.Gateway{
+					ObjectMeta: v1.ObjectMeta{Name: "testgw"},
+				},
 				ClusterGatewayTargets: []dns.ClusterGatewayTarget{
 					{
 
@@ -599,29 +603,29 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 			dnsPolicy: &v1alpha1.DNSPolicy{},
 			probeOne: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testOne",
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
 			probeTwo: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testTwo",
+					Name:      dnsHealthCheckProbeName("2.2.2.2", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
 			wantSpec: &v1alpha1.DNSRecordSpec{
 				Endpoints: []*v1alpha1.Endpoint{
 					{
-						DNSName:    "20qri0.lb-oe3k96.example.com",
+						DNSName:    "20qri0.lb-ocnswx.example.com",
 						Targets:    []string{"1.1.1.1", "2.2.2.2"},
 						RecordType: "A",
 						RecordTTL:  dns.DefaultTTL,
 					},
 					{
-						DNSName:       "na.lb-oe3k96.example.com",
-						Targets:       []string{"20qri0.lb-oe3k96.example.com"},
+						DNSName:       "na.lb-ocnswx.example.com",
+						Targets:       []string{"20qri0.lb-ocnswx.example.com"},
 						RecordType:    "CNAME",
-						SetIdentifier: "20qri0.lb-oe3k96.example.com",
+						SetIdentifier: "20qri0.lb-ocnswx.example.com",
 						RecordTTL:     dns.DefaultTTL,
 						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
 							{
@@ -631,7 +635,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "ie.lb-oe3k96.example.com",
+						DNSName:       "ie.lb-ocnswx.example.com",
 						Targets:       []string{"mylb.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "mylb.example.com",
@@ -644,8 +648,8 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "lb-oe3k96.example.com",
-						Targets:       []string{"na.lb-oe3k96.example.com"},
+						DNSName:       "lb-ocnswx.example.com",
+						Targets:       []string{"na.lb-ocnswx.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "default",
 						RecordTTL:     dns.DefaultCnameTTL,
@@ -657,8 +661,8 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "lb-oe3k96.example.com",
-						Targets:       []string{"na.lb-oe3k96.example.com"},
+						DNSName:       "lb-ocnswx.example.com",
+						Targets:       []string{"na.lb-ocnswx.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "NA",
 						RecordTTL:     dns.DefaultCnameTTL,
@@ -670,8 +674,8 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "lb-oe3k96.example.com",
-						Targets:       []string{"ie.lb-oe3k96.example.com"},
+						DNSName:       "lb-ocnswx.example.com",
+						Targets:       []string{"ie.lb-ocnswx.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "IE",
 						RecordTTL:     dns.DefaultCnameTTL,
@@ -684,7 +688,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 					},
 					{
 						DNSName:    "*.example.com",
-						Targets:    []string{"lb-oe3k96.example.com"},
+						Targets:    []string{"lb-ocnswx.example.com"},
 						RecordType: "CNAME",
 						RecordTTL:  dns.DefaultCnameTTL,
 					},
@@ -752,13 +756,13 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 			dnsPolicy: &v1alpha1.DNSPolicy{},
 			probeOne: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testOne",
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
 			probeTwo: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testTwo",
+					Name:      dnsHealthCheckProbeName("2.2.2.2", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
@@ -822,7 +826,9 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 			name:     "sets geo weighted endpoints",
 			listener: getTestListener("test.example.com"),
 			mcgTarget: &dns.MultiClusterGatewayTarget{
-				Gateway: &gatewayv1beta1.Gateway{},
+				Gateway: &gatewayv1beta1.Gateway{
+					ObjectMeta: v1.ObjectMeta{Name: "testgw"},
+				},
 				ClusterGatewayTargets: []dns.ClusterGatewayTarget{
 					{
 
@@ -879,29 +885,29 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 			dnsPolicy: &v1alpha1.DNSPolicy{},
 			probeOne: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testOne",
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
 			probeTwo: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testTwo",
+					Name:      dnsHealthCheckProbeName("2.2.2.2", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
 			wantSpec: &v1alpha1.DNSRecordSpec{
 				Endpoints: []*v1alpha1.Endpoint{
 					{
-						DNSName:    "20qri0.lb-oe3k96.test.example.com",
+						DNSName:    "20qri0.lb-ocnswx.test.example.com",
 						Targets:    []string{"1.1.1.1", "2.2.2.2"},
 						RecordType: "A",
 						RecordTTL:  dns.DefaultTTL,
 					},
 					{
-						DNSName:       "na.lb-oe3k96.test.example.com",
-						Targets:       []string{"20qri0.lb-oe3k96.test.example.com"},
+						DNSName:       "na.lb-ocnswx.test.example.com",
+						Targets:       []string{"20qri0.lb-ocnswx.test.example.com"},
 						RecordType:    "CNAME",
-						SetIdentifier: "20qri0.lb-oe3k96.test.example.com",
+						SetIdentifier: "20qri0.lb-ocnswx.test.example.com",
 						RecordTTL:     dns.DefaultTTL,
 						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
 							{
@@ -911,7 +917,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "ie.lb-oe3k96.test.example.com",
+						DNSName:       "ie.lb-ocnswx.test.example.com",
 						Targets:       []string{"mylb.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "mylb.example.com",
@@ -924,8 +930,8 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "lb-oe3k96.test.example.com",
-						Targets:       []string{"na.lb-oe3k96.test.example.com"},
+						DNSName:       "lb-ocnswx.test.example.com",
+						Targets:       []string{"na.lb-ocnswx.test.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "default",
 						RecordTTL:     dns.DefaultCnameTTL,
@@ -937,8 +943,8 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "lb-oe3k96.test.example.com",
-						Targets:       []string{"na.lb-oe3k96.test.example.com"},
+						DNSName:       "lb-ocnswx.test.example.com",
+						Targets:       []string{"na.lb-ocnswx.test.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "NA",
 						RecordTTL:     dns.DefaultCnameTTL,
@@ -950,8 +956,8 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						},
 					},
 					{
-						DNSName:       "lb-oe3k96.test.example.com",
-						Targets:       []string{"ie.lb-oe3k96.test.example.com"},
+						DNSName:       "lb-ocnswx.test.example.com",
+						Targets:       []string{"ie.lb-ocnswx.test.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "IE",
 						RecordTTL:     dns.DefaultCnameTTL,
@@ -964,7 +970,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 					},
 					{
 						DNSName:    "test.example.com",
-						Targets:    []string{"lb-oe3k96.test.example.com"},
+						Targets:    []string{"lb-ocnswx.test.example.com"},
 						RecordType: "CNAME",
 						RecordTTL:  dns.DefaultCnameTTL,
 					},
@@ -975,7 +981,9 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 			name:     "sets no endpoints when no target addresses",
 			listener: getTestListener("test.example.com"),
 			mcgTarget: &dns.MultiClusterGatewayTarget{
-				Gateway: &gatewayv1beta1.Gateway{},
+				Gateway: &gatewayv1beta1.Gateway{
+					ObjectMeta: v1.ObjectMeta{Name: "testgw"},
+				},
 				ClusterGatewayTargets: []dns.ClusterGatewayTarget{
 					{
 
@@ -1018,13 +1026,13 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 			dnsPolicy: &v1alpha1.DNSPolicy{},
 			probeOne: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testOne",
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
 			probeTwo: &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: v1.ObjectMeta{
-					Name:      "testTwo",
+					Name:      dnsHealthCheckProbeName("2.2.2.2", "testgw", "test"),
 					Namespace: "namespace",
 				},
 			},
@@ -1106,7 +1114,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 							Namespace: "testns",
 							Name:      "testpolicy",
 						}),
-					Name:      "1.1.1.1-test.example.com",
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
 					Namespace: "testns",
 				},
 			},
@@ -1120,7 +1128,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 							Namespace: "testns",
 							Name:      "testpolicy",
 						}),
-					Name:      "2.2.2.2-test.example.com",
+					Name:      dnsHealthCheckProbeName("2.2.2.2", "testgw", "test"),
 					Namespace: "testns",
 				},
 			},
@@ -1250,7 +1258,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 							Namespace: "testns",
 							Name:      "testpolicy",
 						}),
-					Name:      "1.1.1.1-test.example.com",
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
 					Namespace: "testns",
 				},
 				Status: v1alpha1.DNSHealthCheckProbeStatus{
@@ -1268,7 +1276,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 							Namespace: "testns",
 							Name:      "testpolicy",
 						}),
-					Name:      "2.2.2.2-test.example.com",
+					Name:      dnsHealthCheckProbeName("2.2.2.2", "testgw", "test"),
 					Namespace: "testns",
 				},
 				Status: v1alpha1.DNSHealthCheckProbeStatus{
@@ -1407,7 +1415,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 							Namespace: "testns",
 							Name:      "testpolicy",
 						}),
-					Name:      "1.1.1.1-test.example.com",
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
 					Namespace: "testns",
 				},
 				Spec: v1alpha1.DNSHealthCheckProbeSpec{
@@ -1428,7 +1436,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 							Namespace: "testns",
 							Name:      "testpolicy",
 						}),
-					Name:      "2.2.2.2-test.example.com",
+					Name:      dnsHealthCheckProbeName("2.2.2.2", "testgw", "test"),
 					Namespace: "testns",
 				},
 				Spec: v1alpha1.DNSHealthCheckProbeSpec{
@@ -1552,7 +1560,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 							Namespace: "testns",
 							Name:      "testpolicy",
 						}),
-					Name:      "1.1.1.1-test.example.com",
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
 					Namespace: "testns",
 				},
 				Spec: v1alpha1.DNSHealthCheckProbeSpec{
@@ -1574,7 +1582,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 							Namespace: "testns",
 							Name:      "testpolicy",
 						}),
-					Name:      "2.2.2.2-test.example.com",
+					Name:      dnsHealthCheckProbeName("2.2.2.2", "testgw", "test"),
 					Namespace: "testns",
 				},
 				Spec: v1alpha1.DNSHealthCheckProbeSpec{
@@ -1617,6 +1625,167 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 						Targets:       []string{"2pj3we.lb-0ecjaw.test.example.com"},
 						RecordType:    "CNAME",
 						SetIdentifier: "2pj3we.lb-0ecjaw.test.example.com",
+						RecordTTL:     dns.DefaultTTL,
+						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
+							{
+								Name:  "weight",
+								Value: "120",
+							},
+						},
+					},
+					{
+						DNSName:       "lb-0ecjaw.test.example.com",
+						Targets:       []string{"default.lb-0ecjaw.test.example.com"},
+						RecordType:    "CNAME",
+						SetIdentifier: "default",
+						RecordTTL:     dns.DefaultCnameTTL,
+						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
+							{
+								Name:  "geo-code",
+								Value: "*",
+							},
+						},
+					},
+					{
+						DNSName:    "test.example.com",
+						Targets:    []string{"lb-0ecjaw.test.example.com"},
+						RecordType: "CNAME",
+						RecordTTL:  dns.DefaultCnameTTL,
+					},
+				},
+			},
+		},
+		{
+			name:     "test endpoint presence when probes are present for multiple listeners on the same cluster",
+			listener: getTestListener("test.example.com"),
+			mcgTarget: &dns.MultiClusterGatewayTarget{
+				Gateway: &gatewayv1beta1.Gateway{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "testgw",
+						Namespace: "testns",
+					},
+				},
+				ClusterGatewayTargets: []dns.ClusterGatewayTarget{
+					{
+
+						ClusterGateway: &dns.ClusterGateway{
+							Cluster: &testutil.TestResource{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "test-cluster-1",
+								},
+							},
+							GatewayAddresses: []gatewayv1beta1.GatewayAddress{
+								{
+									Type:  testutil.Pointer(gatewayv1beta1.IPAddressType),
+									Value: "1.1.1.1",
+								},
+							},
+						},
+						Geo:    testutil.Pointer(dns.GeoCode("default")),
+						Weight: testutil.Pointer(120),
+					},
+					{
+
+						ClusterGateway: &dns.ClusterGateway{
+							Cluster: &testutil.TestResource{
+								ObjectMeta: v1.ObjectMeta{
+									Name: "test-cluster-1",
+								},
+							},
+							GatewayAddresses: []gatewayv1beta1.GatewayAddress{
+								{
+									Type:  testutil.Pointer(gatewayv1beta1.IPAddressType),
+									Value: "2.2.2.2",
+								},
+							},
+						},
+						Geo:    testutil.Pointer(dns.GeoCode("default")),
+						Weight: testutil.Pointer(120),
+					},
+				},
+			},
+			dnsRecord: &v1alpha1.DNSRecord{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test.example.com",
+				},
+			},
+			dnsPolicy: &v1alpha1.DNSPolicy{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "testpolicy",
+					Namespace: "testns",
+				},
+			},
+			probeOne: &v1alpha1.DNSHealthCheckProbe{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: commonDNSRecordLabels(
+						types.NamespacedName{
+							Namespace: "testns",
+							Name:      "testgw"},
+						types.NamespacedName{
+							Namespace: "testns",
+							Name:      "testpolicy",
+						}),
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "test"),
+					Namespace: "testns",
+				},
+				Status: v1alpha1.DNSHealthCheckProbeStatus{
+					Healthy: aws.Bool(true),
+				},
+			},
+
+			probeTwo: &v1alpha1.DNSHealthCheckProbe{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: commonDNSRecordLabels(
+						types.NamespacedName{
+							Namespace: "testns",
+							Name:      "testgw"},
+						types.NamespacedName{
+							Namespace: "testns",
+							Name:      "testpolicy",
+						}),
+					Name:      dnsHealthCheckProbeName("1.1.1.1", "testgw", "other"),
+					Namespace: "testns",
+				},
+				Spec: v1alpha1.DNSHealthCheckProbeSpec{
+					FailureThreshold: aws.Int(4),
+				},
+				Status: v1alpha1.DNSHealthCheckProbeStatus{
+					Healthy:             aws.Bool(false),
+					ConsecutiveFailures: 6,
+				},
+			},
+			wantSpec: &v1alpha1.DNSRecordSpec{
+				Endpoints: []*v1alpha1.Endpoint{
+					{
+						DNSName:    "20qri0.lb-0ecjaw.test.example.com",
+						Targets:    []string{"1.1.1.1"},
+						RecordType: "A",
+						RecordTTL:  dns.DefaultTTL,
+					},
+					{
+						DNSName:    "20qri0.lb-0ecjaw.test.example.com",
+						Targets:    []string{"2.2.2.2"},
+						RecordType: "A",
+						RecordTTL:  dns.DefaultTTL,
+					},
+					{
+						DNSName:       "default.lb-0ecjaw.test.example.com",
+						Targets:       []string{"20qri0.lb-0ecjaw.test.example.com"},
+						RecordType:    "CNAME",
+						SetIdentifier: "20qri0.lb-0ecjaw.test.example.com",
+						RecordTTL:     dns.DefaultTTL,
+						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
+							{
+								Name:  "weight",
+								Value: "120",
+							},
+						},
+					},
+					{
+						DNSName:       "default.lb-0ecjaw.test.example.com",
+						Targets:       []string{"20qri0.lb-0ecjaw.test.example.com"},
+						RecordType:    "CNAME",
+						SetIdentifier: "20qri0.lb-0ecjaw.test.example.com",
 						RecordTTL:     dns.DefaultTTL,
 						ProviderSpecific: []v1alpha1.ProviderSpecificProperty{
 							{

--- a/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
@@ -129,7 +129,7 @@ func (r *DNSPolicyReconciler) expectedProbesForGateway(ctx context.Context, gw c
 			log.V(1).Info("reconcileHealthChecks: adding health check for target", "target", address.Value)
 			healthCheck := &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-%s-%s", matches[1], dnsPolicy.Name, listener.Name),
+					Name:      dnsHealthCheckProbeName(matches[1], gw.Name, string(listener.Name)),
 					Namespace: gw.Namespace,
 					Labels:    commonDNSRecordLabels(client.ObjectKeyFromObject(gw), client.ObjectKeyFromObject(dnsPolicy)),
 				},
@@ -151,4 +151,8 @@ func (r *DNSPolicyReconciler) expectedProbesForGateway(ctx context.Context, gw c
 	}
 
 	return healthChecks
+}
+
+func dnsHealthCheckProbeName(address, gatewayName, listenerName string) string {
+	return fmt.Sprintf("%s-%s", address, dnsRecordName(gatewayName, listenerName))
 }

--- a/pkg/controllers/dnspolicy/dnspolicy_healthchecks_test.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_healthchecks_test.go
@@ -105,7 +105,7 @@ func TestDNSPolicyReconciler_expectedProbesForGateway(t *testing.T) {
 			want: []*v1alpha1.DNSHealthCheckProbe{
 				{
 					ObjectMeta: controllerruntime.ObjectMeta{
-						Name:      "172.31.200.0-testdnspolicy-testlistener",
+						Name:      "172.31.200.0-testgateway-testlistener",
 						Namespace: "testnamespace",
 						Labels: map[string]string{
 							DNSPolicyBackRefAnnotation:                              "testdnspolicy",
@@ -184,7 +184,7 @@ func TestDNSPolicyReconciler_expectedProbesForGateway(t *testing.T) {
 			want: []*v1alpha1.DNSHealthCheckProbe{
 				{
 					ObjectMeta: controllerruntime.ObjectMeta{
-						Name:      "172.31.200.0-testdnspolicy-testlistener",
+						Name:      "172.31.200.0-testgateway-testlistener",
 						Namespace: "testnamespace",
 						Labels: map[string]string{
 							DNSPolicyBackRefAnnotation:                              "testdnspolicy",

--- a/test/integration/helper_test.go
+++ b/test/integration/helper_test.go
@@ -32,6 +32,7 @@ const (
 	TestPlacedClusterControlName = "test-placed-control"
 	TestPlaceClusterWorkloadName = "test-placed-workload-1"
 	TestAttachedRouteName        = "test.example.com"
+	OtherAttachedRouteName       = "other.example.com"
 	TestWildCardListenerName     = "wildcard"
 	TestWildCardListenerHost     = "*.example.com"
 	TestAttachedRouteAddressOne  = "172.0.0.1"


### PR DESCRIPTION
**What**
Account for multiple listeners resulting in more than one probe associate with an ip address/hostname which was the check used to get probes for setting endpoints based on healthy check probes.

The change itself is small.
Adding some additional unit and e2e tests to cover this case as well. 

Relates to https://github.com/Kuadrant/multicluster-gateway-controller/issues/272