### PR TITLE
Gh 587

### DIFF
--- a/test/integration/dnsheathcheckprobe_controller_test.go
+++ b/test/integration/dnsheathcheckprobe_controller_test.go
@@ -75,10 +75,10 @@ var _ = Describe("DNSHealthCheckProbe controller", func() {
 			}, probeObj)
 			Expect(err).NotTo(HaveOccurred())
 
+			patch := client.MergeFrom(probeObj.DeepCopy())
 			lastUpdate := probeObj.Status.LastCheckedAt
 			probeObj.Spec.Path = "/unhealthy"
-			err = k8sClient.Update(ctx, probeObj)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Patch(ctx, probeObj, patch)).To(BeNil())
 
 			Eventually(func() error {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(probeObj), probeObj)

--- a/test/util/test_types.go
+++ b/test/util/test_types.go
@@ -3,6 +3,8 @@
 package testutil
 
 import (
+	"strings"
+
 	certmanv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 
@@ -71,8 +73,9 @@ func (t *TestGateway) WithHTTPListener(hostname string) *TestGateway {
 func (t *TestGateway) WithHTTPSListener(hostname, tlsSecretName string) *TestGateway {
 	typedHostname := gatewayv1beta1.Hostname(hostname)
 	typedNamespace := gatewayv1beta1.Namespace(t.GetNamespace())
+	typedNamed := gatewayv1beta1.SectionName(strings.Replace(hostname, "*", "wildcard", 1))
 	t.WithListener(gatewayv1beta1.Listener{
-		Name:     gatewayv1beta1.SectionName(hostname),
+		Name:     typedNamed,
 		Hostname: &typedHostname,
 		Port:     gatewayv1beta1.PortNumber(443),
 		Protocol: gatewayv1beta1.HTTPSProtocolType,


### PR DESCRIPTION
- add TLS Policy integration tests
- Minor tweaks to tests to stop flaky failures and fix issue with wildcard listeners in utility package.
### verification
- see PR tests pass