### PR TITLE
Add DNSPolicy Routing Strategy

### DIFF
--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -156,6 +156,12 @@ spec:
                         type: integer
                     type: object
                 type: object
+              routingStrategy:
+                default: loadbalanced
+                enum:
+                - simple
+                - loadbalanced
+                type: string
               targetRef:
                 description: PolicyTargetReference identifies an API object to apply
                   policy to. This should be used as part of Policy resources that
@@ -194,6 +200,7 @@ spec:
                 - name
                 type: object
             required:
+            - routingStrategy
             - targetRef
             type: object
           status:

--- a/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-11-09T08:49:14Z"
+    createdAt: "2023-11-10T09:41:24Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-gateway-controller.v0.0.0

--- a/config/policy-controller/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/policy-controller/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -155,6 +155,12 @@ spec:
                         type: integer
                     type: object
                 type: object
+              routingStrategy:
+                default: loadbalanced
+                enum:
+                - simple
+                - loadbalanced
+                type: string
               targetRef:
                 description: PolicyTargetReference identifies an API object to apply
                   policy to. This should be used as part of Policy resources that
@@ -193,6 +199,7 @@ spec:
                 - name
                 type: object
             required:
+            - routingStrategy
             - targetRef
             type: object
           status:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/jetstack/cert-manager v1.7.1
-	github.com/kuadrant/authorino v0.10.0
 	github.com/kuadrant/kuadrant-operator v0.1.1-0.20230323151616-58593d01833a
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/onsi/ginkgo/v2 v2.11.0
@@ -66,6 +65,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kuadrant/authorino v0.10.0 // indirect
 	github.com/kuadrant/authorino-operator v0.4.1 // indirect
 	github.com/kuadrant/limitador-operator v0.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/pkg/apis/v1alpha1/dnspolicy_types.go
