### PR TITLE
Gh 583

### DIFF
--- a/pkg/_internal/gracePeriod/gracePeriod.go
+++ b/pkg/_internal/gracePeriod/gracePeriod.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -25,12 +26,18 @@ func GracefulDelete(ctx context.Context, c client.Client, obj client.Object, ign
 	at := time.Now().Add(DefaultGracePeriod)
 	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 		log.V(3).Info("error finding object to graceful delete")
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
 	// If ignored the grace, of if At is before the current time, just delete it
 	if ignoreGrace || at.Before(time.Now()) || at.Equal(time.Now()) {
-		return c.Delete(ctx, obj)
+		if err := c.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+		return nil
 	}
 
 	//ensure annotation is present
@@ -60,5 +67,5 @@ func GracefulDelete(ctx context.Context, c client.Client, obj client.Object, ign
 
 	log.V(3).Info("grace period still pending")
 
-	return ErrGracePeriodNotExpired
+	return fmt.Errorf("%w expires at %v", ErrGracePeriodNotExpired, deleteAt)
 }

--- a/pkg/placement/fake/ocm.go
+++ b/pkg/placement/fake/ocm.go
@@ -24,16 +24,16 @@ func (p *FakeGatewayPlacer) GetClusterGateway(_ context.Context, _ *v1beta1.Gate
 	return dns.ClusterGateway{}, nil
 }
 
-func (p *FakeGatewayPlacer) Place(_ context.Context, upstream *v1beta1.Gateway, _ *v1beta1.Gateway, _ ...metav1.Object) (sets.Set[string], error) {
+func (p *FakeGatewayPlacer) Place(_ context.Context, upstream *v1beta1.Gateway, _ *v1beta1.Gateway, _ ...metav1.Object) (sets.Set[string], string, error) {
 	if upstream.Labels == nil {
-		return nil, nil
+		return nil, "", nil
 	}
 	if *upstream.Spec.Listeners[0].Hostname == testutil.FailPlacementHostname {
-		return nil, fmt.Errorf(testutil.FailPlacementHostname)
+		return nil, "", fmt.Errorf(testutil.FailPlacementHostname)
 	}
 	targetClusters := sets.Set[string](sets.NewString())
 	targetClusters.Insert(testutil.Cluster)
-	return targetClusters, nil
+	return targetClusters, "", nil
 }
 
 func (p *FakeGatewayPlacer) GetPlacedClusters(_ context.Context, gateway *v1beta1.Gateway) (sets.Set[string], error) {

--- a/test/e2e/gateway_single_spoke_test.go
+++ b/test/e2e/gateway_single_spoke_test.go
@@ -128,11 +128,6 @@ var _ = Describe("Gateway single target cluster", func() {
 			client.PropagationPolicy(metav1.DeletePropagationForeground))
 		Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 
-		//Workaround for https://github.com/Kuadrant/multicluster-gateway-controller/issues/420
-		Eventually(func(ctx SpecContext) error {
-			return tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, gw)
-		}).WithContext(ctx).WithTimeout(10 * time.Second).WithPolling(2 * time.Second).Should(MatchError(ContainSubstring("not found")))
-
 		err = tconfig.HubClient().Delete(ctx, placement,
 			client.PropagationPolicy(metav1.DeletePropagationForeground))
 		Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
@@ -173,6 +168,7 @@ var _ = Describe("Gateway single target cluster", func() {
 	})
 
 	When("the Placement label is added to the Gateway", func() {
+		istioGW := &gatewayapi.Gateway{}
 
 		BeforeEach(func(ctx SpecContext) {
 			By("adding a placement label to the Gateway")
@@ -183,10 +179,59 @@ var _ = Describe("Gateway single target cluster", func() {
 		})
 
 		It("the gateway is placed on the spoke cluster once the tls secrets exist", func(ctx SpecContext) {
-			istioGW := &gatewayapi.Gateway{}
+			var group gatewayapi.Group = ""
+			var kindSecret gatewayapi.Kind = "Secret"
+			var modtype gatewayapi.TLSModeType = "Terminate"
+
+			istioGWSpec := gatewayapi.GatewaySpec{
+				GatewayClassName: "istio",
+				Listeners: []gatewayapi.Listener{{
+					Name:     "https",
+					Hostname: &hostname,
+					Port:     443,
+					Protocol: gatewayapi.HTTPSProtocolType,
+					TLS: &gatewayapi.GatewayTLSConfig{
+						Mode: &modtype,
+						CertificateRefs: []gatewayapi.SecretObjectReference{{
+							Name:  gatewayapi.ObjectName(hostname),
+							Group: &group,
+							Kind:  &kindSecret,
+						}},
+					},
+					AllowedRoutes: &gatewayapi.AllowedRoutes{
+						Namespaces: &gatewayapi.RouteNamespaces{
+							From: Pointer(gatewayapi.NamespacesFromAll),
+						},
+					},
+				}},
+			}
+			// the status of the spoke gateway should be true for both Ready and accepted
 			Eventually(func(ctx SpecContext) error {
-				return tconfig.SpokeClient(0).Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.SpokeNamespace()}, istioGW)
-			}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(10 * time.Second).ShouldNot(HaveOccurred())
+				tconfig.SpokeClient(0).Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.SpokeNamespace()}, istioGW)
+				if !meta.IsStatusConditionPresentAndEqual(istioGW.Status.Conditions, string(gatewayapi.GatewayConditionAccepted), "True") {
+					cond := meta.FindStatusCondition(istioGW.Status.Conditions, string(gatewayapi.GatewayConditionAccepted))
+					return fmt.Errorf("Expected condition %s to be true but got %v", string(gatewayapi.GatewayConditionAccepted), cond)
+				}
+				if !meta.IsStatusConditionPresentAndEqual(istioGW.Status.Conditions, string(gatewayapi.GatewayConditionReady), "True") {
+					cond := meta.FindStatusCondition(istioGW.Status.Conditions, string(gatewayapi.GatewayConditionReady))
+					return fmt.Errorf("Expected condition %s to be true but got %v", string(gatewayapi.GatewayConditionReady), cond)
+				}
+				return nil
+			}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+			Expect(istioGW.Spec).Should(Equal(istioGWSpec))
+		})
+
+		It("expects the hub gateway to programmed condition to change to true", func(ctx SpecContext) {
+			Eventually(func(ctx SpecContext) error {
+				err := tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, gw)
+				Expect(err).ToNot(HaveOccurred())
+				if !meta.IsStatusConditionPresentAndEqual(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed), "True") {
+					cond := meta.FindStatusCondition(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed))
+					return fmt.Errorf("Expected condition %s to be true but got %v", string(gatewayapi.GatewayConditionProgrammed), cond)
+				}
+				return nil
+			}).WithContext(ctx).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+
 		})
 
 		When("an HTTPRoute is attached to the Gateway", func() {
@@ -255,6 +300,11 @@ var _ = Describe("Gateway single target cluster", func() {
 						},
 					}
 					err := tconfig.HubClient().Create(ctx, dnsPolicy)
+					Expect(err).ToNot(HaveOccurred())
+					By("adding a placement label to the Gateway")
+					patch := client.MergeFrom(gw.DeepCopy())
+					gw.GetLabels()[PlacementLabel] = testID
+					err = tconfig.HubClient().Patch(ctx, gw, patch)
 					Expect(err).ToNot(HaveOccurred())
 				})
 
