### PR TITLE
Suggestion for change to kustomize setup

### DIFF
--- a/config/default/gateway-controller/kustomization.yaml
+++ b/config/default/gateway-controller/kustomization.yaml
@@ -1,0 +1,10 @@
+
+namePrefix: mgc-
+
+resources:
+- ../../rbac
+- ../../manager
+- ../../add-on-manager
+
+patches:
+- path: manager_metrics_patch.yaml

--- a/config/default/gateway-controller/manager_config_patch.yaml
+++ b/config/default/gateway-controller/manager_config_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager

--- a/config/default/gateway-controller/manager_metrics_patch.yaml
+++ b/config/default/gateway-controller/manager_metrics_patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        args:
+        - "--metrics-bind-address=0.0.0.0:8080"
+        - "--leader-elect"
+        ports:
+        - containerPort: 8080
+          name: metrics

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,21 +1,6 @@
 
 namespace: multicluster-gateway-controller-system
 
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: mgc-
-
 resources:
-- ../rbac
-- ../manager
-- ../add-on-manager
-- ../policy-controller/default
-
-patches:
-- path: manager_metrics_patch.yaml
-
-patchesStrategicMerge:
-  - delete-kuadrant-system-ns-object.yaml
+- ./gateway-controller
+- ./policy-controller

--- a/config/default/policy-controller/delete-kuadrant-system-ns-object.yaml
+++ b/config/default/policy-controller/delete-kuadrant-system-ns-object.yaml
@@ -1,0 +1,6 @@
+---
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system

--- a/config/default/policy-controller/kustomization.yaml
+++ b/config/default/policy-controller/kustomization.yaml
@@ -1,0 +1,8 @@
+
+namePrefix: mgc-policy-
+
+resources:
+  - ../../policy-controller/default
+
+patchesStrategicMerge:
+  - delete-kuadrant-system-ns-object.yaml

--- a/config/policy-controller/default/kustomization.yaml
+++ b/config/policy-controller/default/kustomization.yaml
@@ -1,5 +1,4 @@
 
-
 resources:
 - ../manager
 - ./issuer.yaml

--- a/config/policy-controller/manager/kustomization.yaml
+++ b/config/policy-controller/manager/kustomization.yaml
@@ -1,9 +1,8 @@
 
-
 resources:
 - manager.yaml
 
 images:
-- name: policy-controller
+- name: controller
   newName: quay.io/kuadrant/policy-controller
   newTag: main

--- a/config/policy-controller/manager/manager.yaml
+++ b/config/policy-controller/manager/manager.yaml
@@ -8,21 +8,21 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: policy-controller
+  name: controller-manager
   namespace: system
   labels:
-    control-plane: policy-controller
+    control-plane: controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: policy-controller
+      control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: policy-controller
+        control-plane: controller-manager
     spec:
       securityContext:
         runAsNonRoot: true
@@ -31,9 +31,9 @@ spec:
         - /policy_controller
         args:
         - --leader-elect
-        image: policy-controller:latest
+        image: controller:latest
         imagePullPolicy: Always
-        name: policy-controller
+        name: manager
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/policy-controller/rbac/kustomization.yaml
+++ b/config/policy-controller/rbac/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 # subjects if changing service account names.
 - service_account.yaml
 - role.yaml
-- rolebinding.yaml
+- role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 - dnsrecord_editor_role.yaml

--- a/config/policy-controller/rbac/leader_election_role.yaml
+++ b/config/policy-controller/rbac/leader_election_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: policy-controller-leader-election-role
+  name: leader-election-role
   namespace: system
 rules:
 - apiGroups:

--- a/config/policy-controller/rbac/leader_election_role_binding.yaml
+++ b/config/policy-controller/rbac/leader_election_role_binding.yaml
@@ -2,12 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-  name: policy-controller-leader-election-rolebinding
+  name: leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: policy-controller-leader-election-role
+  name: leader-election-role
 subjects:
-- kind: ServiceAccount
-  name: policy-controller
-  namespace: system
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/config/policy-controller/rbac/role.yaml
+++ b/config/policy-controller/rbac/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: policy-role
+  name: manager-role
 rules:
 - apiGroups:
   - ""

--- a/config/policy-controller/rbac/role_binding.yaml
+++ b/config/policy-controller/rbac/role_binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: policy-controller-rolebinding
+  name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: policy-role
+  name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: policy-controller
+  name: controller-manager
   namespace: system

--- a/config/policy-controller/rbac/service_account.yaml
+++ b/config/policy-controller/rbac/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: policy-controller
+  name: controller-manager
   namespace: system


### PR DESCRIPTION
Rename everything in config/policy-controller to be consistent with normal kubebuilder/operatorsdk controller naming conventions.

Update the default mgc overlay to allow specifying a different nameprefix for mgc (gateway) and policy components.

```
./bin/kustomize build config/default/ | yq .metadata.name
multicluster-gateway-controller-system
dnshealthcheckprobes.kuadrant.io
dnspolicies.kuadrant.io
dnsrecords.kuadrant.io
managedzones.kuadrant.io
tlspolicies.kuadrant.io
mgc-add-on-manager
mgc-controller-manager
mgc-policy-controller-manager
mgc-leader-election-role
mgc-policy-leader-election-role
mgc-kuadrant-addon
mgc-manager-role
mgc-metrics-reader
mgc-policy-dnsrecord-editor-role
mgc-policy-dnsrecord-viewer-role
mgc-policy-manager-role
mgc-proxy-role
mgc-leader-election-rolebinding
mgc-policy-leader-election-rolebinding
mgc-kuadrant-addon
mgc-manager-rolebinding
mgc-policy-manager-rolebinding
mgc-proxy-rolebinding
mgc-controller-manager-metrics-service
mgc-controller-manager
mgc-kuadrant-add-on-manager
mgc-policy-controller-manager
mgc-kuadrant-addon
mgc-policy-glbc-ca
```