### PR TITLE
fixing odd formatting on getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,9 +27,11 @@ Export environment variables with the keys listed below. Fill in your own values
 
 ### Set Up Clusters and Multicluster Gateway Controller
 
-   ```bash
-    curl https://raw.githubusercontent.com/kuadrant/multicluster-gateway-controller/main/hack/quickstart-setup.sh | bash
-   ```
+Run the following:
+
+```bash
+curl https://raw.githubusercontent.com/kuadrant/multicluster-gateway-controller/main/hack/quickstart-setup.sh | bash
+```
 
 ### What's Next
 


### PR DESCRIPTION
Code formatting was looking odd:

![Screenshot 2023-09-12 at 15 14 30](https://github.com/Kuadrant/multicluster-gateway-controller/assets/4467/d3e64875-c35f-40ea-8d5e-3c1e9e2ba934)
