### PR TITLE
allow source ns to be overridden

### DIFF
--- a/cmd/ocm/addon-manager/manifests/subscription.yaml
+++ b/cmd/ocm/addon-manager/manifests/subscription.yaml
@@ -8,7 +8,7 @@ spec:
   installPlanApproval: Automatic
   name: kuadrant-operator
   source: {{.CatalogSource}}
-  sourceNamespace: olm
+  sourceNamespace: {{.CatalogSourceNS}}
   config:
     env: 
       - name: ISTIOOPERATOR_NAME

--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -36,6 +36,7 @@ func GetDefaultValues(cluster *clusterv1.ManagedCluster,
 	defaultIstioOperatorNS := "istio-system"
 	defaultIstioConfigMap := "istio"
 	defaultCatalog := "operatorhubio-catalog"
+	defaultCatalogNS := "olm"
 
 	manifestConfig := struct {
 		IstioOperator          string
@@ -43,12 +44,14 @@ func GetDefaultValues(cluster *clusterv1.ManagedCluster,
 		IstioOperatorNamespace string
 		ClusterName            string
 		CatalogSource          string
+		CatalogSourceNS        string
 	}{
 		ClusterName:            cluster.Name,
 		IstioOperator:          defaultIstioOperator,
 		IstioConfigMapName:     defaultIstioConfigMap,
 		IstioOperatorNamespace: defaultIstioOperatorNS,
 		CatalogSource:          defaultCatalog,
+		CatalogSourceNS:        defaultCatalogNS,
 	}
 
 	return addonfactory.StructToValues(manifestConfig), nil


### PR DESCRIPTION
kubectl annotate managedclusteraddon kuadrant-addon "addon.open-cluster-management.io/values"='{"CatalogSource":"openshift-marketplace/community-operators", "CatalogSourceNS":"somens"}' -n local-cluster