### PR TITLE
#463: Add gateway.networking.k8s.io/policy annotation

### DIFF
--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    gateway.networking.k8s.io/policy: direct
   creationTimestamp: null
   name: dnspolicies.kuadrant.io
 spec:

--- a/bundle/manifests/kuadrant.io_tlspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_tlspolicies.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    gateway.networking.k8s.io/policy: direct
   creationTimestamp: null
   name: tlspolicies.kuadrant.io
 spec:

--- a/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-09-12T08:55:14Z"
+    createdAt: "2023-09-13T11:41:26Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-gateway-controller.v0.0.0

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -12,3 +12,7 @@ resources:
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml
+
+# Set the gateway.networking.k8s.io/policy annotation in the policies
+patchesStrategicMerge:
+  - patches/policy-patch.yaml

--- a/config/crd/patches/policy-patch.yaml
+++ b/config/crd/patches/policy-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dnspolicies.kuadrant.io
+  annotations:
+    gateway.networking.k8s.io/policy: direct
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tlspolicies.kuadrant.io
+  annotations:
+    gateway.networking.k8s.io/policy: direct


### PR DESCRIPTION
> Closes #463 

Add the gateway.networking.k8s.io/policy annotation to policy CRDs

## Verification

* Run `kustomize build config/crd`
* Verify that the output includes the annotation in the DNSPolicy and TLSPolicy CRDs