### PR TITLE
Update tls docs

### DIFF
--- a/docs/tlspolicy/tls-policy.md
+++ b/docs/tlspolicy/tls-policy.md
@@ -130,7 +130,7 @@ Any type of Issuer that is supported by CertManager can be referenced in the TLS
 
 Create a secret containing AWS access key and secret:
 ```bash
-kubectl create secret generic le-aws-credentials --from-literal=AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> -n multi-cluster-gateways
+kubectl create secret generic le-aws-credentials --from-literal=AWS_ACCESS_KEY_ID=<AWS_ACCESS_KEY_ID> --from-literal=AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> -n multi-cluster-gateways
 ```
 
 Create a new Issuer:
@@ -152,7 +152,9 @@ spec:
           route53:
             hostedZoneID: <YOUR HOSTED ZONE ID>
             region: us-east-1
-            accessKeyID: <AWS_SECRET_ACCESS_KEY_ID>
+            accessKeyIDSecretRef:
+              key: AWS_ACCESS_KEY_ID
+              name: le-aws-credentials
             secretAccessKeySecretRef:
               key: AWS_SECRET_ACCESS_KEY
               name: le-aws-credentials


### PR DESCRIPTION
Update the LE Issuer example to use reference all AWS credentials from the secret. The version of cert-manager that is installed by default in local development(v1.12.2) should have these options.