### PR TITLE
Fix lint errors

### DIFF
--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -191,11 +191,7 @@ func (r *DNSPolicyReconciler) reconcileResources(ctx context.Context, dnsPolicy 
 func (r *DNSPolicyReconciler) deleteResources(ctx context.Context, dnsPolicy *v1alpha1.DNSPolicy, targetNetworkObject client.Object) error {
 	// delete based on gateway diffs
 
-	gatewayDiffObj, err := r.ComputeGatewayDiffs(ctx, dnsPolicy, targetNetworkObject, &DNSPolicyRefsConfig{})
-	if err != nil {
-		return err
-	}
-	if err = r.deleteDNSRecords(ctx, dnsPolicy); err != nil {
+	if err := r.deleteDNSRecords(ctx, dnsPolicy); err != nil {
 		log.V(3).Info("error reconciling DNS records from delete, returning", "error", err)
 		return err
 	}
@@ -211,7 +207,7 @@ func (r *DNSPolicyReconciler) deleteResources(ctx context.Context, dnsPolicy *v1
 		}
 	}
 
-	gatewayDiffObj, err = r.ComputeGatewayDiffs(ctx, dnsPolicy, targetNetworkObject, &DNSPolicyRefsConfig{})
+	gatewayDiffObj, err := r.ComputeGatewayDiffs(ctx, dnsPolicy, targetNetworkObject, &DNSPolicyRefsConfig{})
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/tlspolicy/tlspolicy_certmanager_certificates.go
+++ b/pkg/controllers/tlspolicy/tlspolicy_certmanager_certificates.go
@@ -3,7 +3,6 @@ package tlspolicy
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	certmanv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 
@@ -189,22 +188,4 @@ func gatewayTLSCertificateLabels(gwKey client.ObjectKey) map[string]string {
 		"gateway-namespace": gwKey.Namespace,
 		"gateway":           gwKey.Name,
 	}
-}
-
-func alwaysUpdateCertificate(existingObj, desiredObj client.Object) (bool, error) {
-	existing, ok := existingObj.(*certmanv1.Certificate)
-	if !ok {
-		return false, fmt.Errorf("%T is not a *certmanv1.Certificate", existingObj)
-	}
-	desired, ok := desiredObj.(*certmanv1.Certificate)
-	if !ok {
-		return false, fmt.Errorf("%T is not an *certmanv1.Certificate", desiredObj)
-	}
-
-	if reflect.DeepEqual(existing.Spec, desired.Spec) {
-		return false, nil
-	}
-	existing.Spec = desired.Spec
-
-	return true, nil
 }


### PR DESCRIPTION
Remove duplicate assignment of gatewayDiffObj
Remove alwaysUpdateCertificate mutate function (Come back to this, we should be trying to use this pattern in all our policies, not removing it.)

Introduced in https://github.com/Kuadrant/multicluster-gateway-controller/pull/635, really not sure why they weren't picked up in the PR CI job