### PR TITLE
#509: Requeue Gateway placement if TLS secrets not found

### DIFF
--- a/pkg/controllers/gateway/gateway_controller_test.go
+++ b/pkg/controllers/gateway/gateway_controller_test.go
@@ -483,7 +483,7 @@ func TestGatewayReconciler_getTLSSecrets(t *testing.T) {
 				Scheme:    testCase.fields.Scheme,
 				Placement: fakeplacement.NewTestGatewayPlacer(),
 			}
-			got, err := r.getTLSSecrets(context.TODO(), testCase.args.upstreamGateway, testCase.args.downstreamGateway)
+			got, _, err := r.getTLSSecrets(context.TODO(), testCase.args.upstreamGateway, testCase.args.downstreamGateway)
 			if (err != nil) != testCase.wantErr {
 				t.Errorf("reconcileTLS() error = %v, wantErr %v", err, testCase.wantErr)
 				return

--- a/test/e2e/gateway_single_spoke_test.go
+++ b/test/e2e/gateway_single_spoke_test.go
@@ -53,8 +53,19 @@ var _ = Describe("Gateway single target cluster", func() {
 		err := tconfig.HubClient().Create(ctx, placement)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("creating a Gateway in the hub")
 		hostname = gatewayapi.Hostname(strings.Join([]string{testID, tconfig.ManagedZone()}, "."))
+
+		By("creating a dummy TLS secret")
+		tlsSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      string(hostname),
+				Namespace: tconfig.HubNamespace(),
+			},
+		}
+		err = tconfig.HubClient().Create(ctx, tlsSecret)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("creating a Gateway in the hub")
 		gw = &gatewayapi.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testID,


### PR DESCRIPTION
> Closes #509

Add a check to ensure all TLS secrets referenced in a Gateway exist before placing it

## Verification steps

* Follow the steps to reproduce the bug in #509 
* Verify the Gateway is not programmed
    ```
    k get gateways -A
    NAMESPACE                NAME       CLASS                                                 ADDRESS   PROGRAMMED   AGE
    multi-cluster-gateways   prod-web   kuadrant-multi-cluster-gateway-instance-per-cluster             Unknown      15s

    ```