@@ -351,6 +401,7 @@ var _ = Describe("Gateway single target cluster", func() {
 					By("adding wildcard listener to the gateway")
 					{
 						gw := &gatewayapi.Gateway{}
+
 						err = tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, gw)
 						Expect(err).ToNot(HaveOccurred())
 
@@ -363,15 +414,35 @@ var _ = Describe("Gateway single target cluster", func() {
 						err = tconfig.HubClient().Update(ctx, gw)
 						Expect(err).ToNot(HaveOccurred())
 						expectedListeners := 2
+						checkGateway := &gatewayapi.Gateway{}
+
 						Eventually(func(ctx SpecContext) error {
-							checkGateway := &gatewayapi.Gateway{}
+							checkGateway = &gatewayapi.Gateway{}
 							err = tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, checkGateway)
 							Expect(err).ToNot(HaveOccurred())
 							if len(checkGateway.Spec.Listeners) == expectedListeners {
 								return nil
 							}
 							return fmt.Errorf("should be %d listeners in the gateway", expectedListeners)
-						}).WithContext(ctx).WithTimeout(100 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+						}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+
+						istioGWSpec := gatewayapi.GatewaySpec{
+							GatewayClassName: "istio",
+							Listeners: []gatewayapi.Listener{
+
+								ListenerSpec("https", hostname, gatewayapi.ObjectName(hostname)),
+								ListenerSpec("wildcard", wildcardHostname, gatewayapi.ObjectName(secretName)),
+							},
+						}
+
+						//the gateway from the spoke cluster should match the expected spec with the additional listener
+						getIstioGW := func() (gatewayapi.GatewaySpec, error) {
+							var istioGW gatewayapi.Gateway
+							err = tconfig.SpokeClient(0).Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.SpokeNamespace()}, &istioGW)
+							Expect(err).ToNot(HaveOccurred())
+							return istioGW.Spec, nil
+						}
+						Eventually(getIstioGW, 120*time.Second, 2*time.Second).WithContext(ctx).Should(Equal(istioGWSpec))
 
 					}
 
