### PR TITLE
Renamed metric services

### DIFF
--- a/config/prometheus/gateway-controller-service.yaml
+++ b/config/prometheus/gateway-controller-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-  name: metrics
+  name: controller-manager-metrics
   namespace: system
 spec:
   selector:

--- a/config/prometheus/policy-controller-service.yaml
+++ b/config/prometheus/policy-controller-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: policy-controller
-  name: metrics
+  name: policy-controller-metrics
   namespace: system
 spec:
   selector:


### PR DESCRIPTION
# What
This  #648 PR introduced the policy controller metrics service and the quickstart-metrics script failed because it could not merge it with the previous service as they had the same name.

# Verification
Both quickstart-setup and quickstart-metrics still work.


