### PR TITLE
set image pull policy to always

### DIFF
--- a/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-09-14T11:20:33Z"
+    createdAt: "2023-09-14T13:57:32Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-gateway-controller.v0.0.0
@@ -465,6 +465,7 @@ spec:
                 command:
                 - /controller
                 image: quay.io/kuadrant/multicluster-gateway-controller:main
+                imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -529,6 +530,7 @@ spec:
                     name: controller-config
                     optional: true
                 image: quay.io/kuadrant/addon-manager:main
+                imagePullPolicy: Always
                 name: controller
                 resources:
                   limits:

--- a/config/add-on-manager/manager.yaml
+++ b/config/add-on-manager/manager.yaml
@@ -31,6 +31,7 @@ spec:
         args:
         - --leader-elect
         image: addon-manager:latest
+        imagePullPolicy: Always
         envFrom:
           - configMapRef:
               name: controller-config

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,7 @@ spec:
         args:
         - --leader-elect
         image: controller:latest
+        imagePullPolicy: Always
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
#541 
**What**

On  main we build images tagged main. This is a floating tag. To ensure we always get the latest, we need to set the image pull policy to `Always`