+++ b/pkg/apis/v1alpha1/dnspolicy_types.go
@@ -25,6 +25,13 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
+type RoutingStrategy string
+
+const (
+	SimpleRoutingStrategy       RoutingStrategy = "simple"
+	LoadBalancedRoutingStrategy RoutingStrategy = "loadbalanced"
+)
+
 // DNSPolicySpec defines the desired state of DNSPolicy
 type DNSPolicySpec struct {
 
@@ -37,6 +44,11 @@ type DNSPolicySpec struct {
 
 	// +optional
 	LoadBalancing *LoadBalancingSpec `json:"loadBalancing"`
+
+	// +required
+	// +kubebuilder:validation:Enum=simple;loadbalanced
+	// +kubebuilder:default=loadbalanced
+	RoutingStrategy RoutingStrategy `json:"routingStrategy"`
 }
 
 type LoadBalancingSpec struct {

--- a/pkg/controllers/dnspolicy/dns_helper.go
+++ b/pkg/controllers/dnspolicy/dns_helper.go
@@ -33,8 +33,9 @@ const (
 )
 
 var (
-	ErrNoManagedZoneForHost = fmt.Errorf("no managed zone for host")
-	ErrAlreadyAssigned      = fmt.Errorf("managed host already assigned")
+	ErrUnknownRoutingStrategy = fmt.Errorf("unknown routing strategy")
+	ErrNoManagedZoneForHost   = fmt.Errorf("no managed zone for host")
+	ErrAlreadyAssigned        = fmt.Errorf("managed host already assigned")
 )
 
 type dnsHelper struct {
@@ -147,7 +148,74 @@ func withGatewayListener[T metav1.Object](gateway common.GatewayWrapper, listene
 	return obj
 }
 
-// setEndpoints sets the endpoints for the given MultiClusterGatewayTarget
+func (dh *dnsHelper) setEndpoints(ctx context.Context, mcgTarget *dns.MultiClusterGatewayTarget, dnsRecord *v1alpha1.DNSRecord, listener gatewayv1beta1.Listener, strategy v1alpha1.RoutingStrategy) error {
+	old := dnsRecord.DeepCopy()
+	gwListenerHost := string(*listener.Hostname)
+	var endpoints []*v1alpha1.Endpoint
+
+	//Health Checks currently modify endpoints so we have to keep existing ones in order to not lose health check ids
+	currentEndpoints := make(map[string]*v1alpha1.Endpoint, len(dnsRecord.Spec.Endpoints))
+	for _, endpoint := range dnsRecord.Spec.Endpoints {
+		currentEndpoints[endpoint.SetID()] = endpoint
+	}
+
+	switch strategy {
+	case v1alpha1.SimpleRoutingStrategy:
+		endpoints = dh.getSimpleEndpoints(mcgTarget, gwListenerHost, currentEndpoints)
+	case v1alpha1.LoadBalancedRoutingStrategy:
+		endpoints = dh.getLoadBalancedEndpoints(mcgTarget, gwListenerHost, currentEndpoints)
+	default:
+		return fmt.Errorf("%w : %s", ErrUnknownRoutingStrategy, strategy)
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		return endpoints[i].SetID() < endpoints[j].SetID()
+	})
+
+	dnsRecord.Spec.Endpoints = endpoints
+
+	if !equality.Semantic.DeepEqual(old, dnsRecord) {
+		return dh.Update(ctx, dnsRecord)
+	}
+
+	return nil
+}
+
+// getSimpleEndpoints returns the endpoints for the given MultiClusterGatewayTarget using the simple routing strategy
+
+func (dh *dnsHelper) getSimpleEndpoints(mcgTarget *dns.MultiClusterGatewayTarget, hostname string, currentEndpoints map[string]*v1alpha1.Endpoint) []*v1alpha1.Endpoint {
+
+	var (
+		endpoints  []*v1alpha1.Endpoint
+		ipValues   []string
+		hostValues []string
+	)
+
+	for _, cgwTarget := range mcgTarget.ClusterGatewayTargets {
+		for _, gwa := range cgwTarget.GatewayAddresses {
+			if *gwa.Type == gatewayv1beta1.IPAddressType {
+				ipValues = append(ipValues, gwa.Value)
+			} else {
+				hostValues = append(hostValues, gwa.Value)
+			}
+		}
+	}
+
+	if len(ipValues) > 0 {
+		endpoint := createOrUpdateEndpoint(hostname, ipValues, v1alpha1.ARecordType, "", dns.DefaultTTL, currentEndpoints)
+		endpoints = append(endpoints, endpoint)
+	}
+
+	//ToDO This could possibly result in an invalid record since you can't have multiple CNAME target values https://github.com/Kuadrant/multicluster-gateway-controller/issues/663
+	if len(hostValues) > 0 {
+		endpoint := createOrUpdateEndpoint(hostname, hostValues, v1alpha1.CNAMERecordType, "", dns.DefaultTTL, currentEndpoints)
+		endpoints = append(endpoints, endpoint)
+	}
+
+	return endpoints
+}
+
+// getLoadBalancedEndpoints returns the endpoints for the given MultiClusterGatewayTarget using the loadbalanced routing strategy
 //
 // Builds an array of v1alpha1.Endpoint resources and sets them on the given DNSRecord. The endpoints expected are calculated
 // from the MultiClusterGatewayTarget using the target Gateway (MultiClusterGatewayTarget.Gateway), the LoadBalancing Spec
@@ -186,23 +254,15 @@ func withGatewayListener[T metav1.Object](gateway common.GatewayWrapper, listene
 // ab2.lb-a1b2.shop.example.com A 192.22.2.3
 // ab3.lb-a1b2.shop.example.com A 192.22.2.4
 
-func (dh *dnsHelper) setEndpoints(ctx context.Context, mcgTarget *dns.MultiClusterGatewayTarget, dnsRecord *v1alpha1.DNSRecord, listener gatewayv1beta1.Listener) error {
+func (dh *dnsHelper) getLoadBalancedEndpoints(mcgTarget *dns.MultiClusterGatewayTarget, hostname string, currentEndpoints map[string]*v1alpha1.Endpoint) []*v1alpha1.Endpoint {
 
-	old := dnsRecord.DeepCopy()
-	gwListenerHost := string(*listener.Hostname)
-	cnameHost := gwListenerHost
-	if isWildCardListener(listener) {
-		cnameHost = strings.Replace(gwListenerHost, "*.", "", -1)
-	}
-
-	//Health Checks currently modify endpoints so we have to keep existing ones in order to not lose health check ids
-	currentEndpoints := make(map[string]*v1alpha1.Endpoint, len(dnsRecord.Spec.Endpoints))
-	for _, endpoint := range dnsRecord.Spec.Endpoints {
-		currentEndpoints[endpoint.SetID()] = endpoint
+	cnameHost := hostname
+	if isWildCardHost(hostname) {
+		cnameHost = strings.Replace(hostname, "*.", "", -1)
 	}
 
 	var (
-		newEndpoints    []*v1alpha1.Endpoint
+		endpoints       []*v1alpha1.Endpoint
 		endpoint        *v1alpha1.Endpoint
 		defaultEndpoint *v1alpha1.Endpoint
 	)
@@ -239,7 +299,7 @@ func (dh *dnsHelper) setEndpoints(ctx context.Context, mcgTarget *dns.MultiClust
 		if len(clusterEndpoints) == 0 {
 			continue
 		}
-		newEndpoints = append(newEndpoints, clusterEndpoints...)
+		endpoints = append(endpoints, clusterEndpoints...)
 
 		//Create lbName CNAME (lb-a1b2.shop.example.com -> default.lb-a1b2.shop.example.com)
 		endpoint = createOrUpdateEndpoint(lbName, []string{geoLbName}, v1alpha1.CNAMERecordType, string(geoCode), dns.DefaultCnameTTL, currentEndpoints)
@@ -256,28 +316,19 @@ func (dh *dnsHelper) setEndpoints(ctx context.Context, mcgTarget *dns.MultiClust
 
 		endpoint.SetProviderSpecific(dns.ProviderSpecificGeoCode, string(geoCode))
 
-		newEndpoints = append(newEndpoints, endpoint)
+		endpoints = append(endpoints, endpoint)
 	}
 
-	if len(newEndpoints) > 0 {
-		// Add the `defaultEndpoint`, this should always be set by this point if `newEndpoints` isn't empty
+	if len(endpoints) > 0 {
+		// Add the `defaultEndpoint`, this should always be set by this point if `endpoints` isn't empty
 		defaultEndpoint.SetProviderSpecific(dns.ProviderSpecificGeoCode, string(dns.WildcardGeo))
-		newEndpoints = append(newEndpoints, defaultEndpoint)
+		endpoints = append(endpoints, defaultEndpoint)
 		//Create gwListenerHost CNAME (shop.example.com -> lb-a1b2.shop.example.com)
-		endpoint = createOrUpdateEndpoint(gwListenerHost, []string{lbName}, v1alpha1.CNAMERecordType, "", dns.DefaultCnameTTL, currentEndpoints)
-		newEndpoints = append(newEndpoints, endpoint)
+		endpoint = createOrUpdateEndpoint(hostname, []string{lbName}, v1alpha1.CNAMERecordType, "", dns.DefaultCnameTTL, currentEndpoints)
+		endpoints = append(endpoints, endpoint)
 	}
 
-	sort.Slice(newEndpoints, func(i, j int) bool {
-		return newEndpoints[i].SetID() < newEndpoints[j].SetID()
-	})
-
-	dnsRecord.Spec.Endpoints = newEndpoints
-
-	if !equality.Semantic.DeepEqual(old, dnsRecord) {
-		return dh.Update(ctx, dnsRecord)
-	}
-	return nil
+	return endpoints
 }
 
 func createOrUpdateEndpoint(dnsName string, targets v1alpha1.Targets, recordType v1alpha1.DNSRecordType, setIdentifier string,
@@ -374,8 +425,8 @@ func (dh *dnsHelper) deleteDNSRecordForListener(ctx context.Context, owner metav
 	return dh.Delete(ctx, &dnsRecord, &client.DeleteOptions{})
 }
 
-func isWildCardListener(l gatewayv1beta1.Listener) bool {
-	return strings.HasPrefix(string(*l.Hostname), "*")
+func isWildCardHost(host string) bool {
+	return strings.HasPrefix(host, "*")
 }
 
 func (dh *dnsHelper) getDNSHealthCheckProbes(ctx context.Context, gateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) ([]*v1alpha1.DNSHealthCheckProbe, error) {

--- a/pkg/controllers/dnspolicy/dns_helper_test.go
+++ b/pkg/controllers/dnspolicy/dns_helper_test.go
@@ -975,7 +975,7 @@ func Test_dnsHelper_setEndpoints(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			f := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(testCase.dnsRecord).Build()
 			s := dnsHelper{Client: f}
-			if err := s.setEndpoints(context.TODO(), testCase.mcgTarget, testCase.dnsRecord, testCase.listener); (err != nil) != testCase.wantErr {
+			if err := s.setEndpoints(context.TODO(), testCase.mcgTarget, testCase.dnsRecord, testCase.listener, v1alpha1.LoadBalancedRoutingStrategy); (err != nil) != testCase.wantErr {
 				t.Errorf("SetEndpoints() error = %v, wantErr %v", err, testCase.wantErr)
 			}
 

--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/kuadrant/authorino/pkg/log"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -194,7 +193,6 @@ func (r *DNSPolicyReconciler) deleteResources(ctx context.Context, dnsPolicy *v1
 	// delete based on gateway diffs
 
 	if err := r.deleteDNSRecords(ctx, dnsPolicy); err != nil {
-		log.V(3).Info("error reconciling DNS records from delete, returning", "error", err)
 		return err
 	}
 

--- a/test/e2e/gateway_single_spoke_test.go
+++ b/test/e2e/gateway_single_spoke_test.go
@@ -252,6 +252,7 @@ var _ = Describe("Gateway single target cluster", func() {
 								Name:      gatewayapi.ObjectName(testID),
 								Namespace: Pointer(gatewayapi.Namespace(tconfig.HubNamespace())),
 							},
+							RoutingStrategy: v1alpha1.LoadBalancedRoutingStrategy,
 						},
 					}
 					err := tconfig.HubClient().Create(ctx, dnsPolicy)

--- a/test/e2e/gateway_single_spoke_test.go
+++ b/test/e2e/gateway_single_spoke_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Gateway single target cluster", func() {
 
 		By("creating a Gateway in the hub")
 		hostname = gatewayapi.Hostname(strings.Join([]string{testID, tconfig.ManagedZone()}, "."))
-		gw = NewTestGateway(testID, GatewayClassName, tconfig.HubNamespace()).WithListener(gatewayapi.Listener{
+		gw = NewGatewayBuilder(testID, GatewayClassName, tconfig.HubNamespace()).WithListener(gatewayapi.Listener{
 			Name:     "https",
 			Hostname: &hostname,
 			Port:     443,

--- a/test/policy_integration/dnspolicy_controller_test.go
+++ b/test/policy_integration/dnspolicy_controller_test.go
@@ -3,6 +3,7 @@
 package policy_integration
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	v1 "open-cluster-management.io/api/cluster/v1"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/_internal/conditions"
@@ -30,168 +31,21 @@ import (
 	testutil "github.com/Kuadrant/multicluster-gateway-controller/test/util"
 )
 
-func testBuildManagedZone(domainName, ns string) *v1alpha1.ManagedZone {
-	return &v1alpha1.ManagedZone{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      domainName,
-			Namespace: ns,
-		},
-		Spec: v1alpha1.ManagedZoneSpec{
-			ID:          "1234",
-			DomainName:  domainName,
-			Description: domainName,
-			SecretRef: &v1alpha1.SecretRef{
-				Name:      "secretname",
-				Namespace: ns,
-			},
-		},
-	}
-}
-
-func testBuildGatewayClass(gwClassName, ns string) *gatewayv1beta1.GatewayClass {
-	return &gatewayv1beta1.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      gwClassName,
-			Namespace: ns,
-		},
-		Spec: gatewayv1beta1.GatewayClassSpec{
-			ControllerName: "kuadrant.io/mctc-gw-controller",
-		},
-	}
-}
-
-func testBuildGateway(gwName, gwClassName, hostname, ns, dnspolicy string) *gatewayv1beta1.Gateway {
-	typedHostname := gatewayv1beta1.Hostname(hostname)
-	wildcardHost := gatewayv1beta1.Hostname(TestWildCardListenerHost)
-	return &gatewayv1beta1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      gwName,
-			Namespace: ns,
-			Annotations: map[string]string{
-				DNSPoliciesBackRefAnnotation: fmt.Sprintf("[{\"Namespace\":\"%s\",\"Name\":\"%s\"}]", ns, dnspolicy),
-			},
-			Labels: map[string]string{
-				"cluster.open-cluster-management.io/placement": "GatewayControllerTest",
-			},
-		},
-		Spec: gatewayv1beta1.GatewaySpec{
-			GatewayClassName: gatewayv1beta1.ObjectName(gwClassName),
-			Listeners: []gatewayv1beta1.Listener{
-				{
-					Name:     gatewayv1beta1.SectionName(hostname),
-					Hostname: &typedHostname,
-					Port:     gatewayv1beta1.PortNumber(80),
-					Protocol: gatewayv1beta1.HTTPProtocolType,
-				},
-				{
-					Name:     TestWildCardListenerName,
-					Hostname: &wildcardHost,
-					Port:     gatewayv1beta1.PortNumber(80),
-					Protocol: gatewayv1beta1.HTTPProtocolType,
-				},
-			},
-		},
-	}
-}
-
-func testBuildGatewayAddresses() []gatewayv1beta1.GatewayAddress {
-	return []gatewayv1beta1.GatewayAddress{
-		{
-			Type:  testutil.Pointer(mgcgateway.MultiClusterIPAddressType),
-			Value: TestPlacedClusterControlName + "/" + TestAttachedRouteAddressOne,
-		},
-		{
-			Type:  testutil.Pointer(mgcgateway.MultiClusterIPAddressType),
-			Value: TestPlaceClusterWorkloadName + "/" + TestAttachedRouteAddressTwo,
-		},
-	}
-}
-
-func testBuildGatewayListenerStatus(names []string, numRoutes []int32) []gatewayv1beta1.ListenerStatus {
-	listeners := []gatewayv1beta1.ListenerStatus{}
-
-	for i, name := range names {
-		listeners = append(listeners, gatewayv1beta1.ListenerStatus{
-			AttachedRoutes: numRoutes[i],
-			Name:           gatewayv1beta1.SectionName(name),
-			Conditions:     make([]metav1.Condition, 0),
-			SupportedKinds: make([]gatewayv1beta1.RouteGroupKind, 0),
-		})
-	}
-
-	return listeners
-}
-
-func testBuildDNSPolicyWithHealthCheck(policyName, gwName, ns string, threshold *int) *v1alpha1.DNSPolicy {
-	typedNamespace := gatewayv1beta1.Namespace(ns)
-	protocol := v1alpha1.HttpProtocol
-	return &v1alpha1.DNSPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      policyName,
-			Namespace: ns,
-		},
-		Spec: v1alpha1.DNSPolicySpec{
-			RoutingStrategy: v1alpha1.LoadBalancedRoutingStrategy,
-			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
-				Group:     "gateway.networking.k8s.io",
-				Kind:      "Gateway",
-				Name:      gatewayv1beta1.ObjectName(gwName),
-				Namespace: &typedNamespace,
-			},
-			HealthCheck: &v1alpha1.HealthCheckSpec{
-				Endpoint:         "/",
-				Protocol:         &protocol,
-				FailureThreshold: threshold,
-			},
-			LoadBalancing: &v1alpha1.LoadBalancingSpec{
-				Weighted: &v1alpha1.LoadBalancingWeighted{
-					DefaultWeight: 120,
-				},
-			},
-		},
-	}
-}
-
-func testBuildDNSPolicyWithGeo(policyName, gwName, ns string) *v1alpha1.DNSPolicy {
-	typedNamespace := gatewayv1beta1.Namespace(ns)
-	return &v1alpha1.DNSPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      policyName,
-			Namespace: ns,
-		},
-		Spec: v1alpha1.DNSPolicySpec{
-			RoutingStrategy: v1alpha1.LoadBalancedRoutingStrategy,
-			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
-				Group:     "gateway.networking.k8s.io",
-				Kind:      "Gateway",
-				Name:      gatewayv1beta1.ObjectName(gwName),
-				Namespace: &typedNamespace,
-			},
-			LoadBalancing: &v1alpha1.LoadBalancingSpec{
-				Weighted: &v1alpha1.LoadBalancingWeighted{
-					DefaultWeight: 120,
-				},
-				Geo: &v1alpha1.LoadBalancingGeo{
-					DefaultGeo: "IE",
-				},
-			},
-		},
-	}
-}
-
 var _ = Describe("DNSPolicy", Ordered, func() {
 
 	var gatewayClass *gatewayv1beta1.GatewayClass
 	var managedZone *v1alpha1.ManagedZone
 	var testNamespace string
+	var dnsPolicyBuilder *testutil.DNSPolicyBuilder
+	var gateway *gatewayv1beta1.Gateway
+	var dnsPolicy *v1alpha1.DNSPolicy
 
 	BeforeAll(func() {
-		gatewayClass = testBuildGatewayClass("kuadrant-multi-cluster-gateway-instance-per-cluster-dns", "default")
 		logger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
 		logger.WithName("dnspolicy_controller_test")
 		logf.SetLogger(logger)
 
-		gatewayClass = testBuildGatewayClass("kuadrant-multi-cluster-gateway-instance-per-cluster", "default")
+		gatewayClass = testutil.NewTestGatewayClass("foo", "default", "kuadrant.io/bar")
 		Expect(k8sClient.Create(ctx, gatewayClass)).To(BeNil())
 		Eventually(func() error { // gateway class exists
 			return k8sClient.Get(ctx, client.ObjectKey{Name: gatewayClass.Name}, gatewayClass)
@@ -200,16 +54,25 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 	BeforeEach(func() {
 		CreateNamespace(&testNamespace)
-
-		managedZone = testBuildManagedZone("example.com", testNamespace)
+		managedZone = testutil.NewManagedZoneBuilder("mz-example-com", testNamespace, "example.com").ManagedZone
 		Expect(k8sClient.Create(ctx, managedZone)).To(BeNil())
 		Eventually(func() error { // managed zone exists
 			return k8sClient.Get(ctx, client.ObjectKey{Name: managedZone.Name, Namespace: managedZone.Namespace}, managedZone)
 		}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
-
+		dnsPolicyBuilder = testutil.NewDNSPolicyBuilder("test-dns-policy", testNamespace)
 	})
 
 	AfterEach(func() {
+		if gateway != nil {
+			err := k8sClient.Delete(ctx, gateway)
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+		}
+
+		if dnsPolicy != nil {
+			err := k8sClient.Delete(ctx, dnsPolicy)
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+		}
 		gatewayList := &gatewayv1beta1.GatewayList{}
 		Expect(k8sClient.List(ctx, gatewayList)).To(BeNil())
 		for _, gw := range gatewayList.Items {
@@ -228,21 +91,16 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 	})
 
 	Context("invalid target", func() {
-		var gateway *gatewayv1beta1.Gateway
-		var dnsPolicy *v1alpha1.DNSPolicy
-		gwClassName := "istio"
 
 		BeforeEach(func() {
-			dnsPolicy = testBuildDNSPolicyWithHealthCheck("test-dns-policy", "test-gateway", testNamespace, nil)
+			dnsPolicy = dnsPolicyBuilder.
+				WithTargetGateway("test-gateway").
+				WithRoutingStrategy(v1alpha1.SimpleRoutingStrategy).
+				DNSPolicy
 			Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
 			Eventually(func() error { //dns policy exists
 				return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
 			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			err := k8sClient.Delete(ctx, dnsPolicy)
-			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should have ready condition with status false and correct reason", func() {
@@ -270,8 +128,8 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 		It("should have ready condition with status true", func() {
 			By("creating a valid Gateway")
 
-			gateway = testutil.NewTestGateway("test-gateway", gwClassName, testNamespace).
-				WithHTTPListener("test.example.com").Gateway
+			gateway = testutil.NewGatewayBuilder("test-gateway", gatewayClass.Name, testNamespace).
+				WithHTTPListener("test-listener", "test.example.com").Gateway
 			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
 			Eventually(func() error { //gateway exists
 				return k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
@@ -293,7 +151,7 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 			// this one should get deleted if the gateway is invalid policy ref
 			probe := &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-%s-%s", TestAttachedRouteAddressTwo, TestPlacedGatewayName, TestAttachedRouteName),
+					Name:      fmt.Sprintf("%s-%s-%s", TestIPAddressTwo, TestGatewayName, TestHostOne),
 					Namespace: testNamespace,
 					Labels: map[string]string{
 						DNSPolicyBackRefAnnotation:                              "test-dns-policy",
@@ -325,1096 +183,21 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 
 	})
 
-	Context("gateway placed", func() {
-		var gateway *gatewayv1beta1.Gateway
-		var lbHash, dnsRecordName, wildcardDNSRecordName string
+	Context("valid target with no gateway status", func() {
+		testGatewayName := "test-no-gateway-status"
 
 		BeforeEach(func() {
-			gateway = testBuildGateway(TestPlacedGatewayName, testutil.DummyCRName, TestAttachedRouteName, testNamespace, "test-dns-policy")
-			lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
-			dnsRecordName = fmt.Sprintf("%s-%s", TestPlacedGatewayName, TestAttachedRouteName)
-			wildcardDNSRecordName = fmt.Sprintf("%s-%s", TestPlacedGatewayName, TestWildCardListenerName)
-			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
-			Eventually(func() error { //gateway exists
-				return k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
-			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
-			Eventually(func() error { // TODO remove the workaround during https://github.com/Kuadrant/multicluster-gateway-controller/issues/330
-				// also use a proper gateway class
-
-				if err := k8sClient.Create(ctx, &v1.ManagedCluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: TestPlacedClusterControlName,
-					},
-				}); err != nil && !k8serrors.IsAlreadyExists(err) {
-					return err
-				}
-				if err := k8sClient.Create(ctx, &v1.ManagedCluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: TestPlaceClusterWorkloadName,
-					},
-				}); err != nil && !k8serrors.IsAlreadyExists(err) {
-					return err
-				}
-				gateway.Status.Addresses = testBuildGatewayAddresses()
-				gateway.Status.Listeners = testBuildGatewayListenerStatus(
-					[]string{
-						TestPlacedClusterControlName + "." + TestAttachedRouteName,
-						TestPlaceClusterWorkloadName + "." + TestAttachedRouteName,
-						TestPlacedClusterControlName + "." + TestWildCardListenerName,
-						TestPlaceClusterWorkloadName + "." + TestWildCardListenerName,
-					},
-					[]int32{1, 1, 1, 1})
-				return k8sClient.Status().Update(ctx, gateway)
-			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred()) // end of the workaround
-		})
-
-		AfterEach(func() {
-			err := k8sClient.Delete(ctx, gateway)
-			// ignore not found err
-			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
-
-			dnsRecordList := &v1alpha1.DNSRecordList{}
-			err = k8sClient.List(ctx, dnsRecordList)
-			Expect(err).ToNot(HaveOccurred())
-
-			for _, record := range dnsRecordList.Items {
-				err := k8sClient.Delete(ctx, &record)
-				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
-			}
-		})
-
-		Context("weighted dnspolicy", func() {
-			var dnsPolicy *v1alpha1.DNSPolicy
-
-			BeforeEach(func() {
-				dnsPolicy = testBuildDNSPolicyWithHealthCheck("test-dns-policy", TestPlacedGatewayName, testNamespace, nil)
-				Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
-				Eventually(func() error { //dns policy exists
-					return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
-				}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
-			})
-
-			It("should create a dns record", func() {
-				createdDNSRecord := &v1alpha1.DNSRecord{}
-				expectedEndpoints := []*v1alpha1.Endpoint{
-					{
-						DNSName: "test.example.com",
-						Targets: []string{
-							"lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "",
-						RecordTTL:     300,
-					},
-					{
-						DNSName: "lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"default.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "default",
-						RecordTTL:     300,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "geo-code",
-								Value: "*",
-							},
-						},
-					},
-					{
-						DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							TestAttachedRouteAddressOne,
-						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-					{
-						DNSName: "default.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"s07c46.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
-						RecordTTL:     60,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
-							},
-						},
-					},
-					{
-						DNSName: "default.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"2w705o.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
-						RecordTTL:     60,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
-							},
-						},
-					},
-					{
-						DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							TestAttachedRouteAddressTwo,
-						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-				}
-				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord); err != nil {
-						return err
-					}
-					if len(createdDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-						return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(createdDNSRecord.Spec.Endpoints))
-					}
-					return nil
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-				Expect(createdDNSRecord.Spec.ManagedZoneRef.Name).To(Equal("example.com"))
-				Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
-				Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
-			})
-			It("should create a wildcard dns record", func() {
-				wildcardDNSRecord := &v1alpha1.DNSRecord{}
-				expectedEndpoints := []*v1alpha1.Endpoint{
-					{
-						DNSName: TestWildCardListenerHost,
-						Targets: []string{
-							"lb-" + lbHash + ".example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "",
-						RecordTTL:     300,
-					},
-					{
-						DNSName: "lb-" + lbHash + ".example.com",
-						Targets: []string{
-							"default.lb-" + lbHash + ".example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "default",
-						RecordTTL:     300,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "geo-code",
-								Value: "*",
-							},
-						},
-					},
-					{
-						DNSName: "s07c46.lb-" + lbHash + ".example.com",
-						Targets: []string{
-							TestAttachedRouteAddressOne,
-						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-					{
-						DNSName: "default.lb-" + lbHash + ".example.com",
-						Targets: []string{
-							"s07c46.lb-" + lbHash + ".example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "s07c46.lb-" + lbHash + ".example.com",
-						RecordTTL:     60,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
-							},
-						},
-					},
-					{
-						DNSName: "2w705o.lb-" + lbHash + ".example.com",
-						Targets: []string{
-							TestAttachedRouteAddressTwo,
-						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-					{
-						DNSName: "default.lb-" + lbHash + ".example.com",
-						Targets: []string{
-							"2w705o.lb-" + lbHash + ".example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "2w705o.lb-" + lbHash + ".example.com",
-						RecordTTL:     60,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
-							},
-						},
-					},
-				}
-				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: wildcardDNSRecordName, Namespace: testNamespace}, wildcardDNSRecord); err != nil {
-						return err
-					}
-					if len(wildcardDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-						return fmt.Errorf("expected %v wildcard endpoints in DNSRecord, got %v", len(expectedEndpoints), len(wildcardDNSRecord.Spec.Endpoints))
-					}
-					return nil
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-				Expect(wildcardDNSRecord.Spec.ManagedZoneRef.Name).To(Equal("example.com"))
-				Expect(wildcardDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
-				Expect(wildcardDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
-				Expect(expectedEndpoints).Should(ContainElements(wildcardDNSRecord.Spec.Endpoints))
-			})
-
-			It("should have correct status", func() {
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
-						return err
-					}
-					if !meta.IsStatusConditionTrue(dnsPolicy.Status.Conditions, string(conditions.ConditionTypeReady)) {
-						return fmt.Errorf("expected status condition %s to be True", conditions.ConditionTypeReady)
-					}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(gateway), gateway); err != nil {
-						return err
-					}
-
-					policyAffectedCond := meta.FindStatusCondition(gateway.Status.Conditions, string(DNSPolicyAffected))
-					if policyAffectedCond == nil {
-						return fmt.Errorf("policy affected conditon expected but not found")
-					}
-					if policyAffectedCond.ObservedGeneration != gateway.Generation {
-						return fmt.Errorf("expected policy affected cond generation to be %d but got %d", gateway.Generation, policyAffectedCond.ObservedGeneration)
-					}
-					if !meta.IsStatusConditionTrue(gateway.Status.Conditions, string(DNSPolicyAffected)) {
-						return fmt.Errorf("expected gateway status condition %s to be True", DNSPolicyAffected)
-					}
-
-					return nil
-				}, time.Second*15, time.Second).Should(BeNil())
-			})
-
-			It("should set gateway back reference", func() {
-				existingGateway := &gatewayv1beta1.Gateway{}
-				policyBackRefValue := testNamespace + "/" + dnsPolicy.Name
-				refs, _ := json.Marshal([]client.ObjectKey{{Name: dnsPolicy.Name, Namespace: testNamespace}})
-				policiesBackRefValue := string(refs)
-
-				Eventually(func() map[string]string {
-					// Check gateway back references
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
-					// must exist
-					Expect(err).ToNot(HaveOccurred())
-					return existingGateway.GetAnnotations()
-				}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPolicyBackRefAnnotation, policyBackRefValue))
-				Eventually(func() map[string]string {
-					// Check gateway back references
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
-					// must exist
-					Expect(err).ToNot(HaveOccurred())
-					return existingGateway.GetAnnotations()
-				}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPoliciesBackRefAnnotation, policiesBackRefValue))
-			})
-
-			It("should remove dns records when listener removed", func() {
-				//get the gateway and remove the listeners
-
-				Eventually(func() error {
-					existingGateway := &gatewayv1beta1.Gateway{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(gateway), existingGateway); err != nil {
-						return err
-					}
-					newListeners := []gatewayv1beta1.Listener{}
-					for _, existing := range existingGateway.Spec.Listeners {
-						if existing.Name == TestWildCardListenerName {
-							newListeners = append(newListeners, existing)
-						}
-					}
-
-					patch := client.MergeFrom(existingGateway.DeepCopy())
-					existingGateway.Spec.Listeners = newListeners
-					rec := &v1alpha1.DNSRecord{}
-					if err := k8sClient.Patch(ctx, existingGateway, patch); err != nil {
-						return err
-					}
-					//dns record should be removed for non wildcard
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, rec); err != nil && !k8serrors.IsNotFound(err) {
-						return err
-					}
-					return k8sClient.Get(ctx, client.ObjectKey{Name: wildcardDNSRecordName, Namespace: testNamespace}, rec)
-				}, time.Second*10, time.Second).Should(BeNil())
-			})
-
-			It("should remove gateway back reference on policy deletion", func() {
-				existingGateway := &gatewayv1beta1.Gateway{}
-				policyBackRefValue := testNamespace + "/" + dnsPolicy.Name
-				refs, _ := json.Marshal([]client.ObjectKey{{Name: dnsPolicy.Name, Namespace: testNamespace}})
-				policiesBackRefValue := string(refs)
-
-				Eventually(func() map[string]string {
-					// Check gateway back references
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
-					// must exist
-					Expect(err).ToNot(HaveOccurred())
-					return existingGateway.GetAnnotations()
-				}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPolicyBackRefAnnotation, policyBackRefValue))
-				Eventually(func() map[string]string {
-					// Check gateway back references
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
-					// must exist
-					Expect(err).ToNot(HaveOccurred())
-					return existingGateway.GetAnnotations()
-				}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPoliciesBackRefAnnotation, policiesBackRefValue))
-
-				//finalizer should exist
-				Eventually(func() bool {
-					existingDNSPolicy := &v1alpha1.DNSPolicy{}
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: testNamespace}, existingDNSPolicy)
-					// must exist
-					Expect(err).ToNot(HaveOccurred())
-					return metadata.HasFinalizer(existingDNSPolicy, DNSPolicyFinalizer)
-				}, time.Second*5, time.Second).Should(BeTrue())
-
-				Expect(k8sClient.Delete(ctx, dnsPolicy)).To(BeNil())
-
-				Eventually(func() map[string]string {
-					// Check gateway back references
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, existingGateway)
-					// must exist
-					Expect(err).ToNot(HaveOccurred())
-					return existingGateway.GetAnnotations()
-				}, time.Second*5, time.Second).ShouldNot(HaveKey(DNSPolicyBackRefAnnotation))
-
-				Eventually(func() map[string]string {
-					// Check gateway back references
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
-					// must exist
-					Expect(err).ToNot(HaveOccurred())
-					return existingGateway.GetAnnotations()
-				}, time.Second*5, time.Second).ShouldNot(HaveKeyWithValue(DNSPoliciesBackRefAnnotation, policiesBackRefValue))
-
-				Eventually(func() error {
-					// Check gateway back references
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway); err != nil {
-						return err
-					}
-					cond := meta.FindStatusCondition(existingGateway.Status.Conditions, string(DNSPolicyAffected))
-					if cond != nil {
-						return fmt.Errorf("expected the condition %s to be gone", DNSPolicyAffected)
-					}
-					return nil
-				}, time.Second*5, time.Second).Should(BeNil())
-			})
-
-			It("should remove dns record reference on policy deletion even if gateway is removed", func() {
-				createdDNSRecord := &v1alpha1.DNSRecord{}
-				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord); err != nil {
-						return err
-					}
-					return nil
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-
-				err := k8sClient.Delete(ctx, gateway)
-				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
-
-				dnsPolicy = testBuildDNSPolicyWithHealthCheck("test-dns-policy", TestPlacedGatewayName, testNamespace, nil)
-				err = k8sClient.Delete(ctx, dnsPolicy)
-				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
-
-				Eventually(func() error { // DNS record removed
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord); err != nil {
-						if k8serrors.IsNotFound(err) {
-							return nil
-						}
-						return err
-					}
-					return errors.New("found dnsrecord when it should be deleted")
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-			})
-
-		})
-
-		Context("geo dnspolicy", func() {
-			var dnsPolicy *v1alpha1.DNSPolicy
-
-			BeforeEach(func() {
-				dnsPolicy = testBuildDNSPolicyWithGeo("test-dns-policy", TestPlacedGatewayName, testNamespace)
-				Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
-				Eventually(func() error { //dns policy exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
-						return err
-					}
-					return nil
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-			})
-
-			It("should create a dns record", func() {
-				createdDNSRecord := &v1alpha1.DNSRecord{}
-				expectedEndpoints := []*v1alpha1.Endpoint{
-					{
-						DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							TestAttachedRouteAddressTwo,
-						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-					{
-						DNSName: "ie.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"2w705o.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
-						RecordTTL:     60,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
-							},
-						},
-					},
-					{
-						DNSName: "ie.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"s07c46.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
-						RecordTTL:     60,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
-							},
-						},
-					},
-					{
-						DNSName: "lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"ie.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "IE",
-						RecordTTL:     300,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "geo-code",
-								Value: "IE",
-							},
-						},
-					},
-					{
-						DNSName: "lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							"ie.lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "default",
-						RecordTTL:     300,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "geo-code",
-								Value: "*",
-							},
-						},
-					},
-					{
-						DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
-						Targets: []string{
-							TestAttachedRouteAddressOne,
-						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-					{
-						DNSName: "test.example.com",
-						Targets: []string{
-							"lb-" + lbHash + ".test.example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "",
-						RecordTTL:     300,
-					},
-				}
-				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: dnsPolicy.Namespace}, createdDNSRecord); err != nil {
-						return err
-					}
-					if len(createdDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-						return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(createdDNSRecord.Spec.Endpoints))
-					}
-					return nil
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-				Expect(createdDNSRecord.Spec.ManagedZoneRef.Name).To(Equal("example.com"))
-				Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
-				Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
-				Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
-
-			})
-
-			It("should create a wildcard dns record", func() {
-				wildcardDNSRecord := &v1alpha1.DNSRecord{}
-				expectedEndpoints := []*v1alpha1.Endpoint{
-					{
-						DNSName: "*.example.com",
-						Targets: []string{
-							"lb-" + lbHash + ".example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "",
-						RecordTTL:     300,
-					},
-					{
-						DNSName: "2w705o.lb-" + lbHash + ".example.com",
-						Targets: []string{
-							TestAttachedRouteAddressTwo,
-						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-					{
-						DNSName: "ie.lb-" + lbHash + ".example.com",
-						Targets: []string{
-							"2w705o.lb-" + lbHash + ".example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "2w705o.lb-" + lbHash + ".example.com",
-						RecordTTL:     60,
-						Labels:        nil,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
-							},
-						},
-					},
-					{
-						DNSName: "ie.lb-" + lbHash + ".example.com",
-						Targets: []string{
-							"s07c46.lb-" + lbHash + ".example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "s07c46.lb-" + lbHash + ".example.com",
-						RecordTTL:     60,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "weight",
-								Value: "120",
-							},
-						},
-					},
-					{
-						DNSName: "lb-" + lbHash + ".example.com",
-						Targets: []string{
-							"ie.lb-" + lbHash + ".example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "IE",
-						RecordTTL:     300,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "geo-code",
-								Value: "IE",
-							},
-						},
-					},
-					{
-						DNSName: "lb-" + lbHash + ".example.com",
-						Targets: []string{
-							"ie.lb-" + lbHash + ".example.com",
-						},
-						RecordType:    "CNAME",
-						SetIdentifier: "default",
-						RecordTTL:     300,
-						ProviderSpecific: v1alpha1.ProviderSpecific{
-							{
-								Name:  "geo-code",
-								Value: "*",
-							},
-						},
-					},
-					{
-						DNSName: "s07c46.lb-" + lbHash + ".example.com",
-						Targets: []string{
-							TestAttachedRouteAddressOne,
-						},
-						RecordType:    "A",
-						SetIdentifier: "",
-						RecordTTL:     60,
-					},
-				}
-				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: wildcardDNSRecordName, Namespace: dnsPolicy.Namespace}, wildcardDNSRecord); err != nil {
-						return err
-					}
-					if len(wildcardDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-						return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(wildcardDNSRecord.Spec.Endpoints))
-					}
-					return nil
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-				Expect(wildcardDNSRecord.Spec.ManagedZoneRef.Name).To(Equal("example.com"))
-				Expect(wildcardDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
-				Expect(wildcardDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
-				Expect(expectedEndpoints).Should(ContainElements(wildcardDNSRecord.Spec.Endpoints))
-			})
-		})
-		Context("probes status impact DNS records", func() {
-			var dnsPolicy *v1alpha1.DNSPolicy
-			var unhealthy bool
-
-			BeforeEach(func() {
-				dnsPolicy = testBuildDNSPolicyWithHealthCheck("test-dns-policy", TestPlacedGatewayName, testNamespace, testutil.Pointer(4))
-				Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
-				Eventually(func() error { //dns policy exists
-					return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
-				}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
-			})
-
-			It("should create a dns record", func() {
-				createdDNSRecord := &v1alpha1.DNSRecord{}
-				Eventually(func() error { // DNS record exists
-					if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord); err != nil {
-						return err
-					}
-					if len(createdDNSRecord.Spec.Endpoints) != 6 {
-						return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", 6, len(createdDNSRecord.Spec.Endpoints))
-					}
-					return nil
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-				Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(6))
-			})
-			It("should have probes that are healthy", func() {
-				probeList := &v1alpha1.DNSHealthCheckProbeList{}
-				Eventually(func() error {
-					Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
-					if len(probeList.Items) != 2 {
-						return fmt.Errorf("expected %v probes, got %v", 2, len(probeList.Items))
-					}
-					return nil
-				}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-				Expect(len(probeList.Items)).To(Equal(2))
-			})
-
-			Context("all unhealthy probes", func() {
-				It("should publish all dns records endpoints", func() {
-					lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
-
-					expectedEndpoints := []*v1alpha1.Endpoint{
-						{
-							DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								TestAttachedRouteAddressTwo,
-							},
-							RecordType:    "A",
-							SetIdentifier: "",
-							RecordTTL:     60,
-						},
-						{
-							DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								TestAttachedRouteAddressOne,
-							},
-							RecordType:    "A",
-							SetIdentifier: "",
-							RecordTTL:     60,
-						},
-						{
-							DNSName: "default.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								"2w705o.lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
-							RecordTTL:     60,
-							ProviderSpecific: v1alpha1.ProviderSpecific{
-								{
-									Name:  "weight",
-									Value: "120",
-								},
-							},
-						},
-						{
-							DNSName: "default.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								"s07c46.lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
-							RecordTTL:     60,
-							Labels:        nil,
-							ProviderSpecific: v1alpha1.ProviderSpecific{
-								{
-									Name:  "weight",
-									Value: "120",
-								},
-							},
-						},
-						{
-							DNSName: "lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								"default.lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "default",
-							RecordTTL:     300,
-							ProviderSpecific: v1alpha1.ProviderSpecific{
-								{
-									Name:  "geo-code",
-									Value: "*",
-								},
-							},
-						},
-						{
-							DNSName: "test.example.com",
-							Targets: []string{
-								"lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "",
-							RecordTTL:     300,
-						},
-					}
-
-					probeList := &v1alpha1.DNSHealthCheckProbeList{}
-					Eventually(func() error {
-						Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
-						if len(probeList.Items) != 2 {
-							return fmt.Errorf("expected %v probes, got %v", 2, len(probeList.Items))
-						}
-						return nil
-					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
-
-					for _, probe := range probeList.Items {
-						Eventually(func() error {
-							if probe.Name == fmt.Sprintf("%s-%s-%s", TestAttachedRouteAddressTwo, TestPlacedGatewayName, TestAttachedRouteName) ||
-								probe.Name == fmt.Sprintf("%s-%s-%s", TestAttachedRouteAddressOne, TestPlacedGatewayName, TestAttachedRouteName) {
-								getProbe := &v1alpha1.DNSHealthCheckProbe{}
-								if err := k8sClient.Get(ctx, client.ObjectKey{Name: probe.Name, Namespace: probe.Namespace}, getProbe); err != nil {
-									return err
-								}
-								patch := client.MergeFrom(getProbe.DeepCopy())
-								unhealthy = false
-								getProbe.Status = v1alpha1.DNSHealthCheckProbeStatus{
-									LastCheckedAt:       metav1.NewTime(time.Now()),
-									ConsecutiveFailures: *getProbe.Spec.FailureThreshold + 1,
-									Healthy:             &unhealthy,
-								}
-								if err := k8sClient.Status().Patch(ctx, getProbe, patch); err != nil {
-									return err
-								}
-							}
-							return nil
-						}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-					}
-					createdDNSRecord := &v1alpha1.DNSRecord{}
-					Eventually(func() error {
-
-						err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord)
-						if err != nil && k8serrors.IsNotFound(err) {
-							return err
-						}
-						if len(createdDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
-							return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(createdDNSRecord.Spec.Endpoints))
-						}
-						return nil
-					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
-					Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
-					Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
-					Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
-
-				})
-			})
-			Context("some unhealthy probes", func() {
-				It("should publish expected endpoints", func() {
-					lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
-
-					expectedEndpoints := []*v1alpha1.Endpoint{
-						{
-							DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								TestAttachedRouteAddressTwo,
-							},
-							RecordType:    "A",
-							SetIdentifier: "",
-							RecordTTL:     60,
-						},
-						{
-							DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								TestAttachedRouteAddressOne,
-							},
-							RecordType:    "A",
-							SetIdentifier: "",
-							RecordTTL:     60,
-						},
-						{
-							DNSName: "default.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								"2w705o.lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
-							RecordTTL:     60,
-							ProviderSpecific: v1alpha1.ProviderSpecific{
-								{
-									Name:  "weight",
-									Value: "120",
-								},
-							},
-						},
-						{
-							DNSName: "default.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								"s07c46.lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
-							RecordTTL:     60,
-							Labels:        nil,
-							ProviderSpecific: v1alpha1.ProviderSpecific{
-								{
-									Name:  "weight",
-									Value: "120",
-								},
-							},
-						},
-						{
-							DNSName: "lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								"default.lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "default",
-							RecordTTL:     300,
-							ProviderSpecific: v1alpha1.ProviderSpecific{
-								{
-									Name:  "geo-code",
-									Value: "*",
-								},
-							},
-						},
-						{
-							DNSName: "test.example.com",
-							Targets: []string{
-								"lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "",
-							RecordTTL:     300,
-						},
-					}
-
-					probeList := &v1alpha1.DNSHealthCheckProbeList{}
-					Eventually(func() error {
-						Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
-						if len(probeList.Items) != 2 {
-							return fmt.Errorf("expected %v probes, got %v", 2, len(probeList.Items))
-						}
-						return nil
-					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
-					Expect(probeList.Items).To(HaveLen(2))
-
-					Eventually(func() error {
-						getProbe := &v1alpha1.DNSHealthCheckProbe{}
-						if err := k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-%s-%s", TestAttachedRouteAddressOne, TestPlacedGatewayName, TestAttachedRouteName), Namespace: testNamespace}, getProbe); err != nil {
-							return err
-						}
-						patch := client.MergeFrom(getProbe.DeepCopy())
-						unhealthy = false
-						getProbe.Status = v1alpha1.DNSHealthCheckProbeStatus{
-							LastCheckedAt:       metav1.NewTime(time.Now()),
-							ConsecutiveFailures: *getProbe.Spec.FailureThreshold + 1,
-							Healthy:             &unhealthy,
-						}
-						if err := k8sClient.Status().Patch(ctx, getProbe, patch); err != nil {
-							return err
-						}
-						return nil
-					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
-
-					// after that verify that in time the endpoints are 5 in the dnsrecord
-					createdDNSRecord := &v1alpha1.DNSRecord{}
-					Eventually(func() error {
-						err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord)
-						if err != nil && k8serrors.IsNotFound(err) {
-							return err
-						}
-						return nil
-					}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-					Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
-					Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
-					Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
-				})
-			})
-			Context("some unhealthy endpoints for other listener", func() {
-				It("should publish expected endpoints", func() {
-					lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
-
-					expectedEndpoints := []*v1alpha1.Endpoint{
-						{
-							DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								TestAttachedRouteAddressTwo,
-							},
-							RecordType:    "A",
-							SetIdentifier: "",
-							RecordTTL:     60,
-						},
-						{
-							DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								TestAttachedRouteAddressOne,
-							},
-							RecordType:    "A",
-							SetIdentifier: "",
-							RecordTTL:     60,
-						},
-						{
-							DNSName: "default.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								"2w705o.lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
-							RecordTTL:     60,
-							ProviderSpecific: v1alpha1.ProviderSpecific{
-								{
-									Name:  "weight",
-									Value: "120",
-								},
-							},
-						},
-						{
-							DNSName: "default.lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								"s07c46.lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
-							RecordTTL:     60,
-							Labels:        nil,
-							ProviderSpecific: v1alpha1.ProviderSpecific{
-								{
-									Name:  "weight",
-									Value: "120",
-								},
-							},
-						},
-						{
-							DNSName: "lb-" + lbHash + ".test.example.com",
-							Targets: []string{
-								"default.lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "default",
-							RecordTTL:     300,
-							ProviderSpecific: v1alpha1.ProviderSpecific{
-								{
-									Name:  "geo-code",
-									Value: "*",
-								},
-							},
-						},
-						{
-							DNSName: "test.example.com",
-							Targets: []string{
-								"lb-" + lbHash + ".test.example.com",
-							},
-							RecordType:    "CNAME",
-							SetIdentifier: "",
-							RecordTTL:     300,
-						},
-					}
-
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(gateway.Spec.Listeners).NotTo(BeNil())
-					// add another listener, should result in 4 probes
-					typedHostname := gatewayv1beta1.Hostname(OtherAttachedRouteName)
-					otherListener := gatewayv1beta1.Listener{
-						Name:     gatewayv1beta1.SectionName(OtherAttachedRouteName),
-						Hostname: &typedHostname,
-						Port:     gatewayv1beta1.PortNumber(80),
-						Protocol: gatewayv1beta1.HTTPProtocolType,
-					}
-
-					patch := client.MergeFrom(gateway.DeepCopy())
-					gateway.Spec.Listeners = append(gateway.Spec.Listeners, otherListener)
-					Expect(k8sClient.Patch(ctx, gateway, patch)).To(BeNil())
-
-					probeList := &v1alpha1.DNSHealthCheckProbeList{}
-					Eventually(func() error {
-						Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
-						if len(probeList.Items) != 4 {
-							return fmt.Errorf("expected %v probes, got %v", 4, len(probeList.Items))
-						}
-						return nil
-					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
-					Expect(len(probeList.Items)).To(Equal(4))
-
-					//
-					Eventually(func() error {
-						getProbe := &v1alpha1.DNSHealthCheckProbe{}
-						if err = k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-%s-%s", TestAttachedRouteAddressOne, TestPlacedGatewayName, OtherAttachedRouteName), Namespace: testNamespace}, getProbe); err != nil {
-							return err
-						}
-						patch := client.MergeFrom(getProbe.DeepCopy())
-						unhealthy = false
-						getProbe.Status = v1alpha1.DNSHealthCheckProbeStatus{
-							LastCheckedAt:       metav1.NewTime(time.Now()),
-							ConsecutiveFailures: *getProbe.Spec.FailureThreshold + 1,
-							Healthy:             &unhealthy,
-						}
-						if err = k8sClient.Status().Patch(ctx, getProbe, patch); err != nil {
-							return err
-						}
-						return nil
-					}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
-
-					// after that verify that in time the endpoints are 5 in the dnsrecord
-					createdDNSRecord := &v1alpha1.DNSRecord{}
-					Eventually(func() error {
-						err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsRecordName, Namespace: testNamespace}, createdDNSRecord)
-						if err != nil && k8serrors.IsNotFound(err) {
-							return err
-						}
-						return nil
-					}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-					Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
-					Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
-					Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
-				})
-			})
-		})
-	})
-
-	Context("gateway not placed", func() {
-		var gateway *gatewayv1beta1.Gateway
-		var dnsPolicy *v1alpha1.DNSPolicy
-		testGatewayName := "test-not-placed-gateway"
-
-		BeforeEach(func() {
-			gateway = testBuildGateway(testGatewayName, testutil.DummyCRName, TestAttachedRouteName, testNamespace, "test-dns-policy")
-			dnsPolicy = testBuildDNSPolicyWithHealthCheck("test-dns-policy", testGatewayName, testNamespace, nil)
+			gateway = testutil.NewGatewayBuilder(testGatewayName, gatewayClass.Name, testNamespace).
+				WithHTTPListener(TestListenerNameOne, TestHostOne).
+				WithHTTPListener(TestListenerNameWildcard, TestHostWildcard).
+				Gateway
+			dnsPolicy = dnsPolicyBuilder.
+				WithTargetGateway(testGatewayName).
+				WithRoutingStrategy(v1alpha1.SimpleRoutingStrategy).
+				DNSPolicy
 
 			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
 			Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
-
-			Eventually(func() error {
-				return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
-			}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
 
 			Eventually(func() error { //gateway exists
 				return k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
@@ -1423,11 +206,6 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 			Eventually(func() error { //dns policy exists
 				return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
 			}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
-		})
-
-		AfterEach(func() {
-			err := k8sClient.Delete(ctx, gateway)
-			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should not create a dns record", func() {
@@ -1494,4 +272,1245 @@ var _ = Describe("DNSPolicy", Ordered, func() {
 			}, time.Second*5, time.Second).Should(BeNil())
 		})
 	})
+
+	Context("multi cluster gateway status", func() {
+		var lbHash, recordName, wildcardRecordName string
+
+		BeforeEach(func() {
+			gateway = testutil.NewGatewayBuilder(TestGatewayName, gatewayClass.Name, testNamespace).
+				WithHTTPListener(TestListenerNameOne, TestHostOne).
+				WithHTTPListener(TestListenerNameWildcard, TestHostWildcard).
+				Gateway
+			dnsPolicyBuilder.WithTargetGateway(TestGatewayName)
+			lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
+			recordName = fmt.Sprintf("%s-%s", TestGatewayName, TestListenerNameOne)
+			wildcardRecordName = fmt.Sprintf("%s-%s", TestGatewayName, TestListenerNameWildcard)
+			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
+			Eventually(func() error { //gateway exists
+				return k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
+			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
+			Eventually(func() error {
+				if err := k8sClient.Create(ctx, &v1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: TestClusterNameOne,
+					},
+				}); err != nil && !k8serrors.IsAlreadyExists(err) {
+					return err
+				}
+				if err := k8sClient.Create(ctx, &v1.ManagedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: TestClusterNameTwo,
+					},
+				}); err != nil && !k8serrors.IsAlreadyExists(err) {
+					return err
+				}
+				gateway.Status.Addresses = []gatewayv1beta1.GatewayAddress{
+					{
+						Type:  testutil.Pointer(mgcgateway.MultiClusterIPAddressType),
+						Value: TestClusterNameOne + "/" + TestIPAddressOne,
+					},
+					{
+						Type:  testutil.Pointer(mgcgateway.MultiClusterIPAddressType),
+						Value: TestClusterNameTwo + "/" + TestIPAddressTwo,
+					},
+				}
+				gateway.Status.Listeners = []gatewayv1beta1.ListenerStatus{
+					{
+						Name:           TestClusterNameOne + "." + TestListenerNameOne,
+						SupportedKinds: []gatewayv1beta1.RouteGroupKind{},
+						AttachedRoutes: 1,
+						Conditions:     []metav1.Condition{},
+					},
+					{
+						Name:           TestClusterNameTwo + "." + TestListenerNameOne,
+						SupportedKinds: []gatewayv1beta1.RouteGroupKind{},
+						AttachedRoutes: 1,
+						Conditions:     []metav1.Condition{},
+					},
+					{
+						Name:           TestClusterNameOne + "." + TestListenerNameWildcard,
+						SupportedKinds: []gatewayv1beta1.RouteGroupKind{},
+						AttachedRoutes: 1,
+						Conditions:     []metav1.Condition{},
+					},
+					{
+						Name:           TestClusterNameTwo + "." + TestListenerNameWildcard,
+						SupportedKinds: []gatewayv1beta1.RouteGroupKind{},
+						AttachedRoutes: 1,
+						Conditions:     []metav1.Condition{},
+					},
+				}
+				return k8sClient.Status().Update(ctx, gateway)
+			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			dnsRecordList := &v1alpha1.DNSRecordList{}
+			err := k8sClient.List(ctx, dnsRecordList)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, record := range dnsRecordList.Items {
+				err := k8sClient.Delete(ctx, &record)
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+			}
+		})
+
+		Context("simple routing strategy", func() {
+
+			BeforeEach(func() {
+				dnsPolicyBuilder.WithRoutingStrategy(v1alpha1.SimpleRoutingStrategy)
+				dnsPolicy = dnsPolicyBuilder.DNSPolicy
+				Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
+				Eventually(func() error { //dns policy exists
+					return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
+				}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
+			})
+
+			It("should create dns records", func() {
+				Eventually(func(g Gomega, ctx context.Context) {
+					recordList := &v1alpha1.DNSRecordList{}
+					err := k8sClient.List(ctx, recordList, &client.ListOptions{Namespace: testNamespace})
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(recordList.Items).To(HaveLen(2))
+					g.Expect(recordList.Items).To(
+						ContainElements(
+							MatchFields(IgnoreExtras, Fields{
+								"ObjectMeta": HaveField("Name", recordName),
+								"Spec": MatchFields(IgnoreExtras, Fields{
+									"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+									"Endpoints": ConsistOf(
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":       Equal(TestHostOne),
+											"Targets":       ContainElements(TestIPAddressOne, TestIPAddressTwo),
+											"RecordType":    Equal("A"),
+											"SetIdentifier": Equal(""),
+											"RecordTTL":     Equal(v1alpha1.TTL(60)),
+										})),
+									),
+								}),
+							}),
+							MatchFields(IgnoreExtras, Fields{
+								"ObjectMeta": HaveField("Name", wildcardRecordName),
+								"Spec": MatchFields(IgnoreExtras, Fields{
+									"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+									"Endpoints": ConsistOf(
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":       Equal(TestHostWildcard),
+											"Targets":       ContainElements(TestIPAddressOne, TestIPAddressTwo),
+											"RecordType":    Equal("A"),
+											"SetIdentifier": Equal(""),
+											"RecordTTL":     Equal(v1alpha1.TTL(60)),
+										})),
+									),
+								}),
+							}),
+						))
+				}, TestTimeoutMedium, TestRetryIntervalMedium, ctx).Should(Succeed())
+			})
+
+		})
+
+		Context("loadbalanced routing strategy", func() {
+
+			BeforeEach(func() {
+				dnsPolicyBuilder.WithRoutingStrategy(v1alpha1.LoadBalancedRoutingStrategy)
+			})
+
+			Context("weighted", func() {
+
+				BeforeEach(func() {
+					dnsPolicyBuilder.WithLoadBalancingWeightedFor(120, nil)
+					dnsPolicy = dnsPolicyBuilder.DNSPolicy
+					Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
+					Eventually(func() error { //dns policy exists
+						return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
+					}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
+				})
+
+				It("should create dns records", func() {
+					Eventually(func(g Gomega, ctx context.Context) {
+						recordList := &v1alpha1.DNSRecordList{}
+						err := k8sClient.List(ctx, recordList, &client.ListOptions{Namespace: testNamespace})
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(recordList.Items).To(HaveLen(2))
+						g.Expect(recordList.Items).To(
+							ContainElements(
+								MatchFields(IgnoreExtras, Fields{
+									"ObjectMeta": HaveField("Name", recordName),
+									"Spec": MatchFields(IgnoreExtras, Fields{
+										"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+										"Endpoints": ConsistOf(
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal("2w705o.lb-" + lbHash + ".test.example.com"),
+												"Targets":       ConsistOf(TestIPAddressTwo),
+												"RecordType":    Equal("A"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(60)),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("default.lb-" + lbHash + ".test.example.com"),
+												"Targets":          ConsistOf("2w705o.lb-" + lbHash + ".test.example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("2w705o.lb-" + lbHash + ".test.example.com"),
+												"RecordTTL":        Equal(v1alpha1.TTL(60)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("default.lb-" + lbHash + ".test.example.com"),
+												"Targets":          ConsistOf("s07c46.lb-" + lbHash + ".test.example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("s07c46.lb-" + lbHash + ".test.example.com"),
+												"RecordTTL":        Equal(v1alpha1.TTL(60)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal("s07c46.lb-" + lbHash + ".test.example.com"),
+												"Targets":       ConsistOf(TestIPAddressOne),
+												"RecordType":    Equal("A"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(60)),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("lb-" + lbHash + ".test.example.com"),
+												"Targets":          ConsistOf("default.lb-" + lbHash + ".test.example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("default"),
+												"RecordTTL":        Equal(v1alpha1.TTL(300)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal(TestHostOne),
+												"Targets":       ConsistOf("lb-" + lbHash + ".test.example.com"),
+												"RecordType":    Equal("CNAME"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(300)),
+											})),
+										),
+									}),
+								}),
+								MatchFields(IgnoreExtras, Fields{
+									"ObjectMeta": HaveField("Name", wildcardRecordName),
+									"Spec": MatchFields(IgnoreExtras, Fields{
+										"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+										"Endpoints": ConsistOf(
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal("2w705o.lb-" + lbHash + ".example.com"),
+												"Targets":       ConsistOf(TestIPAddressTwo),
+												"RecordType":    Equal("A"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(60)),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("default.lb-" + lbHash + ".example.com"),
+												"Targets":          ConsistOf("2w705o.lb-" + lbHash + ".example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("2w705o.lb-" + lbHash + ".example.com"),
+												"RecordTTL":        Equal(v1alpha1.TTL(60)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("default.lb-" + lbHash + ".example.com"),
+												"Targets":          ConsistOf("s07c46.lb-" + lbHash + ".example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("s07c46.lb-" + lbHash + ".example.com"),
+												"RecordTTL":        Equal(v1alpha1.TTL(60)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal("s07c46.lb-" + lbHash + ".example.com"),
+												"Targets":       ConsistOf(TestIPAddressOne),
+												"RecordType":    Equal("A"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(60)),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("lb-" + lbHash + ".example.com"),
+												"Targets":          ConsistOf("default.lb-" + lbHash + ".example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("default"),
+												"RecordTTL":        Equal(v1alpha1.TTL(300)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal(TestHostWildcard),
+												"Targets":       ConsistOf("lb-" + lbHash + ".example.com"),
+												"RecordType":    Equal("CNAME"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(300)),
+											})),
+										),
+									}),
+								}),
+							))
+					}, TestTimeoutMedium, TestRetryIntervalMedium, ctx).Should(Succeed())
+				})
+
+				It("should have correct status", func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
+							return err
+						}
+						if !meta.IsStatusConditionTrue(dnsPolicy.Status.Conditions, string(conditions.ConditionTypeReady)) {
+							return fmt.Errorf("expected status condition %s to be True", conditions.ConditionTypeReady)
+						}
+						if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(gateway), gateway); err != nil {
+							return err
+						}
+
+						policyAffectedCond := meta.FindStatusCondition(gateway.Status.Conditions, string(DNSPolicyAffected))
+						if policyAffectedCond == nil {
+							return fmt.Errorf("policy affected conditon expected but not found")
+						}
+						if policyAffectedCond.ObservedGeneration != gateway.Generation {
+							return fmt.Errorf("expected policy affected cond generation to be %d but got %d", gateway.Generation, policyAffectedCond.ObservedGeneration)
+						}
+						if !meta.IsStatusConditionTrue(gateway.Status.Conditions, string(DNSPolicyAffected)) {
+							return fmt.Errorf("expected gateway status condition %s to be True", DNSPolicyAffected)
+						}
+
+						return nil
+					}, time.Second*15, time.Second).Should(BeNil())
+				})
+
+				It("should set gateway back reference", func() {
+					existingGateway := &gatewayv1beta1.Gateway{}
+					policyBackRefValue := testNamespace + "/" + dnsPolicy.Name
+					refs, _ := json.Marshal([]client.ObjectKey{{Name: dnsPolicy.Name, Namespace: testNamespace}})
+					policiesBackRefValue := string(refs)
+
+					Eventually(func() map[string]string {
+						// Check gateway back references
+						err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
+						// must exist
+						Expect(err).ToNot(HaveOccurred())
+						return existingGateway.GetAnnotations()
+					}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPolicyBackRefAnnotation, policyBackRefValue))
+					Eventually(func() map[string]string {
+						// Check gateway back references
+						err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
+						// must exist
+						Expect(err).ToNot(HaveOccurred())
+						return existingGateway.GetAnnotations()
+					}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPoliciesBackRefAnnotation, policiesBackRefValue))
+				})
+
+				It("should remove dns records when listener removed", func() {
+					//get the gateway and remove the listeners
+
+					Eventually(func() error {
+						existingGateway := &gatewayv1beta1.Gateway{}
+						if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(gateway), existingGateway); err != nil {
+							return err
+						}
+						newListeners := []gatewayv1beta1.Listener{}
+						for _, existing := range existingGateway.Spec.Listeners {
+							if existing.Name == TestListenerNameWildcard {
+								newListeners = append(newListeners, existing)
+							}
+						}
+
+						patch := client.MergeFrom(existingGateway.DeepCopy())
+						existingGateway.Spec.Listeners = newListeners
+						rec := &v1alpha1.DNSRecord{}
+						if err := k8sClient.Patch(ctx, existingGateway, patch); err != nil {
+							return err
+						}
+						//dns record should be removed for non wildcard
+						if err := k8sClient.Get(ctx, client.ObjectKey{Name: recordName, Namespace: testNamespace}, rec); err != nil && !k8serrors.IsNotFound(err) {
+							return err
+						}
+						return k8sClient.Get(ctx, client.ObjectKey{Name: wildcardRecordName, Namespace: testNamespace}, rec)
+					}, time.Second*10, time.Second).Should(BeNil())
+				})
+
+				It("should remove gateway back reference on policy deletion", func() {
+					existingGateway := &gatewayv1beta1.Gateway{}
+					policyBackRefValue := testNamespace + "/" + dnsPolicy.Name
+					refs, _ := json.Marshal([]client.ObjectKey{{Name: dnsPolicy.Name, Namespace: testNamespace}})
+					policiesBackRefValue := string(refs)
+
+					Eventually(func() map[string]string {
+						// Check gateway back references
+						err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
+						// must exist
+						Expect(err).ToNot(HaveOccurred())
+						return existingGateway.GetAnnotations()
+					}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPolicyBackRefAnnotation, policyBackRefValue))
+					Eventually(func() map[string]string {
+						// Check gateway back references
+						err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
+						// must exist
+						Expect(err).ToNot(HaveOccurred())
+						return existingGateway.GetAnnotations()
+					}, time.Second*5, time.Second).Should(HaveKeyWithValue(DNSPoliciesBackRefAnnotation, policiesBackRefValue))
+
+					//finalizer should exist
+					Eventually(func() bool {
+						existingDNSPolicy := &v1alpha1.DNSPolicy{}
+						err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: testNamespace}, existingDNSPolicy)
+						// must exist
+						Expect(err).ToNot(HaveOccurred())
+						return metadata.HasFinalizer(existingDNSPolicy, DNSPolicyFinalizer)
+					}, time.Second*5, time.Second).Should(BeTrue())
+
+					Expect(k8sClient.Delete(ctx, dnsPolicy)).To(BeNil())
+
+					Eventually(func() map[string]string {
+						// Check gateway back references
+						err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, existingGateway)
+						// must exist
+						Expect(err).ToNot(HaveOccurred())
+						return existingGateway.GetAnnotations()
+					}, time.Second*5, time.Second).ShouldNot(HaveKey(DNSPolicyBackRefAnnotation))
+
+					Eventually(func() map[string]string {
+						// Check gateway back references
+						err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway)
+						// must exist
+						Expect(err).ToNot(HaveOccurred())
+						return existingGateway.GetAnnotations()
+					}, time.Second*5, time.Second).ShouldNot(HaveKeyWithValue(DNSPoliciesBackRefAnnotation, policiesBackRefValue))
+
+					Eventually(func() error {
+						// Check gateway back references
+						if err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: testNamespace}, existingGateway); err != nil {
+							return err
+						}
+						cond := meta.FindStatusCondition(existingGateway.Status.Conditions, string(DNSPolicyAffected))
+						if cond != nil {
+							return fmt.Errorf("expected the condition %s to be gone", DNSPolicyAffected)
+						}
+						return nil
+					}, time.Second*5, time.Second).Should(BeNil())
+				})
+
+				It("should remove dns record reference on policy deletion even if gateway is removed", func() {
+					createdDNSRecord := &v1alpha1.DNSRecord{}
+					Eventually(func() error { // DNS record exists
+						if err := k8sClient.Get(ctx, client.ObjectKey{Name: recordName, Namespace: testNamespace}, createdDNSRecord); err != nil {
+							return err
+						}
+						return nil
+					}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+
+					err := k8sClient.Delete(ctx, gateway)
+					Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+					err = k8sClient.Delete(ctx, dnsPolicy)
+					Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+					Eventually(func() error { // DNS record removed
+						if err := k8sClient.Get(ctx, client.ObjectKey{Name: recordName, Namespace: testNamespace}, createdDNSRecord); err != nil {
+							if k8serrors.IsNotFound(err) {
+								return nil
+							}
+							return err
+						}
+						return errors.New("found dnsrecord when it should be deleted")
+					}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+				})
+
+			})
+
+			Context("geo+weighted", func() {
+
+				BeforeEach(func() {
+					dnsPolicyBuilder.
+						WithLoadBalancingWeightedFor(120, nil).
+						WithLoadBalancingGeoFor("IE")
+					dnsPolicy = dnsPolicyBuilder.DNSPolicy
+					Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
+					Eventually(func() error { //dns policy exists
+						if err := k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy); err != nil {
+							return err
+						}
+						return nil
+					}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+				})
+
+				It("should create dns records", func() {
+					Eventually(func(g Gomega, ctx context.Context) {
+						recordList := &v1alpha1.DNSRecordList{}
+						err := k8sClient.List(ctx, recordList, &client.ListOptions{Namespace: testNamespace})
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(recordList.Items).To(HaveLen(2))
+						g.Expect(recordList.Items).To(
+							ContainElements(
+								MatchFields(IgnoreExtras, Fields{
+									"ObjectMeta": HaveField("Name", recordName),
+									"Spec": MatchFields(IgnoreExtras, Fields{
+										"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+										"Endpoints": ConsistOf(
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal("2w705o.lb-" + lbHash + ".test.example.com"),
+												"Targets":       ConsistOf(TestIPAddressTwo),
+												"RecordType":    Equal("A"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(60)),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("ie.lb-" + lbHash + ".test.example.com"),
+												"Targets":          ConsistOf("2w705o.lb-" + lbHash + ".test.example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("2w705o.lb-" + lbHash + ".test.example.com"),
+												"RecordTTL":        Equal(v1alpha1.TTL(60)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("ie.lb-" + lbHash + ".test.example.com"),
+												"Targets":          ConsistOf("s07c46.lb-" + lbHash + ".test.example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("s07c46.lb-" + lbHash + ".test.example.com"),
+												"RecordTTL":        Equal(v1alpha1.TTL(60)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal("s07c46.lb-" + lbHash + ".test.example.com"),
+												"Targets":       ConsistOf(TestIPAddressOne),
+												"RecordType":    Equal("A"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(60)),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("lb-" + lbHash + ".test.example.com"),
+												"Targets":          ConsistOf("ie.lb-" + lbHash + ".test.example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("IE"),
+												"RecordTTL":        Equal(v1alpha1.TTL(300)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "geo-code", Value: "IE"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("lb-" + lbHash + ".test.example.com"),
+												"Targets":          ConsistOf("ie.lb-" + lbHash + ".test.example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("default"),
+												"RecordTTL":        Equal(v1alpha1.TTL(300)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal(TestHostOne),
+												"Targets":       ConsistOf("lb-" + lbHash + ".test.example.com"),
+												"RecordType":    Equal("CNAME"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(300)),
+											})),
+										),
+									}),
+								}),
+								MatchFields(IgnoreExtras, Fields{
+									"ObjectMeta": HaveField("Name", wildcardRecordName),
+									"Spec": MatchFields(IgnoreExtras, Fields{
+										"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+										"Endpoints": ConsistOf(
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal("2w705o.lb-" + lbHash + ".example.com"),
+												"Targets":       ConsistOf(TestIPAddressTwo),
+												"RecordType":    Equal("A"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(60)),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("ie.lb-" + lbHash + ".example.com"),
+												"Targets":          ConsistOf("2w705o.lb-" + lbHash + ".example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("2w705o.lb-" + lbHash + ".example.com"),
+												"RecordTTL":        Equal(v1alpha1.TTL(60)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("ie.lb-" + lbHash + ".example.com"),
+												"Targets":          ConsistOf("s07c46.lb-" + lbHash + ".example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("s07c46.lb-" + lbHash + ".example.com"),
+												"RecordTTL":        Equal(v1alpha1.TTL(60)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal("s07c46.lb-" + lbHash + ".example.com"),
+												"Targets":       ConsistOf(TestIPAddressOne),
+												"RecordType":    Equal("A"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(60)),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("lb-" + lbHash + ".example.com"),
+												"Targets":          ConsistOf("ie.lb-" + lbHash + ".example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("IE"),
+												"RecordTTL":        Equal(v1alpha1.TTL(300)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "geo-code", Value: "IE"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":          Equal("lb-" + lbHash + ".example.com"),
+												"Targets":          ConsistOf("ie.lb-" + lbHash + ".example.com"),
+												"RecordType":       Equal("CNAME"),
+												"SetIdentifier":    Equal("default"),
+												"RecordTTL":        Equal(v1alpha1.TTL(300)),
+												"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+											})),
+											PointTo(MatchFields(IgnoreExtras, Fields{
+												"DNSName":       Equal(TestHostWildcard),
+												"Targets":       ConsistOf("lb-" + lbHash + ".example.com"),
+												"RecordType":    Equal("CNAME"),
+												"SetIdentifier": Equal(""),
+												"RecordTTL":     Equal(v1alpha1.TTL(300)),
+											})),
+										),
+									}),
+								}),
+							))
+					}, TestTimeoutMedium, TestRetryIntervalMedium, ctx).Should(Succeed())
+				})
+
+			})
+
+			Context("with health checks", func() {
+				var unhealthy bool
+
+				BeforeEach(func() {
+					dnsPolicyBuilder.
+						WithLoadBalancingWeightedFor(120, nil).
+						WithHealthCheckFor("/", nil, v1alpha1.HttpProtocol, testutil.Pointer(4))
+					dnsPolicy = dnsPolicyBuilder.DNSPolicy
+					Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
+					Eventually(func() error { //dns policy exists
+						return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
+					}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
+				})
+
+				It("should create a dns record", func() {
+					createdDNSRecord := &v1alpha1.DNSRecord{}
+					Eventually(func() error { // DNS record exists
+						if err := k8sClient.Get(ctx, client.ObjectKey{Name: recordName, Namespace: testNamespace}, createdDNSRecord); err != nil {
+							return err
+						}
+						if len(createdDNSRecord.Spec.Endpoints) != 6 {
+							return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", 6, len(createdDNSRecord.Spec.Endpoints))
+						}
+						return nil
+					}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+					Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(6))
+				})
+				It("should have probes that are healthy", func() {
+					probeList := &v1alpha1.DNSHealthCheckProbeList{}
+					Eventually(func() error {
+						Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
+						if len(probeList.Items) != 2 {
+							return fmt.Errorf("expected %v probes, got %v", 2, len(probeList.Items))
+						}
+						return nil
+					}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+					Expect(len(probeList.Items)).To(Equal(2))
+				})
+
+				Context("all unhealthy probes", func() {
+					It("should publish all dns records endpoints", func() {
+						lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
+
+						expectedEndpoints := []*v1alpha1.Endpoint{
+							{
+								DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									TestIPAddressTwo,
+								},
+								RecordType:    "A",
+								SetIdentifier: "",
+								RecordTTL:     60,
+							},
+							{
+								DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									TestIPAddressOne,
+								},
+								RecordType:    "A",
+								SetIdentifier: "",
+								RecordTTL:     60,
+							},
+							{
+								DNSName: "default.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									"2w705o.lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
+								RecordTTL:     60,
+								ProviderSpecific: v1alpha1.ProviderSpecific{
+									{
+										Name:  "weight",
+										Value: "120",
+									},
+								},
+							},
+							{
+								DNSName: "default.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									"s07c46.lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
+								RecordTTL:     60,
+								Labels:        nil,
+								ProviderSpecific: v1alpha1.ProviderSpecific{
+									{
+										Name:  "weight",
+										Value: "120",
+									},
+								},
+							},
+							{
+								DNSName: "lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									"default.lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "default",
+								RecordTTL:     300,
+								ProviderSpecific: v1alpha1.ProviderSpecific{
+									{
+										Name:  "geo-code",
+										Value: "*",
+									},
+								},
+							},
+							{
+								DNSName: "test.example.com",
+								Targets: []string{
+									"lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "",
+								RecordTTL:     300,
+							},
+						}
+
+						probeList := &v1alpha1.DNSHealthCheckProbeList{}
+						Eventually(func() error {
+							Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
+							if len(probeList.Items) != 2 {
+								return fmt.Errorf("expected %v probes, got %v", 2, len(probeList.Items))
+							}
+							return nil
+						}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
+
+						for _, probe := range probeList.Items {
+							Eventually(func() error {
+								if probe.Name == fmt.Sprintf("%s-%s-%s", TestIPAddressTwo, TestGatewayName, TestHostOne) ||
+									probe.Name == fmt.Sprintf("%s-%s-%s", TestIPAddressOne, TestGatewayName, TestHostOne) {
+									getProbe := &v1alpha1.DNSHealthCheckProbe{}
+									if err := k8sClient.Get(ctx, client.ObjectKey{Name: probe.Name, Namespace: probe.Namespace}, getProbe); err != nil {
+										return err
+									}
+									patch := client.MergeFrom(getProbe.DeepCopy())
+									unhealthy = false
+									getProbe.Status = v1alpha1.DNSHealthCheckProbeStatus{
+										LastCheckedAt:       metav1.NewTime(time.Now()),
+										ConsecutiveFailures: *getProbe.Spec.FailureThreshold + 1,
+										Healthy:             &unhealthy,
+									}
+									if err := k8sClient.Status().Patch(ctx, getProbe, patch); err != nil {
+										return err
+									}
+								}
+								return nil
+							}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+						}
+						createdDNSRecord := &v1alpha1.DNSRecord{}
+						Eventually(func() error {
+
+							err := k8sClient.Get(ctx, client.ObjectKey{Name: recordName, Namespace: testNamespace}, createdDNSRecord)
+							if err != nil && k8serrors.IsNotFound(err) {
+								return err
+							}
+							if len(createdDNSRecord.Spec.Endpoints) != len(expectedEndpoints) {
+								return fmt.Errorf("expected %v endpoints in DNSRecord, got %v", len(expectedEndpoints), len(createdDNSRecord.Spec.Endpoints))
+							}
+							return nil
+						}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
+						Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
+						Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
+						Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
+
+					})
+				})
+				Context("some unhealthy probes", func() {
+					It("should publish expected endpoints", func() {
+						lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
+
+						expectedEndpoints := []*v1alpha1.Endpoint{
+							{
+								DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									TestIPAddressTwo,
+								},
+								RecordType:    "A",
+								SetIdentifier: "",
+								RecordTTL:     60,
+							},
+							{
+								DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									TestIPAddressOne,
+								},
+								RecordType:    "A",
+								SetIdentifier: "",
+								RecordTTL:     60,
+							},
+							{
+								DNSName: "default.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									"2w705o.lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
+								RecordTTL:     60,
+								ProviderSpecific: v1alpha1.ProviderSpecific{
+									{
+										Name:  "weight",
+										Value: "120",
+									},
+								},
+							},
+							{
+								DNSName: "default.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									"s07c46.lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
+								RecordTTL:     60,
+								Labels:        nil,
+								ProviderSpecific: v1alpha1.ProviderSpecific{
+									{
+										Name:  "weight",
+										Value: "120",
+									},
+								},
+							},
+							{
+								DNSName: "lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									"default.lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "default",
+								RecordTTL:     300,
+								ProviderSpecific: v1alpha1.ProviderSpecific{
+									{
+										Name:  "geo-code",
+										Value: "*",
+									},
+								},
+							},
+							{
+								DNSName: "test.example.com",
+								Targets: []string{
+									"lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "",
+								RecordTTL:     300,
+							},
+						}
+
+						probeList := &v1alpha1.DNSHealthCheckProbeList{}
+						Eventually(func() error {
+							Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
+							if len(probeList.Items) != 2 {
+								return fmt.Errorf("expected %v probes, got %v", 2, len(probeList.Items))
+							}
+							return nil
+						}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
+						Expect(probeList.Items).To(HaveLen(2))
+
+						Eventually(func() error {
+							getProbe := &v1alpha1.DNSHealthCheckProbe{}
+							if err := k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-%s-%s", TestIPAddressOne, TestGatewayName, TestListenerNameOne), Namespace: testNamespace}, getProbe); err != nil {
+								return err
+							}
+							patch := client.MergeFrom(getProbe.DeepCopy())
+							unhealthy = false
+							getProbe.Status = v1alpha1.DNSHealthCheckProbeStatus{
+								LastCheckedAt:       metav1.NewTime(time.Now()),
+								ConsecutiveFailures: *getProbe.Spec.FailureThreshold + 1,
+								Healthy:             &unhealthy,
+							}
+							if err := k8sClient.Status().Patch(ctx, getProbe, patch); err != nil {
+								return err
+							}
+							return nil
+						}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
+
+						// after that verify that in time the endpoints are 5 in the dnsrecord
+						createdDNSRecord := &v1alpha1.DNSRecord{}
+						Eventually(func() error {
+							err := k8sClient.Get(ctx, client.ObjectKey{Name: recordName, Namespace: testNamespace}, createdDNSRecord)
+							if err != nil && k8serrors.IsNotFound(err) {
+								return err
+							}
+							return nil
+						}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+						Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
+						Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
+						Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
+					})
+				})
+				Context("some unhealthy endpoints for other listener", func() {
+					It("should publish expected endpoints", func() {
+						lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
+
+						expectedEndpoints := []*v1alpha1.Endpoint{
+							{
+								DNSName: "2w705o.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									TestIPAddressTwo,
+								},
+								RecordType:    "A",
+								SetIdentifier: "",
+								RecordTTL:     60,
+							},
+							{
+								DNSName: "s07c46.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									TestIPAddressOne,
+								},
+								RecordType:    "A",
+								SetIdentifier: "",
+								RecordTTL:     60,
+							},
+							{
+								DNSName: "default.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									"2w705o.lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "2w705o.lb-" + lbHash + ".test.example.com",
+								RecordTTL:     60,
+								ProviderSpecific: v1alpha1.ProviderSpecific{
+									{
+										Name:  "weight",
+										Value: "120",
+									},
+								},
+							},
+							{
+								DNSName: "default.lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									"s07c46.lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "s07c46.lb-" + lbHash + ".test.example.com",
+								RecordTTL:     60,
+								Labels:        nil,
+								ProviderSpecific: v1alpha1.ProviderSpecific{
+									{
+										Name:  "weight",
+										Value: "120",
+									},
+								},
+							},
+							{
+								DNSName: "lb-" + lbHash + ".test.example.com",
+								Targets: []string{
+									"default.lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "default",
+								RecordTTL:     300,
+								ProviderSpecific: v1alpha1.ProviderSpecific{
+									{
+										Name:  "geo-code",
+										Value: "*",
+									},
+								},
+							},
+							{
+								DNSName: "test.example.com",
+								Targets: []string{
+									"lb-" + lbHash + ".test.example.com",
+								},
+								RecordType:    "CNAME",
+								SetIdentifier: "",
+								RecordTTL:     300,
+							},
+						}
+
+						err := k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(gateway.Spec.Listeners).NotTo(BeNil())
+						// add another listener, should result in 4 probes
+						typedHostname := gatewayv1beta1.Hostname(TestHostTwo)
+						otherListener := gatewayv1beta1.Listener{
+							Name:     gatewayv1beta1.SectionName(TestListenerNameTwo),
+							Hostname: &typedHostname,
+							Port:     gatewayv1beta1.PortNumber(80),
+							Protocol: gatewayv1beta1.HTTPProtocolType,
+						}
+
+						patch := client.MergeFrom(gateway.DeepCopy())
+						gateway.Spec.Listeners = append(gateway.Spec.Listeners, otherListener)
+						Expect(k8sClient.Patch(ctx, gateway, patch)).To(BeNil())
+
+						probeList := &v1alpha1.DNSHealthCheckProbeList{}
+						Eventually(func() error {
+							Expect(k8sClient.List(ctx, probeList, &client.ListOptions{Namespace: testNamespace})).To(BeNil())
+							if len(probeList.Items) != 4 {
+								return fmt.Errorf("expected %v probes, got %v", 4, len(probeList.Items))
+							}
+							return nil
+						}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
+						Expect(len(probeList.Items)).To(Equal(4))
+
+						//
+						Eventually(func() error {
+							getProbe := &v1alpha1.DNSHealthCheckProbe{}
+							if err = k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-%s-%s", TestIPAddressOne, TestGatewayName, TestListenerNameTwo), Namespace: testNamespace}, getProbe); err != nil {
+								return err
+							}
+							patch := client.MergeFrom(getProbe.DeepCopy())
+							unhealthy = false
+							getProbe.Status = v1alpha1.DNSHealthCheckProbeStatus{
+								LastCheckedAt:       metav1.NewTime(time.Now()),
+								ConsecutiveFailures: *getProbe.Spec.FailureThreshold + 1,
+								Healthy:             &unhealthy,
+							}
+							if err = k8sClient.Status().Patch(ctx, getProbe, patch); err != nil {
+								return err
+							}
+							return nil
+						}, TestTimeoutLong, TestRetryIntervalMedium).Should(BeNil())
+
+						// after that verify that in time the endpoints are 5 in the dnsrecord
+						createdDNSRecord := &v1alpha1.DNSRecord{}
+						Eventually(func() error {
+							err := k8sClient.Get(ctx, client.ObjectKey{Name: recordName, Namespace: testNamespace}, createdDNSRecord)
+							if err != nil && k8serrors.IsNotFound(err) {
+								return err
+							}
+							return nil
+						}, TestTimeoutMedium, TestRetryIntervalMedium).Should(BeNil())
+						Expect(createdDNSRecord.Spec.Endpoints).To(HaveLen(len(expectedEndpoints)))
+						Expect(createdDNSRecord.Spec.Endpoints).Should(ContainElements(expectedEndpoints))
+						Expect(expectedEndpoints).Should(ContainElements(createdDNSRecord.Spec.Endpoints))
+					})
+				})
+			})
+
+		})
+
+	})
+
+	Context("single cluster gateway status", func() {
+		var lbHash, recordName, wildcardRecordName string
+
+		BeforeEach(func() {
+			gateway = testutil.NewGatewayBuilder(TestGatewayName, gatewayClass.Name, testNamespace).
+				WithHTTPListener(TestListenerNameOne, TestHostOne).
+				WithHTTPListener(TestListenerNameWildcard, TestHostWildcard).
+				Gateway
+			dnsPolicyBuilder.WithTargetGateway(TestGatewayName)
+			lbHash = dns.ToBase36hash(fmt.Sprintf("%s-%s", gateway.Name, gateway.Namespace))
+			recordName = fmt.Sprintf("%s-%s", TestGatewayName, TestListenerNameOne)
+			wildcardRecordName = fmt.Sprintf("%s-%s", TestGatewayName, TestListenerNameWildcard)
+			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
+			Eventually(func() error { //gateway exists
+				return k8sClient.Get(ctx, client.ObjectKey{Name: gateway.Name, Namespace: gateway.Namespace}, gateway)
+			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
+			Eventually(func() error {
+				gateway.Status.Addresses = []gatewayv1beta1.GatewayAddress{
+					{
+						Type:  testutil.Pointer(gatewayv1beta1.IPAddressType),
+						Value: TestIPAddressOne,
+					},
+					{
+						Type:  testutil.Pointer(gatewayv1beta1.IPAddressType),
+						Value: TestIPAddressTwo,
+					},
+				}
+				gateway.Status.Listeners = []gatewayv1beta1.ListenerStatus{
+					{
+						Name:           TestListenerNameOne,
+						SupportedKinds: []gatewayv1beta1.RouteGroupKind{},
+						AttachedRoutes: 1,
+						Conditions:     []metav1.Condition{},
+					},
+					{
+						Name:           TestListenerNameWildcard,
+						SupportedKinds: []gatewayv1beta1.RouteGroupKind{},
+						AttachedRoutes: 1,
+						Conditions:     []metav1.Condition{},
+					},
+				}
+				return k8sClient.Status().Update(ctx, gateway)
+			}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			dnsRecordList := &v1alpha1.DNSRecordList{}
+			err := k8sClient.List(ctx, dnsRecordList)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, record := range dnsRecordList.Items {
+				err := k8sClient.Delete(ctx, &record)
+				Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+			}
+		})
+
+		Context("simple routing strategy", func() {
+
+			BeforeEach(func() {
+				dnsPolicyBuilder.WithRoutingStrategy(v1alpha1.SimpleRoutingStrategy)
+				dnsPolicy = dnsPolicyBuilder.DNSPolicy
+				Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
+				Eventually(func() error { //dns policy exists
+					return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
+				}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
+			})
+
+			It("should create dns records", func() {
+				Eventually(func(g Gomega, ctx context.Context) {
+					recordList := &v1alpha1.DNSRecordList{}
+					err := k8sClient.List(ctx, recordList, &client.ListOptions{Namespace: testNamespace})
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(recordList.Items).To(HaveLen(2))
+					g.Expect(recordList.Items).To(
+						ContainElements(
+							MatchFields(IgnoreExtras, Fields{
+								"ObjectMeta": HaveField("Name", recordName),
+								"Spec": MatchFields(IgnoreExtras, Fields{
+									"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+									"Endpoints": ConsistOf(
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":       Equal(TestHostOne),
+											"Targets":       ContainElements(TestIPAddressOne, TestIPAddressTwo),
+											"RecordType":    Equal("A"),
+											"SetIdentifier": Equal(""),
+											"RecordTTL":     Equal(v1alpha1.TTL(60)),
+										})),
+									),
+								}),
+							}),
+							MatchFields(IgnoreExtras, Fields{
+								"ObjectMeta": HaveField("Name", wildcardRecordName),
+								"Spec": MatchFields(IgnoreExtras, Fields{
+									"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+									"Endpoints": ConsistOf(
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":       Equal(TestHostWildcard),
+											"Targets":       ContainElements(TestIPAddressOne, TestIPAddressTwo),
+											"RecordType":    Equal("A"),
+											"SetIdentifier": Equal(""),
+											"RecordTTL":     Equal(v1alpha1.TTL(60)),
+										})),
+									),
+								}),
+							}),
+						))
+				}, TestTimeoutMedium, TestRetryIntervalMedium, ctx).Should(Succeed())
+			})
+
+		})
+
+		Context("loadbalanced routing strategy", func() {
+
+			BeforeEach(func() {
+				dnsPolicyBuilder.WithRoutingStrategy(v1alpha1.LoadBalancedRoutingStrategy)
+				dnsPolicy = dnsPolicyBuilder.DNSPolicy
+				Expect(k8sClient.Create(ctx, dnsPolicy)).To(BeNil())
+				Eventually(func() error { //dns policy exists
+					return k8sClient.Get(ctx, client.ObjectKey{Name: dnsPolicy.Name, Namespace: dnsPolicy.Namespace}, dnsPolicy)
+				}, TestTimeoutMedium, TestRetryIntervalMedium).ShouldNot(HaveOccurred())
+			})
+
+			It("should create dns records", func() {
+				Eventually(func(g Gomega, ctx context.Context) {
+					recordList := &v1alpha1.DNSRecordList{}
+					err := k8sClient.List(ctx, recordList, &client.ListOptions{Namespace: testNamespace})
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(recordList.Items).To(HaveLen(2))
+					g.Expect(recordList.Items).To(
+						ContainElements(
+							MatchFields(IgnoreExtras, Fields{
+								"ObjectMeta": HaveField("Name", recordName),
+								"Spec": MatchFields(IgnoreExtras, Fields{
+									"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+									"Endpoints": ConsistOf(
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":       Equal("19sc9b.lb-" + lbHash + ".test.example.com"),
+											"Targets":       ConsistOf(TestIPAddressOne, TestIPAddressTwo),
+											"RecordType":    Equal("A"),
+											"SetIdentifier": Equal(""),
+											"RecordTTL":     Equal(v1alpha1.TTL(60)),
+										})),
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":          Equal("default.lb-" + lbHash + ".test.example.com"),
+											"Targets":          ConsistOf("19sc9b.lb-" + lbHash + ".test.example.com"),
+											"RecordType":       Equal("CNAME"),
+											"SetIdentifier":    Equal("19sc9b.lb-" + lbHash + ".test.example.com"),
+											"RecordTTL":        Equal(v1alpha1.TTL(60)),
+											"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+										})),
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":          Equal("lb-" + lbHash + ".test.example.com"),
+											"Targets":          ConsistOf("default.lb-" + lbHash + ".test.example.com"),
+											"RecordType":       Equal("CNAME"),
+											"SetIdentifier":    Equal("default"),
+											"RecordTTL":        Equal(v1alpha1.TTL(300)),
+											"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+										})),
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":       Equal(TestHostOne),
+											"Targets":       ConsistOf("lb-" + lbHash + ".test.example.com"),
+											"RecordType":    Equal("CNAME"),
+											"SetIdentifier": Equal(""),
+											"RecordTTL":     Equal(v1alpha1.TTL(300)),
+										})),
+									),
+								}),
+							}),
+							MatchFields(IgnoreExtras, Fields{
+								"ObjectMeta": HaveField("Name", wildcardRecordName),
+								"Spec": MatchFields(IgnoreExtras, Fields{
+									"ManagedZoneRef": HaveField("Name", "mz-example-com"),
+									"Endpoints": ContainElements(
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":       Equal("19sc9b.lb-" + lbHash + ".example.com"),
+											"Targets":       ConsistOf(TestIPAddressOne, TestIPAddressTwo),
+											"RecordType":    Equal("A"),
+											"SetIdentifier": Equal(""),
+											"RecordTTL":     Equal(v1alpha1.TTL(60)),
+										})),
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":          Equal("default.lb-" + lbHash + ".example.com"),
+											"Targets":          ConsistOf("19sc9b.lb-" + lbHash + ".example.com"),
+											"RecordType":       Equal("CNAME"),
+											"SetIdentifier":    Equal("19sc9b.lb-" + lbHash + ".example.com"),
+											"RecordTTL":        Equal(v1alpha1.TTL(60)),
+											"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "weight", Value: "120"}}),
+										})),
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":          Equal("lb-" + lbHash + ".example.com"),
+											"Targets":          ConsistOf("default.lb-" + lbHash + ".example.com"),
+											"RecordType":       Equal("CNAME"),
+											"SetIdentifier":    Equal("default"),
+											"RecordTTL":        Equal(v1alpha1.TTL(300)),
+											"ProviderSpecific": Equal(v1alpha1.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+										})),
+										PointTo(MatchFields(IgnoreExtras, Fields{
+											"DNSName":       Equal(TestHostWildcard),
+											"Targets":       ConsistOf("lb-" + lbHash + ".example.com"),
+											"RecordType":    Equal("CNAME"),
+											"SetIdentifier": Equal(""),
+											"RecordTTL":     Equal(v1alpha1.TTL(300)),
+										})),
+									),
+								}),
+							}),
+						))
+				}, TestTimeoutMedium, TestRetryIntervalMedium, ctx).Should(Succeed())
+			})
+
+		})
+
+	})
+
 })

