### PR TITLE
gateway.networking.k8s.io/policy should be a label

### DIFF
--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -3,8 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-    gateway.networking.k8s.io/policy: direct
   creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: direct
   name: dnspolicies.kuadrant.io
 spec:
   group: kuadrant.io

--- a/bundle/manifests/kuadrant.io_tlspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_tlspolicies.yaml
@@ -3,8 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-    gateway.networking.k8s.io/policy: direct
   creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: direct
   name: tlspolicies.kuadrant.io
 spec:
   group: kuadrant.io

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -13,6 +13,6 @@ resources:
 configurations:
 - kustomizeconfig.yaml
 
-# Set the gateway.networking.k8s.io/policy annotation in the policies
+# Set the gateway.networking.k8s.io/policy label in the policies
 patchesStrategicMerge:
   - patches/policy-patch.yaml

--- a/config/crd/patches/policy-patch.yaml
+++ b/config/crd/patches/policy-patch.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dnspolicies.kuadrant.io
-  annotations:
+  labels:
     gateway.networking.k8s.io/policy: direct
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tlspolicies.kuadrant.io
-  annotations:
+  labels:
     gateway.networking.k8s.io/policy: direct


### PR DESCRIPTION
`gateway.networking.k8s.io/policy` should be a label, rather than an annotation:

See: https://gateway-api.sigs.k8s.io/geps/gep-713/#kubectl-plugin

Noticed while checking out `gwctl` (should be able to use it after this). 

I think RLP and AuthPolicy may be missing this label.