@@ -395,7 +466,7 @@ var _ = Describe("Gateway single target cluster", func() {
 								}
 							}
 							return fmt.Errorf("dns names for secret not as expected")
-						}).WithContext(ctx).WithTimeout(180 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+						}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
 					}
 
 					By("checking a wildcard cert is present via get request")
@@ -446,7 +517,26 @@ var _ = Describe("Gateway single target cluster", func() {
 								return nil
 							}
 							return fmt.Errorf("expected %d listeners in the ", expectedLiseners)
-						}).WithContext(ctx).WithTimeout(100 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+						}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+
+						istioGWSpec := gatewayapi.GatewaySpec{
+							GatewayClassName: "istio",
+							Listeners: []gatewayapi.Listener{
+
+								ListenerSpec("https", hostname, gatewayapi.ObjectName(hostname)),
+								ListenerSpec("wildcard", wildcardHostname, gatewayapi.ObjectName(hostname)),
+								ListenerSpec("other", otherHostname, gatewayapi.ObjectName(otherHostname)),
+							},
+						}
+
+						//the gateway from the spoke cluster should match the expected spec with the additional listener
+						getIstioGW := func() (gatewayapi.GatewaySpec, error) {
+							var istioGW gatewayapi.Gateway
+							err = tconfig.SpokeClient(0).Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.SpokeNamespace()}, &istioGW)
+							Expect(err).ToNot(HaveOccurred())
+							return istioGW.Spec, nil
+						}
+						Eventually(getIstioGW, 120*time.Second, 2*time.Second).WithContext(ctx).Should(Equal(istioGWSpec))
 
 						Eventually(func(ctx SpecContext) error {
 							secret := &corev1.Secret{}
@@ -458,9 +548,17 @@ var _ = Describe("Gateway single target cluster", func() {
 								return err
 							}
 							return nil
-						}).WithContext(ctx).WithTimeout(180 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+						}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
 
 						// remove the listener
+						istioGWSpecRemove := gatewayapi.GatewaySpec{
+							GatewayClassName: "istio",
+							Listeners: []gatewayapi.Listener{
+
+								ListenerSpec("https", hostname, gatewayapi.ObjectName(hostname)),
+								ListenerSpec("wildcard", wildcardHostname, gatewayapi.ObjectName(hostname)),
+							},
+						}
 						err = tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, gw)
 						Expect(err).ToNot(HaveOccurred())
 
@@ -485,7 +583,11 @@ var _ = Describe("Gateway single target cluster", func() {
 								return err
 							}
 							return fmt.Errorf("secret %s found, should be removed", otherHostname)
-						}).WithContext(ctx).WithTimeout(180 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+						}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+						//the gateway from the spoke cluster should match the expected spec with the additional listener removed
+
+						Eventually(getIstioGW, 120*time.Second, 2*time.Second).WithContext(ctx).Should(Equal(istioGWSpecRemove))
+
 					}
 					By("deleting tls policy, tls secrets are removed")
 					{
@@ -509,10 +611,135 @@ var _ = Describe("Gateway single target cluster", func() {
 								return err
 							}
 							return fmt.Errorf("secret %s found, should be removed", hostname)
-						}).WithContext(ctx).WithTimeout(180 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+						}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
 					}
 				})
 			})
 		})
