### PR TITLE
validate the presence of specified issuer or clusterisssuer in tlspolicy

### DIFF
--- a/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-09-14T13:57:32Z"
+    createdAt: "2023-09-21T16:23:26Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-gateway-controller.v0.0.0
@@ -206,6 +206,20 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - clusterissuers
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - issuers
+          verbs:
+          - get
+          - list
         - apiGroups:
           - cluster.open-cluster-management.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -39,6 +39,20 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - clusterissuers
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - issuers
+  verbs:
+  - get
+  - list
+- apiGroups:
   - cluster.open-cluster-management.io
   resources:
   - managedclusters

--- a/pkg/controllers/tlspolicy/tlspolicy_controller.go
+++ b/pkg/controllers/tlspolicy/tlspolicy_controller.go
@@ -65,6 +65,8 @@ type TLSPolicyReconciler struct {
 //+kubebuilder:rbac:groups=kuadrant.io,resources=tlspolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kuadrant.io,resources=tlspolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kuadrant.io,resources=tlspolicies/finalizers,verbs=update
+//+kubebuilder:rbac:groups="cert-manager.io",resources=issuers,verbs=get;list;
+//+kubebuilder:rbac:groups="cert-manager.io",resources=clusterissuers,verbs=get;list;
 
 func (r *TLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Logger().WithValues("TLSPolicy", req.NamespacedName)
@@ -147,6 +149,11 @@ func (r *TLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *TLSPolicyReconciler) reconcileResources(ctx context.Context, tlsPolicy *v1alpha1.TLSPolicy, targetNetworkObject client.Object) error {
 	// validate
 	err := tlsPolicy.Validate()
+	if err != nil {
+		return err
+	}
+
+	err = validateIssuer(ctx, r.Client(), tlsPolicy)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/gateway_single_spoke_test.go
+++ b/test/e2e/gateway_single_spoke_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Gateway single target cluster", func() {
 		err = tconfig.HubClient().Create(ctx, gw)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("setting up  TLSPolicy in the hub")
+		By("setting up TLSPolicy in the hub")
 		tlsPolicy = &mgcv1alpha1.TLSPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testID,

--- a/test/util/suite_config.go
+++ b/test/util/suite_config.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/goombaio/namegenerator"
+	certmanv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	ocm_cluster_v1 "open-cluster-management.io/api/cluster/v1"
 	ocm_cluster_v1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	ocm_cluster_v1beta2 "open-cluster-management.io/api/cluster/v1beta2"
@@ -107,6 +108,10 @@ func (cfg *SuiteConfig) Build() error {
 		return err
 	}
 	err = mgcv1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return err
+	}
+	err = certmanv1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return err
 	}

--- a/test/util/test_types.go
+++ b/test/util/test_types.go
@@ -3,6 +3,7 @@
 package testutil
 
 import (
+	certmanv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,23 @@ func NewTestGateway(gwName, gwClassName, ns string) *TestGateway {
 				GatewayClassName: gatewayv1beta1.ObjectName(gwClassName),
 				Listeners:        []gatewayv1beta1.Listener{},
 			},
+		},
+	}
+}
+
+func NewTestIssuer(name, ns string) *certmanv1.Issuer {
+	return &certmanv1.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+}
+
+func NewTestClusterIssuer(name string) *certmanv1.ClusterIssuer {
+	return &certmanv1.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
 		},
 	}
 }


### PR DESCRIPTION
# What

Closes #581 

Verification 
Follow https://docs.kuadrant.io/getting-started/
Follow https://docs.kuadrant.io/multicluster-gateway-controller/docs/how-to/multicluster-gateways-walkthrough/ until the creation of the TLSPolicy

### Error should be reported in status for ClusterIssuer that doesn't exist in cluster
Create TLSPolicy pointing to ClusterIssuer with a name that doesn't exist in the cluster
Validate that error is present in the status of the TLSPolicy
```
 - lastTransitionTime: "2023-09-21T10:13:13Z"
      message: ClusterIssuer.cert-manager.io "blah" not found
      reason: ReconciliationError
      status: "False"
      type: Ready
```
### Error should be reported in status for Issuer that doesn't exist in the namespace of the tlspolicy

Create an issuer in a namespace that is different to the TLSPolicy - steps here to do that https://github.com/Kuadrant/multicluster-gateway-controller/blob/main/docs/tlspolicy/tls-policy.md#lets-encrypt-issuer-for-route53-hosted-domain - update the namespace in the issuer in the steps to another namespace in the cluster

Validate that error is present in the status of the TLSPolicy
```
- lastTransitionTime: "2023-09-21T10:13:13Z"
      message: Issuer.cert-manager.io "le-staging" not found
      reason: ReconciliationError
      status: "False"
      type: Ready
```

### Error should NOT be reported in status for Issuer that does exist in the same namespace as the tlspolicy

Create the same issuer but in the same namespace as the tlspolicy e.g. multi-cluster-gateways
Validate the status is good
```
    - lastTransitionTime: "2023-09-21T10:21:11Z"
      message: Gateway is TLS Enabled
      reason: GatewayTLSEnabled
      status: "True"
      type: Ready
```

### Error should NOT be reported in status for ClusterIssuer that does exist in the same namespace as the tlspolicy

Update the policy to have a valid ClusterIssuer glbc
e.g. 
```
issuerRef:
      group: cert-manager.io
      kind: ClusterIssuer
      name: glbc-ca
```
Validate the status is good
```
    - lastTransitionTime: "2023-09-21T10:21:11Z"
      message: Gateway is TLS Enabled
      reason: GatewayTLSEnabled
      status: "True"
      type: Ready
```

### Error should NOT be reported in status for Issuer that does not specify kind
Update the policy to have the following issuerRef - create the issuer in the same namespace if needed
e.g. 
```
issuerRef:
      group: cert-manager.io
      name: le-staging
```
Validate the status is good
```
    - lastTransitionTime: "2023-09-21T10:21:11Z"
      message: Gateway is TLS Enabled
      reason: GatewayTLSEnabled
      status: "True"
      type: Ready
```





