### PR TITLE
Add verify bundle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,20 @@ jobs:
       - name: Run make verify-manifests
         run: |
           make verify-manifests
+  verify-bundle:
+    name: Verify bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.20.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.20.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make verify-bundle
+        run: |
+          make verify-bundle
   verify-imports:
     name: Verify imports
     runs-on: ubuntu-latest

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -61,6 +61,8 @@ spec:
                     type: array
                   failureThreshold:
                     type: integer
+                  interval:
+                    type: string
                   port:
                     type: integer
                   protocol:

--- a/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-09-08T13:55:08Z"
+    createdAt: "2023-09-12T08:55:14Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-gateway-controller.v0.0.0

--- a/hack/make/bundle.make
+++ b/hack/make/bundle.make
@@ -50,6 +50,18 @@ bundle: manifests operator-sdk kustomize
 	$(OPERATOR_SDK) generate kustomize manifests -q --apis-dir pkg/apis/v1alpha1
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
+	$(MAKE) bundle-ignore-createdAt
+
+# Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle
+# even if it is patched:
+#   https://github.com/operator-framework/operator-sdk/pull/6136
+# This code checks if only the createdAt field. If is the only change, it is ignored.
+# Else, it will do nothing.
+# https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
+# https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1532150678
+.PHONY: bundle-ignore-createdAt
+bundle-ignore-createdAt:
+	git diff --quiet -I'^    createdAt: ' ./bundle && git checkout ./bundle || true
 
 ## Build the bundle image.
 .PHONY: bundle-build

--- a/hack/make/check.make
+++ b/hack/make/check.make
@@ -9,6 +9,11 @@ verify-manifests: manifests ## Verify manifests update.
 	git diff --exit-code ./config
 	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./config)" ]
 
+.PHONY: verify-bundle
+verify-bundle: bundle ## Verify bundle update.
+	git diff --exit-code ./bundle
+	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle)" ]
+
 .PHONY: verify-imports
 verify-imports: ## Verify go imports are sorted and grouped correctly.
 	hack/verify-imports.sh


### PR DESCRIPTION
Adds a new verify bundle command that executes `make bundle` and ensures
the contents of `./bundle` are unchanged.

Add a check for createdAt being the only change to the bundle and ignore
it. Since operator-sdk 1.26.0, `make bundle` changes the `createdAt`
field from the bundle even if there are not other changes.

see https://github.com/Kuadrant/kuadrant-operator/blob/main/Makefile#L427

Update out of date OLM bundle contents `make bundle`