### PR TITLE
gh-628 fix deletion of dnsrecord and certificates on deletion of gateway target for dnspolicy and tlspolicy

### DIFF
--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -195,13 +195,12 @@ func (r *DNSPolicyReconciler) deleteResources(ctx context.Context, dnsPolicy *v1
 	if err != nil {
 		return err
 	}
-
-	if err := r.reconcileDNSRecords(ctx, dnsPolicy, gatewayDiffObj); err != nil {
+	if err = r.deleteDNSRecords(ctx, dnsPolicy); err != nil {
 		log.V(3).Info("error reconciling DNS records from delete, returning", "error", err)
 		return err
 	}
 
-	if err := r.reconcileHealthChecks(ctx, dnsPolicy, gatewayDiffObj); err != nil {
+	if err := r.deleteProbes(ctx, dnsPolicy); err != nil {
 		return err
 	}
 

--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -159,7 +159,7 @@ func (r *DNSPolicyReconciler) reconcileResources(ctx context.Context, dnsPolicy 
 		return errors.Join(fmt.Errorf("reconcile DNSRecords error %w", err), updateErr)
 	}
 
-	if err = r.reconcileHealthChecks(ctx, dnsPolicy, gatewayDiffObj); err != nil {
+	if err = r.reconcileHealthCheckProbes(ctx, dnsPolicy, gatewayDiffObj); err != nil {
 		gatewayCondition = conditions.BuildPolicyAffectedCondition(DNSPolicyAffected, dnsPolicy, targetNetworkObject, conditions.PolicyReasonInvalid, err)
 		updateErr := r.updateGatewayCondition(ctx, gatewayCondition, gatewayDiffObj)
 		return errors.Join(fmt.Errorf("reconcile HealthChecks error %w", err), updateErr)
@@ -200,7 +200,7 @@ func (r *DNSPolicyReconciler) deleteResources(ctx context.Context, dnsPolicy *v1
 		return err
 	}
 
-	if err := r.deleteProbes(ctx, dnsPolicy); err != nil {
+	if err := r.deleteHealthCheckProbes(ctx, dnsPolicy); err != nil {
 		return err
 	}
 

--- a/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
@@ -33,7 +33,7 @@ func (r *DNSPolicyReconciler) reconcileDNSRecords(ctx context.Context, dnsPolicy
 
 	// Reconcile DNSRecords for each gateway directly referred by the policy (existing and new)
 	for _, gw := range append(gwDiffObj.GatewaysWithValidPolicyRef, gwDiffObj.GatewaysMissingPolicyRef...) {
-		log.V(1).Info("reconcileDNSRecords: gateway with valid and missing policy ref", "key", gw.Key())
+		log.V(1).Info("reconcileDNSRecords: gateway with valid or missing policy ref", "key", gw.Key())
 		err := r.reconcileGatewayDNSRecords(ctx, gw.Gateway, dnsPolicy)
 		if err != nil {
 			return err
@@ -124,9 +124,17 @@ func (r *DNSPolicyReconciler) reconcileGatewayDNSRecords(ctx context.Context, ga
 }
 
 func (r *DNSPolicyReconciler) deleteGatewayDNSRecords(ctx context.Context, gateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) error {
+	return r.deleteDNSRecordsWithLabels(ctx, commonDNSRecordLabels(client.ObjectKeyFromObject(gateway), client.ObjectKeyFromObject(dnsPolicy)), dnsPolicy.Namespace)
+}
+
+func (r *DNSPolicyReconciler) deleteDNSRecords(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy) error {
+	return r.deleteDNSRecordsWithLabels(ctx, policyDNSRecordLabels(client.ObjectKeyFromObject(dnsPolicy)), dnsPolicy.Namespace)
+}
+
+func (r *DNSPolicyReconciler) deleteDNSRecordsWithLabels(ctx context.Context, lbls map[string]string, namespace string) error {
 	log := crlog.FromContext(ctx)
 
-	listOptions := &client.ListOptions{LabelSelector: labels.SelectorFromSet(commonDNSRecordLabels(client.ObjectKeyFromObject(gateway), client.ObjectKeyFromObject(dnsPolicy)))}
+	listOptions := &client.ListOptions{LabelSelector: labels.SelectorFromSet(lbls), Namespace: namespace}
 	recordsList := &v1alpha1.DNSRecordList{}
 	if err := r.Client().List(ctx, recordsList, listOptions); err != nil {
 		return err

--- a/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_dnsrecords.go
@@ -23,23 +23,21 @@ import (
 func (r *DNSPolicyReconciler) reconcileDNSRecords(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy, gwDiffObj *reconcilers.GatewayDiff) error {
 	log := crlog.FromContext(ctx)
 
+	log.V(3).Info("reconciling dns records")
 	for _, gw := range gwDiffObj.GatewaysWithInvalidPolicyRef {
 		log.V(1).Info("reconcileDNSRecords: gateway with invalid policy ref", "key", gw.Key())
-		err := r.deleteGatewayDNSRecords(ctx, gw.Gateway, dnsPolicy)
-		if err != nil {
-			return err
+		if err := r.deleteGatewayDNSRecords(ctx, gw.Gateway, dnsPolicy); err != nil {
+			return fmt.Errorf("error deleting dns records for gw %v: %w", gw.Gateway.Name, err)
 		}
 	}
 
 	// Reconcile DNSRecords for each gateway directly referred by the policy (existing and new)
 	for _, gw := range append(gwDiffObj.GatewaysWithValidPolicyRef, gwDiffObj.GatewaysMissingPolicyRef...) {
 		log.V(1).Info("reconcileDNSRecords: gateway with valid or missing policy ref", "key", gw.Key())
-		err := r.reconcileGatewayDNSRecords(ctx, gw.Gateway, dnsPolicy)
-		if err != nil {
-			return err
+		if err := r.reconcileGatewayDNSRecords(ctx, gw.Gateway, dnsPolicy); err != nil {
+			return fmt.Errorf("error reconciling dns records for gateway %v: %w", gw.Gateway.Name, err)
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_healthchecks.go
@@ -20,33 +20,33 @@ import (
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
 )
 
-func (r *DNSPolicyReconciler) reconcileHealthChecks(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy, gwDiffObj *reconcilers.GatewayDiff) error {
+func (r *DNSPolicyReconciler) reconcileHealthCheckProbes(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy, gwDiffObj *reconcilers.GatewayDiff) error {
 	log := crlog.FromContext(ctx)
 
 	log.V(3).Info("reconciling health checks")
-	for _, gw := range append(gwDiffObj.GatewaysWithValidPolicyRef, gwDiffObj.GatewaysMissingPolicyRef...) {
-		log.V(3).Info("reconciling probes", "gateway", gw.Name)
-		expectedProbes := r.expectedProbesForGateway(ctx, gw, dnsPolicy)
-		if err := r.createOrUpdateProbes(ctx, expectedProbes); err != nil {
-			return fmt.Errorf("error creating and updating expected proves for gateway %v: %w", gw.Gateway.Name, err)
-		}
-		if err := r.deleteUnexpectedGatewayProbes(ctx, expectedProbes, gw.Gateway, dnsPolicy); err != nil {
-			return fmt.Errorf("error removing unexpected probes for gateway %v: %w", gw.Gateway.Name, err)
-		}
-
-	}
-
 	for _, gw := range gwDiffObj.GatewaysWithInvalidPolicyRef {
-		log.V(3).Info("deleting probes", "gateway", gw.Gateway.Name)
-		if err := r.deleteGatewayProbes(ctx, gw.Gateway, dnsPolicy); err != nil {
+		log.V(1).Info("reconcileHealthCheckProbes: gateway with invalid policy ref", "key", gw.Key())
+		if err := r.deleteGatewayHealthCheckProbes(ctx, gw.Gateway, dnsPolicy); err != nil {
 			return fmt.Errorf("error deleting probes for gw %v: %w", gw.Gateway.Name, err)
 		}
 	}
 
+	// Reconcile DNSHealthCheckProbes for each gateway directly referred by the policy (existing and new)
+	for _, gw := range append(gwDiffObj.GatewaysWithValidPolicyRef, gwDiffObj.GatewaysMissingPolicyRef...) {
+		log.V(3).Info("reconciling probes", "gateway", gw.Name)
+		expectedProbes := r.expectedHealthCheckProbesForGateway(ctx, gw, dnsPolicy)
+		if err := r.createOrUpdateHealthCheckProbes(ctx, expectedProbes); err != nil {
+			return fmt.Errorf("error creating or updating expected probes for gateway %v: %w", gw.Gateway.Name, err)
+		}
+		if err := r.deleteUnexpectedGatewayHealthCheckProbes(ctx, expectedProbes, gw.Gateway, dnsPolicy); err != nil {
+			return fmt.Errorf("error removing unexpected probes for gateway %v: %w", gw.Gateway.Name, err)
+		}
+
+	}
 	return nil
 }
 
-func (r *DNSPolicyReconciler) createOrUpdateProbes(ctx context.Context, expectedProbes []*v1alpha1.DNSHealthCheckProbe) error {
+func (r *DNSPolicyReconciler) createOrUpdateHealthCheckProbes(ctx context.Context, expectedProbes []*v1alpha1.DNSHealthCheckProbe) error {
 	//create or update all expected probes
 	for _, hcProbe := range expectedProbes {
 		p := &v1alpha1.DNSHealthCheckProbe{}
@@ -67,15 +67,15 @@ func (r *DNSPolicyReconciler) createOrUpdateProbes(ctx context.Context, expected
 	return nil
 }
 
-func (r *DNSPolicyReconciler) deleteGatewayProbes(ctx context.Context, gateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) error {
-	return r.deleteProbesWithLabels(ctx, commonDNSRecordLabels(client.ObjectKeyFromObject(gateway), client.ObjectKeyFromObject(dnsPolicy)), dnsPolicy.Namespace)
+func (r *DNSPolicyReconciler) deleteGatewayHealthCheckProbes(ctx context.Context, gateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) error {
+	return r.deleteHealthCheckProbesWithLabels(ctx, commonDNSRecordLabels(client.ObjectKeyFromObject(gateway), client.ObjectKeyFromObject(dnsPolicy)), dnsPolicy.Namespace)
 }
 
-func (r *DNSPolicyReconciler) deleteProbes(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy) error {
-	return r.deleteProbesWithLabels(ctx, policyDNSRecordLabels(client.ObjectKeyFromObject(dnsPolicy)), dnsPolicy.Namespace)
+func (r *DNSPolicyReconciler) deleteHealthCheckProbes(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy) error {
+	return r.deleteHealthCheckProbesWithLabels(ctx, policyDNSRecordLabels(client.ObjectKeyFromObject(dnsPolicy)), dnsPolicy.Namespace)
 }
 
-func (r *DNSPolicyReconciler) deleteProbesWithLabels(ctx context.Context, lbls map[string]string, namespace string) error {
+func (r *DNSPolicyReconciler) deleteHealthCheckProbesWithLabels(ctx context.Context, lbls map[string]string, namespace string) error {
 	probes := &v1alpha1.DNSHealthCheckProbeList{}
 	listOptions := &client.ListOptions{LabelSelector: labels.SelectorFromSet(lbls), Namespace: namespace}
 	if err := r.Client().List(ctx, probes, listOptions); client.IgnoreNotFound(err) != nil {
@@ -89,7 +89,7 @@ func (r *DNSPolicyReconciler) deleteProbesWithLabels(ctx context.Context, lbls m
 	return nil
 }
 
-func (r *DNSPolicyReconciler) deleteUnexpectedGatewayProbes(ctx context.Context, expectedProbes []*v1alpha1.DNSHealthCheckProbe, gateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) error {
+func (r *DNSPolicyReconciler) deleteUnexpectedGatewayHealthCheckProbes(ctx context.Context, expectedProbes []*v1alpha1.DNSHealthCheckProbe, gateway *gatewayv1beta1.Gateway, dnsPolicy *v1alpha1.DNSPolicy) error {
 	// remove any probes for this gateway and DNS Policy that are no longer expected
 	existingProbes := &v1alpha1.DNSHealthCheckProbeList{}
 	dnsLabels := commonDNSRecordLabels(client.ObjectKeyFromObject(gateway), client.ObjectKeyFromObject(dnsPolicy))
@@ -109,7 +109,7 @@ func (r *DNSPolicyReconciler) deleteUnexpectedGatewayProbes(ctx context.Context,
 	return nil
 }
 
-func (r *DNSPolicyReconciler) expectedProbesForGateway(ctx context.Context, gw common.GatewayWrapper, dnsPolicy *v1alpha1.DNSPolicy) []*v1alpha1.DNSHealthCheckProbe {
+func (r *DNSPolicyReconciler) expectedHealthCheckProbesForGateway(ctx context.Context, gw common.GatewayWrapper, dnsPolicy *v1alpha1.DNSPolicy) []*v1alpha1.DNSHealthCheckProbe {
 	log := crlog.FromContext(ctx)
 	var healthChecks []*v1alpha1.DNSHealthCheckProbe
 	if dnsPolicy.Spec.HealthCheck == nil {
@@ -147,7 +147,7 @@ func (r *DNSPolicyReconciler) expectedProbesForGateway(ctx context.Context, gw c
 			} else {
 				protocol = string(*dnsPolicy.Spec.HealthCheck.Protocol)
 			}
-			log.V(1).Info("reconcileHealthChecks: adding health check for target", "target", address.Value)
+			log.V(1).Info("reconcileHealthCheckProbes: adding health check for target", "target", address.Value)
 			healthCheck := &v1alpha1.DNSHealthCheckProbe{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dnsHealthCheckProbeName(matches[1], gw.Name, string(listener.Name)),

--- a/pkg/controllers/dnspolicy/dnspolicy_healthchecks_test.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_healthchecks_test.go
@@ -343,9 +343,9 @@ func TestDNSPolicyReconciler_expectedProbesForGateway(t *testing.T) {
 				DNSProvider:         tt.fields.DNSProvider,
 				dnsHelper:           tt.fields.dnsHelper,
 			}
-			got := r.expectedProbesForGateway(tt.args.ctx, tt.args.gw, tt.args.dnsPolicy)
+			got := r.expectedHealthCheckProbesForGateway(tt.args.ctx, tt.args.gw, tt.args.dnsPolicy)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("expectedProbesForGateway() got = %v, want %v", got, tt.want)
+				t.Errorf("expectedHealthCheckProbesForGateway() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/controllers/tlspolicy/tlspolicy_certmanager_certificates.go
+++ b/pkg/controllers/tlspolicy/tlspolicy_certmanager_certificates.go
@@ -8,7 +8,7 @@ import (
 	certmanv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -25,74 +25,88 @@ import (
 func (r *TLSPolicyReconciler) reconcileCertificates(ctx context.Context, tlsPolicy *v1alpha1.TLSPolicy, gwDiffObj *reconcilers.GatewayDiff) error {
 	log := crlog.FromContext(ctx)
 
+	log.V(3).Info("reconciling certificates")
 	for _, gw := range gwDiffObj.GatewaysWithInvalidPolicyRef {
 		log.V(1).Info("reconcileCertificates: gateway with invalid policy ref", "key", gw.Key())
-		if err := r.deleteGatewayCertificates(ctx, []*certmanv1.Certificate{}, gw.Gateway, tlsPolicy); err != nil {
-			return err
+		if err := r.deleteGatewayCertificates(ctx, gw.Gateway, tlsPolicy); err != nil {
+			return fmt.Errorf("error deleting certificates for gw %v: %w", gw.Gateway.Name, err)
 		}
 	}
 
 	// Reconcile Certificates for each gateway directly referred by the policy (existing and new)
 	for _, gw := range append(gwDiffObj.GatewaysWithValidPolicyRef, gwDiffObj.GatewaysMissingPolicyRef...) {
 		log.V(1).Info("reconcileCertificates: gateway with valid or missing policy ref", "key", gw.Key())
-		if err := r.reconcileGatewayCertificates(ctx, gw.Gateway, tlsPolicy); err != nil {
-			return err
+		expectedCertificates := r.expectedCertificatesForGateway(ctx, gw.Gateway, tlsPolicy)
+		if err := r.createOrUpdateGatewayCertificates(ctx, expectedCertificates); err != nil {
+			return fmt.Errorf("error creating and updating expected certificates for gateway %v: %w", gw.Gateway.Name, err)
+		}
+		if err := r.deleteUnexpectedCertificates(ctx, expectedCertificates, gw.Gateway, tlsPolicy); err != nil {
+			return fmt.Errorf("error removing unexpected certificate for gateway %v: %w", gw.Gateway.Name, err)
 		}
 	}
-
 	return nil
 }
 
-func (r *TLSPolicyReconciler) reconcileGatewayCertificates(ctx context.Context, gateway *gatewayv1beta1.Gateway, tlsPolicy *v1alpha1.TLSPolicy) error {
-	log := crlog.FromContext(ctx)
-
-	log.V(1).Info("reconcileGatewayCertificates", "tlsPolicy", tlsPolicy)
-
-	expectedCerts := r.expectedCertificatesForGateway(ctx, gateway, tlsPolicy)
-
-	if err := r.deleteGatewayCertificates(ctx, expectedCerts, gateway, tlsPolicy); err != nil {
-		return err
-	}
-
-	for _, cert := range expectedCerts {
-		err := r.ReconcileResource(ctx, &certmanv1.Certificate{}, cert, alwaysUpdateCertificate)
-		if err != nil && !apierrors.IsAlreadyExists(err) {
-			log.Error(err, "failed to reconcile Certificate resource")
+func (r *TLSPolicyReconciler) createOrUpdateGatewayCertificates(ctx context.Context, expectedCertificates []*certmanv1.Certificate) error {
+	//create or update all expected Certificates
+	for _, cert := range expectedCertificates {
+		p := &certmanv1.Certificate{}
+		if err := r.Client().Get(ctx, client.ObjectKeyFromObject(cert), p); k8serror.IsNotFound(err) {
+			if err := r.Client().Create(ctx, cert); err != nil {
+				return err
+			}
+		} else if client.IgnoreNotFound(err) == nil {
+			p.Spec = cert.Spec
+			if err := r.Client().Update(ctx, p); err != nil {
+				return err
+			}
+		} else {
 			return err
 		}
 	}
-
 	return nil
 }
 
-func (r *TLSPolicyReconciler) deleteGatewayCertificates(ctx context.Context, expectedCerts []*certmanv1.Certificate, gateway *gatewayv1beta1.Gateway, tlsPolicy *v1alpha1.TLSPolicy) error {
-	return r.deleteCertificatesWithLabels(ctx, expectedCerts, commonTLSCertificateLabels(client.ObjectKeyFromObject(gateway), client.ObjectKeyFromObject(tlsPolicy)), tlsPolicy.Namespace)
+func (r *TLSPolicyReconciler) deleteGatewayCertificates(ctx context.Context, gateway *gatewayv1beta1.Gateway, tlsPolicy *v1alpha1.TLSPolicy) error {
+	return r.deleteCertificatesWithLabels(ctx, commonTLSCertificateLabels(client.ObjectKeyFromObject(gateway), client.ObjectKeyFromObject(tlsPolicy)), tlsPolicy.Namespace)
 }
 
 func (r *TLSPolicyReconciler) deleteCertificates(ctx context.Context, tlsPolicy *v1alpha1.TLSPolicy) error {
-	return r.deleteCertificatesWithLabels(ctx, []*certmanv1.Certificate{}, policyTLSCertificateLabels(client.ObjectKeyFromObject(tlsPolicy)), tlsPolicy.Namespace)
+	return r.deleteCertificatesWithLabels(ctx, policyTLSCertificateLabels(client.ObjectKeyFromObject(tlsPolicy)), tlsPolicy.Namespace)
 }
 
-func (r *TLSPolicyReconciler) deleteCertificatesWithLabels(ctx context.Context, expectedCerts []*certmanv1.Certificate, lbls map[string]string, namespace string) error {
-	log := crlog.FromContext(ctx)
-
+func (r *TLSPolicyReconciler) deleteCertificatesWithLabels(ctx context.Context, lbls map[string]string, namespace string) error {
 	listOptions := &client.ListOptions{LabelSelector: labels.SelectorFromSet(lbls), Namespace: namespace}
 	certList := &certmanv1.CertificateList{}
 	if err := r.Client().List(ctx, certList, listOptions); err != nil {
 		return err
 	}
 
-	for _, cert := range certList.Items {
-		if !slice.Contains(expectedCerts, func(expectedCert *certmanv1.Certificate) bool {
-			return expectedCert.Name == cert.Name && expectedCert.Namespace == cert.Namespace
+	for _, c := range certList.Items {
+		if err := r.Client().Delete(ctx, &c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *TLSPolicyReconciler) deleteUnexpectedCertificates(ctx context.Context, expectedCertificates []*certmanv1.Certificate, gateway *gatewayv1beta1.Gateway, tlsPolicy *v1alpha1.TLSPolicy) error {
+	// remove any certificates for this gateway and TLSPolicy that are no longer expected
+	existingCertificates := &certmanv1.CertificateList{}
+	dnsLabels := commonTLSCertificateLabels(client.ObjectKeyFromObject(gateway), client.ObjectKeyFromObject(tlsPolicy))
+	listOptions := &client.ListOptions{LabelSelector: labels.SelectorFromSet(dnsLabels)}
+	if err := r.Client().List(ctx, existingCertificates, listOptions); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+	for _, p := range existingCertificates.Items {
+		if !slice.Contains(expectedCertificates, func(expectedCertificate *certmanv1.Certificate) bool {
+			return expectedCertificate.Name == p.Name && expectedCertificate.Namespace == p.Namespace
 		}) {
-			if err := r.DeleteResource(ctx, &cert); client.IgnoreNotFound(err) != nil {
-				log.Error(err, "failed to delete Certificate resource")
+			if err := r.Client().Delete(ctx, &p); err != nil {
 				return err
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/controllers/tlspolicy/tlspolicy_controller.go
+++ b/pkg/controllers/tlspolicy/tlspolicy_controller.go
@@ -196,7 +196,7 @@ func (r *TLSPolicyReconciler) deleteResources(ctx context.Context, tlsPolicy *v1
 		return err
 	}
 
-	if err := r.reconcileCertificates(ctx, tlsPolicy, gatewayDiffObj); err != nil {
+	if err := r.deleteCertificates(ctx, tlsPolicy); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Addressed #628  

# Verification
## DNSRecord
Follow the steps described in the issue, the dnsrecord should be deleted.

## Health Check Probes
kubectl create secret generic probe-headers --from-literal=test=dGVzdAo= -n multi-cluster-gateways

Follow the steps describe in the issue with the following adjustments. 
Add the following block to your dnspolicy
```
healthCheck:
      additionalHeadersRef:
        name: probe-headers
      allowInsecureCertificates: true
      endpoint: /
      expectedResponses:
      - 200
      - 201
      - 301
      failureThreshold: 1
      port: 443
      protocol: https
```
there should be one dnshealthcheck probe present in the cluster now
e.g.
```
kc get dnshealthcheckprobes -A        

NAMESPACE                NAME                        HEALTHY   LAST CHECKED
multi-cluster-gateways   172.31.200.0-prod-web-api   true      3s
```

Delete the dnspolicy, the healthcheck probe should be deleted.


## Certificates
- create gateway
- label gateway
- create tlspolicy
- verify certificates are created
- delete gateway
- verify certificates are deleted.