+	})
+
+	When("incorrect values are given status and specs should reflect this", func() {
+
+		BeforeEach(func(ctx SpecContext) {
+			By("adding a placement label to the Gateway")
+			patch := client.MergeFrom(gw.DeepCopy())
+			gw.GetLabels()[PlacementLabel] = testID
+			err := tconfig.HubClient().Patch(ctx, gw, patch)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("A https listener added to the hub gateway without the correct secret the programmed status should reflect this", func(ctx SpecContext) {
+			gw := &gatewayapi.Gateway{}
+			Eventually(func(ctx SpecContext) error {
+				err := tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, gw)
+				Expect(err).ToNot(HaveOccurred())
+				if !meta.IsStatusConditionPresentAndEqual(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed), "True") {
+					cond := meta.FindStatusCondition(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed))
+					return fmt.Errorf("Expected condition %s to be true but got %v", string(gatewayapi.GatewayConditionProgrammed), cond)
+				}
+				return nil
+			}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+			AddListener("testfake", otherHostname, gatewayapi.ObjectName("fake"), gw)
+			err := tconfig.HubClient().Update(ctx, gw)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(ctx SpecContext) error {
+				err := tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, gw)
+				Expect(err).ToNot(HaveOccurred())
+				if !meta.IsStatusConditionPresentAndEqual(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed), "Unknown") {
+					cond := meta.FindStatusCondition(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed))
+					return fmt.Errorf("Expected condition %s to be unknown but got %v", string(gatewayapi.GatewayConditionProgrammed), cond)
+				}
+				return nil
+			}).WithContext(ctx).WithTimeout(180 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+		})
+
+		It("The placement is changed to remove the number of clusters the spoke cluster gateway should be removed", func(ctx SpecContext) {
+
+			istioGW := gatewayapi.Gateway{}
+			Eventually(func(ctx SpecContext) error {
+				err := tconfig.SpokeClient(0).Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.SpokeNamespace()}, &istioGW)
+				Expect(err).To(HaveOccurred())
+				return nil
+			}, 300*time.Second, 10*time.Second).WithContext(ctx)
+
+			placement = &ocm_cluster_v1beta1.Placement{
+				ObjectMeta: metav1.ObjectMeta{Name: testID, Namespace: tconfig.HubNamespace()},
+				Spec: ocm_cluster_v1beta1.PlacementSpec{
+					NumberOfClusters: Pointer(int32(0)),
+				},
+			}
+			ogPlacement := &ocm_cluster_v1beta1.Placement{}
+			err := tconfig.HubClient().Get(ctx, client.ObjectKey{Name: placement.Name, Namespace: placement.Namespace}, ogPlacement)
+			Expect(err).ToNot(HaveOccurred())
+
+			patch := client.MergeFrom(ogPlacement)
+			err = tconfig.HubClient().Patch(ctx, gw, patch)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(ctx SpecContext) error {
+
+				err = tconfig.SpokeClient(0).Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.SpokeNamespace()}, &istioGW)
+				Expect(err).To(HaveOccurred())
+				return nil
+			}, 120*time.Second, 2*time.Second).WithContext(ctx)
+
+		})
+	})
+
+	When("If the placement label is incorrect the hub cluster should reflect these changes", func() {
+		BeforeEach(func(ctx SpecContext) {
+			By("adding a placement label to the Gateway")
+			patch := client.MergeFrom(gw.DeepCopy())
+			gw.GetLabels()[PlacementLabel] = testID
+			err := tconfig.HubClient().Patch(ctx, gw, patch)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("If a wrong placement label is given to the gateway, it should show errors and programmed status should be unknown", func(ctx SpecContext) {
+			gw := &gatewayapi.Gateway{}
+
+			// Checking the status is programmed true first to ensure a gateway is on the spoke cluster begin with
+			Eventually(func(ctx SpecContext) error {
+				err := tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, gw)
+				Expect(err).ToNot(HaveOccurred())
+				if !meta.IsStatusConditionPresentAndEqual(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed), "True") {
+					cond := meta.FindStatusCondition(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed))
+					return fmt.Errorf("Expected condition %s to be unknown but got %v", string(gatewayapi.GatewayConditionProgrammed), cond)
+				}
+				return nil
+			}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+			// adding a unknown label to see if the status will show up as unknown
+			patch := client.MergeFrom(gw.DeepCopy())
+			gw.GetLabels()[PlacementLabel] = "fake"
+			err := tconfig.HubClient().Patch(ctx, gw, patch)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(ctx SpecContext) error {
+				err := tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, gw)
+				Expect(err).ToNot(HaveOccurred())
+				if !meta.IsStatusConditionPresentAndEqual(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed), "Unknown") {
+					cond := meta.FindStatusCondition(gw.Status.Conditions, string(gatewayapi.GatewayConditionProgrammed))
+					return fmt.Errorf("Expected condition %s to be unknown but got %v", string(gatewayapi.GatewayConditionProgrammed), cond)
+				}
+				return nil
+			}).WithContext(ctx).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+		})
+		It("Removing the placment should delete the gateway", func(ctx SpecContext) {
+			istioGW := gatewayapi.Gateway{}
+			err := tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, placement)
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+			err = tconfig.HubClient().Delete(ctx, placement, &client.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(ctx SpecContext) error {
+				err = tconfig.SpokeClient(0).Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.SpokeNamespace()}, &istioGW)
+				Expect(err).To(HaveOccurred())
+
+				return nil
+			}).WithContext(ctx).WithTimeout(10 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
+
+		})
+
 	})
 })