--- a/test/policy_integration/dnspolicy_controller_test.go
+++ b/test/policy_integration/dnspolicy_controller_test.go
@@ -131,6 +131,7 @@ func testBuildDNSPolicyWithHealthCheck(policyName, gwName, ns string, threshold 
 			Namespace: ns,
 		},
 		Spec: v1alpha1.DNSPolicySpec{
+			RoutingStrategy: v1alpha1.LoadBalancedRoutingStrategy,
 			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 				Group:     "gateway.networking.k8s.io",
 				Kind:      "Gateway",
@@ -159,6 +160,7 @@ func testBuildDNSPolicyWithGeo(policyName, gwName, ns string) *v1alpha1.DNSPolic
 			Namespace: ns,
 		},
 		Spec: v1alpha1.DNSPolicySpec{
+			RoutingStrategy: v1alpha1.LoadBalancedRoutingStrategy,
 			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 				Group:     "gateway.networking.k8s.io",
 				Kind:      "Gateway",

--- a/test/policy_integration/helper_test.go
+++ b/test/policy_integration/helper_test.go
@@ -10,24 +10,22 @@ import (
 )
 
 const (
-	TestTimeoutMedium            = time.Second * 10
-	TestTimeoutLong              = time.Second * 30
-	ConsistentlyTimeoutMedium    = time.Second * 60
-	TestRetryIntervalMedium      = time.Millisecond * 250
-	TestPlacedGatewayName        = "test-placed-gateway"
-	TestPlacedClusterControlName = "test-placed-control"
-	TestPlaceClusterWorkloadName = "test-placed-workload-1"
-	TestAttachedRouteName        = "test.example.com"
-	OtherAttachedRouteName       = "other.example.com"
-	TestWildCardListenerName     = "wildcard"
-	TestWildCardListenerHost     = "*.example.com"
-	TestAttachedRouteAddressOne  = "172.0.0.1"
-	TestAttachedRouteAddressTwo  = "172.0.0.2"
-	nsSpoke1Name                 = "test-spoke-cluster-1"
-	nsSpoke2Name                 = "test-spoke-cluster-2"
-	defaultNS                    = "default"
-	gatewayFinalizer             = "kuadrant.io/gateway"
-	providerCredential           = "secretname"
+	TestTimeoutMedium        = time.Second * 10
+	TestTimeoutLong          = time.Second * 30
+	TestRetryIntervalMedium  = time.Millisecond * 250
+	TestGatewayName          = "test-placed-gateway"
+	TestClusterNameOne       = "test-placed-control"
+	TestClusterNameTwo       = "test-placed-workload-1"
+	TestHostOne              = "test.example.com"
+	TestHostTwo              = "other.example.com"
+	TestHostWildcard         = "*.example.com"
+	TestListenerNameWildcard = "wildcard"
+	TestListenerNameOne      = "test-listener-1"
+	TestListenerNameTwo      = "test-listener-2"
+	TestIPAddressOne         = "172.0.0.1"
+	TestIPAddressTwo         = "172.0.0.2"
+	defaultNS                = "default"
+	providerCredential       = "secretname"
 )
 
 type testHealthServer struct {

--- a/test/util/test_dnspolicy_types.go
+++ b/test/util/test_dnspolicy_types.go
@@ -1,0 +1,131 @@
+//go:build unit || integration || e2e
+
+package testutil
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
+)
+
+// DNSPolicyBuilder wrapper for DNSPolicy builder helper
+type DNSPolicyBuilder struct {
+	*v1alpha1.DNSPolicy
+}
+
+func NewDNSPolicyBuilder(name, ns string) *DNSPolicyBuilder {
+	return &DNSPolicyBuilder{
+		&v1alpha1.DNSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+			},
+			Spec: v1alpha1.DNSPolicySpec{},
+		},
+	}
+}
+
+func (t *DNSPolicyBuilder) WithTargetRef(targetRef gatewayapiv1alpha2.PolicyTargetReference) *DNSPolicyBuilder {
+	t.Spec.TargetRef = targetRef
+	return t
+}
+
+func (t *DNSPolicyBuilder) WithHealthCheck(healthCheck v1alpha1.HealthCheckSpec) *DNSPolicyBuilder {
+	t.Spec.HealthCheck = &healthCheck
+	return t
+}
+
+func (t *DNSPolicyBuilder) WithLoadBalancing(loadBalancing v1alpha1.LoadBalancingSpec) *DNSPolicyBuilder {
+	t.Spec.LoadBalancing = &loadBalancing
+	return t
+}
+
+func (t *DNSPolicyBuilder) WithRoutingStrategy(strategy v1alpha1.RoutingStrategy) *DNSPolicyBuilder {
+	t.Spec.RoutingStrategy = strategy
+	return t
+}
+
+//TargetRef
+
+func (t *DNSPolicyBuilder) WithTargetGateway(gwName string) *DNSPolicyBuilder {
+	typedNamespace := gatewayv1beta1.Namespace(t.GetNamespace())
+	return t.WithTargetRef(gatewayapiv1alpha2.PolicyTargetReference{
+		Group:     "gateway.networking.k8s.io",
+		Kind:      "Gateway",
+		Name:      gatewayv1beta1.ObjectName(gwName),
+		Namespace: &typedNamespace,
+	})
+}
+
+//HealthCheck
+
+func (t *DNSPolicyBuilder) WithHealthCheckFor(endpoint string, port *int, protocol v1alpha1.HealthProtocol, failureThreshold *int) *DNSPolicyBuilder {
+	return t.WithHealthCheck(v1alpha1.HealthCheckSpec{
+		Endpoint:                  endpoint,
+		Port:                      port,
+		Protocol:                  &protocol,
+		FailureThreshold:          failureThreshold,
+		AdditionalHeadersRef:      nil,
+		ExpectedResponses:         nil,
+		AllowInsecureCertificates: false,
+		Interval:                  nil,
+	})
+}
+
+//LoadBalancing
+
+func (t *DNSPolicyBuilder) WithLoadBalancingWeighted(lbWeighted v1alpha1.LoadBalancingWeighted) *DNSPolicyBuilder {
+	if t.Spec.LoadBalancing == nil {
+		t.Spec.LoadBalancing = &v1alpha1.LoadBalancingSpec{}
+	}
+	t.Spec.LoadBalancing.Weighted = &lbWeighted
+	return t
+}
+
+func (t *DNSPolicyBuilder) WithLoadBalancingGeo(lbGeo v1alpha1.LoadBalancingGeo) *DNSPolicyBuilder {
+	if t.Spec.LoadBalancing == nil {
+		t.Spec.LoadBalancing = &v1alpha1.LoadBalancingSpec{}
+	}
+	t.Spec.LoadBalancing.Geo = &lbGeo
+	return t
+}
+
+func (t *DNSPolicyBuilder) WithLoadBalancingWeightedFor(defaultWeight v1alpha1.Weight, custom []*v1alpha1.CustomWeight) *DNSPolicyBuilder {
+	return t.WithLoadBalancingWeighted(v1alpha1.LoadBalancingWeighted{
+		DefaultWeight: defaultWeight,
+		Custom:        custom,
+	})
+}
+
+func (t *DNSPolicyBuilder) WithLoadBalancingGeoFor(defaultGeo string) *DNSPolicyBuilder {
+	return t.WithLoadBalancingGeo(v1alpha1.LoadBalancingGeo{
+		DefaultGeo: defaultGeo,
+	})
+}
+
+// ManagedZoneBuilder wrapper for ManagedZone builder helper
+type ManagedZoneBuilder struct {
+	*v1alpha1.ManagedZone
+}
+
+func NewManagedZoneBuilder(name, ns, domainName string) *ManagedZoneBuilder {
+	return &ManagedZoneBuilder{
+		&v1alpha1.ManagedZone{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+			},
+			Spec: v1alpha1.ManagedZoneSpec{
+				ID:          "1234",
+				DomainName:  domainName,
+				Description: domainName,
+				SecretRef: &v1alpha1.SecretRef{
+					Name:      "secretname",
+					Namespace: ns,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Adds a routing strategy field to the DNSPolicy spec that determines how the policy with generate endpoints for any created DNSRecords.

Two routing strategies are allowed, `simple` and `loadbalanced`. Simple will creates a single DNS record (A or CNAME) for each listener/hostname with all ip/hostnames as targets. LoadBalanced works as before by creating a more complex record structure with CNAMES and A records using Geo and Weighted routing strategies to achieve loadbalancing functionality.

The strategy field is currently marked as immutable and it should not be changed after initial DNSPolicy creation.

closes #655