### PR TITLE
Update policy status on TargetNotFound

### DIFF
--- a/pkg/_internal/conditions/conditions.go
+++ b/pkg/_internal/conditions/conditions.go
@@ -1,6 +1,7 @@
 package conditions
 
 import (
+	"errors"
 	"fmt"
 
 	k8smeta "k8s.io/apimachinery/pkg/api/meta"
@@ -20,7 +21,11 @@ const (
 	PolicyReasonInvalid    ConditionReason = "Invalid"
 	PolicyReasonUnknown    ConditionReason = "Unknown"
 	PolicyReasonConflicted ConditionReason = "Conflicted"
+
+	PolicyReasonTargetNotFound ConditionReason = "TargetNotFound"
 )
+
+var ErrTargetNotFound = errors.New("target not found")
 
 func BuildPolicyAffectedCondition(conditionType ConditionType, policyObject runtime.Object, targetRef metav1.Object, reason ConditionReason, err error) metav1.Condition {
 


### PR DESCRIPTION
Updates the policy status (DNSPolicy and TLSPolicy) when the target resource is not found. The Ready condition is set to false with the reason "TargetNotFound" and the message is set to the appropriate error detailing the missing object.

```
{
  "lastTransitionTime": "2023-09-26T17:20:17Z",
  "message": "target not found : Gateway.gateway.networking.k8s.io \"prod-web-istio\" not found",
  "reason": "TargetNotFound",
  "status": "False",
  "type": "Ready"
}
```

closes #361 