--- a/test/integration/helper_test.go
+++ b/test/integration/helper_test.go
@@ -82,8 +82,8 @@ func NewTestOCMPlacer() *FakeOCMPlacer {
 	return NewFakeOCMPlacer(TestPlacedGatewayName, TestAttachedRouteName)
 }
 
-func (f FakeOCMPlacer) Place(ctx context.Context, upstream *gatewayv1beta1.Gateway, downstream *gatewayv1beta1.Gateway, children ...metav1.Object) (sets.Set[string], error) {
-	return nil, nil
+func (f FakeOCMPlacer) Place(ctx context.Context, upstream *gatewayv1beta1.Gateway, downstream *gatewayv1beta1.Gateway, children ...metav1.Object) (sets.Set[string], string, error) {
+	return nil, "", nil
 }
 
 func (f FakeOCMPlacer) GetPlacedClusters(ctx context.Context, gateway *gatewayv1beta1.Gateway) (sets.Set[string], error) {
@@ -94,10 +94,6 @@ func (f FakeOCMPlacer) GetPlacedClusters(ctx context.Context, gateway *gatewayv1
 		}
 	}
 	return clusters, nil
-}
-
-func (f FakeOCMPlacer) GetClusters(ctx context.Context, gateway *gatewayv1beta1.Gateway) (sets.Set[string], error) {
-	return f.GetPlacedClusters(ctx, gateway)
 }
 
 func (f FakeOCMPlacer) ListenerTotalAttachedRoutes(ctx context.Context, gateway *gatewayv1beta1.Gateway, listenerName string, downstream string) (int, error) {

--- a/test/util/suite_config.go
+++ b/test/util/suite_config.go
@@ -212,7 +212,7 @@ func (cfg *SuiteConfig) InstallPrerequisites(ctx context.Context) error {
 		}
 	}
 
