### PR TITLE
Deploy release candidate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,8 @@ config/deploy/**/_*
 /application.yaml
 /ratelimitpolicy.yaml
 /echo_httproute.yaml
-
+/control-plane.yaml
+/workload*.yaml
 cmd/controller/__debug_bin
 
 # Submariner broker config

--- a/config/deploy/release-testing/kustomization.yaml
+++ b/config/deploy/release-testing/kustomization.yaml
@@ -1,0 +1,25 @@
+# Local deployment overlay.
+#
+# This requires the following .env files to exist in the project directory before
+# it can be used:
+# controller-config.env
+# aws-credentials.env
+
+resources:
+  - ../../default
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: controller-config
+    envs:
+      - ../../../controller-config.env
+
+secretGenerator:
+  - name: aws-credentials
+    envs:
+      - ../../../aws-credentials.env
+
+patchesStrategicMerge:
+- manager_config_patch.yaml

--- a/config/deploy/release-testing/manager_config_patch.yaml
+++ b/config/deploy/release-testing/manager_config_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        imagePullPolicy: IfNotPresent

--- a/hack/make/controller.make
+++ b/hack/make/controller.make
@@ -35,6 +35,14 @@ deploy-controller: manifests kustomize ## Deploy controller to the K8s cluster s
 		$(KUSTOMIZE) build config/prometheus | kubectl apply -f -;\
 	fi
 
+.PHONY: deploy-controller-release-candidate
+deploy-controller-release-candidate: 
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}
+	$(KUSTOMIZE) --load-restrictor LoadRestrictionsNone build config/deploy/release-testing | kubectl apply -f -
+	@if [ $(METRICS) = "true" ]; then\
+		$(KUSTOMIZE) build config/prometheus | kubectl apply -f -;\
+	fi
+
 .PHONY: undeploy-controller
 undeploy-controller: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	@if [ $(METRICS) = "true" ]; then\


### PR DESCRIPTION
Add a new make target to deploy the release target to the active cluster - allowing the specification to pull if not present and not interfere with the usual local dev environment.