-	//TODO ensure ManagedZone: right now this is added by local-setup
+	// TODO ensure ManagedZone: right now this is added by local-setup
 
 	// ensure ManagedClusterSet
 	{

--- a/test/util/test_types.go
+++ b/test/util/test_types.go
@@ -22,6 +22,12 @@ type TestGateway struct {
 	*gatewayv1beta1.Gateway
 }
 
+var (
+	group      gatewayv1beta1.Group       = ""
+	kindSecret gatewayv1beta1.Kind        = "Secret"
+	modtype    gatewayv1beta1.TLSModeType = "Terminate"
+)
+
 func NewTestGateway(gwName, gwClassName, ns string) *TestGateway {
 	return &TestGateway{
 		&gatewayv1beta1.Gateway{
@@ -61,9 +67,12 @@ func AddListener(name string, hostname gatewayapiv1alpha2.Hostname, secretName g
 		Port:     443,
 		Protocol: gatewayv1beta1.HTTPSProtocolType,
 		TLS: &gatewayv1beta1.GatewayTLSConfig{
+			Mode: &modtype,
 			CertificateRefs: []gatewayv1beta1.SecretObjectReference{
 				{
-					Name: secretName,
+					Group: &group,
+					Name:  secretName,
+					Kind:  &kindSecret,
 				},
 			},
 		},
@@ -73,7 +82,34 @@ func AddListener(name string, hostname gatewayapiv1alpha2.Hostname, secretName g
 			},
 		},
 	}
+
 	gw.Spec.Listeners = append(gw.Spec.Listeners, listener)
+
+}
+
+func ListenerSpec(name string, hostname gatewayapiv1alpha2.Hostname, secretName gatewayv1beta1.ObjectName) gatewayv1beta1.Listener {
+	listener := gatewayapiv1alpha2.Listener{
+		Name:     gatewayv1beta1.SectionName(name),
+		Hostname: &hostname,
+		Port:     443,
+		Protocol: gatewayv1beta1.HTTPSProtocolType,
+		TLS: &gatewayv1beta1.GatewayTLSConfig{
+			Mode: &modtype,
+			CertificateRefs: []gatewayv1beta1.SecretObjectReference{
+				{
+					Group: &group,
+					Name:  secretName,
+					Kind:  &kindSecret,
+				},
+			},
+		},
+		AllowedRoutes: &gatewayv1beta1.AllowedRoutes{
+			Namespaces: &gatewayv1beta1.RouteNamespaces{
+				From: Pointer(gatewayv1beta1.NamespacesFromAll),
+			},
+		},
+	}
+	return listener
 
 }
 


### PR DESCRIPTION
**What**

makes some significant changes to placement logic
adds finalizers to placement decisions
ensure gateways are removed when placement decisions are deleted 
ensure changing placement choice cleans up existing gateways
adds a placement condition to the gateway status

- [x] Update integration tests
- [x] Update e2e tests


**Verification**

- use the quickstart
- scale down the mgc controller
- run this version locally

Create a Gateway
```
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: prod-web
  namespace: multi-cluster-gateways
  labels:
    cluster.open-cluster-management.io/placement: http-gateway
spec:
  gatewayClassName: kuadrant-multi-cluster-gateway-instance-per-cluster
  listeners:
  - allowedRoutes:
      namespaces:
        from: All
    name: specific
    hostname: 'specific.cb.hcpapps.net'
    port: 443
    protocol: HTTP
```

This will place it on the CP cluster
Verify the gateway is placed (should be an istio gateway present)
Verify the status is updated as expected on the gateway

```
 - lastTransitionTime: "2023-09-28T11:06:30Z"
    message: http-gateway
    observedGeneration: 1
    reason: PlacementCompleted
    status: "True"
    type: Placed
```

Create a new placement

```
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: Placement
metadata:
  name: gateways
  namespace: multi-cluster-gateways
spec:
  numberOfClusters: 2
  clusterSets:
    - gateway-clusters
```

make sure second cluster availabe for placement
```
k label managedcluster kind-mgc-workload-1 ingress-cluster=true
```

update the placement label on the gateway to use this

```
k label gateway prod-web -n multi-cluster-gateways "cluster.open-cluster-management.io/placement"=gateways --overwrite
```

check the gateway is now on 2 clusters and placement condition is set to true

delete the placement

```
k delete placement gateways -n multi-cluster-gateways

```

check istio gateways are all gone. Check status is set to placement not found

Update the placement label

```

k label gateway prod-web -n multi-cluster-gateways "cluster.open-cluster-management.io/placement"=http-gateway --overwrite
```

check it is just on one cluster and the status is correct
set it back to something that doesn't exist
```

k label gateway prod-web -n multi-cluster-gateways "cluster.open-cluster-management.io/placement"=nope --overwrite
```

delete the gateway

```
k delete gateway prod-web -n multi-cluster-gateways
```
the gateway should delete