### PR TITLE
fix perms around issuers

### DIFF
--- a/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-11-10T09:41:24Z"
+    createdAt: "2023-11-10T17:08:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-gateway-controller.v0.0.0
@@ -332,6 +332,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - cert-manager.io
           resources:
@@ -339,6 +340,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - cluster.open-cluster-management.io
           resources:
@@ -504,6 +506,50 @@ spec:
         serviceAccountName: mgc-policy-controller
       deployments:
       - label:
+          control-plane: kuadrant-add-on-manager
+        name: mgc-add-on-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: kuadrant-add-on-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: controller
+              labels:
+                control-plane: kuadrant-add-on-manager
+            spec:
+              containers:
+              - args:
+                - --leader-elect
+                command:
+                - /add-on-manager
+                envFrom:
+                - configMapRef:
+                    name: controller-config
+                    optional: true
+                image: quay.io/kuadrant/addon-manager:main
+                imagePullPolicy: Always
+                name: controller
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: mgc-add-on-manager
+              terminationGracePeriodSeconds: 10
+      - label:
           app.kubernetes.io/component: manager
           app.kubernetes.io/created-by: multicluster-gateway-controller
           app.kubernetes.io/instance: controller-manager
@@ -564,56 +610,6 @@ spec:
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: mgc-controller-manager
-              terminationGracePeriodSeconds: 10
-      - label:
-          app.kubernetes.io/component: add-on-manager
-          app.kubernetes.io/created-by: kuadrant-add-on-manager
-          app.kubernetes.io/instance: kuadrant-add-on-manager
-          app.kubernetes.io/managed-by: kustomize
-          app.kubernetes.io/name: deployment
-          app.kubernetes.io/part-of: kuadrant
-          control-plane: kuadrant-add-on-manager
-        name: mgc-kuadrant-add-on-manager
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              control-plane: kuadrant-add-on-manager
-          strategy: {}
-          template:
-            metadata:
-              annotations:
-                kubectl.kubernetes.io/default-container: controller
-              labels:
-                control-plane: kuadrant-add-on-manager
-            spec:
-              containers:
-              - args:
-                - --leader-elect
-                command:
-                - /add-on-manager
-                envFrom:
-                - configMapRef:
-                    name: controller-config
-                    optional: true
-                image: quay.io/kuadrant/addon-manager:main
-                imagePullPolicy: Always
-                name: controller
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 10m
-                    memory: 64Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-              securityContext:
-                runAsNonRoot: true
-              serviceAccountName: mgc-add-on-manager
               terminationGracePeriodSeconds: 10
       - label:
           control-plane: policy-controller

--- a/config/add-on-manager/manager.yaml
+++ b/config/add-on-manager/manager.yaml
@@ -1,16 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kuadrant-add-on-manager
+  name: add-on-manager
   namespace: system
   labels:
     control-plane: kuadrant-add-on-manager
-    app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: kuadrant-add-on-manager
-    app.kubernetes.io/component: add-on-manager
-    app.kubernetes.io/created-by: kuadrant-add-on-manager
-    app.kubernetes.io/part-of: kuadrant
-    app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:

--- a/config/policy-controller/rbac/role.yaml
+++ b/config/policy-controller/rbac/role.yaml
@@ -32,6 +32,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - cert-manager.io
   resources:
@@ -39,6 +40,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:

--- a/hack/make/policy_controller.make
+++ b/hack/make/policy_controller.make
@@ -41,8 +41,8 @@ docker-push-policy-controller: ## Push docker image with the controller.
 
 .PHONY: deploy-policy-controller
 deploy-policy-controller: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/policy-controller && $(KUSTOMIZE) edit set image policy-controller=${POLICY_CONTROLLER_IMG}
-	$(KUSTOMIZE) --load-restrictor LoadRestrictionsNone build config/deploy/local | kubectl apply -f -
+	cd config/policy-controller/default && $(KUSTOMIZE) edit set image policy-controller=${POLICY_CONTROLLER_IMG}
+	$(KUSTOMIZE) --load-restrictor LoadRestrictionsNone build config/policy-controller/default | kubectl apply -f -
 	@if [ "$(METRICS)" = "true" ]; then\
 		$(KUSTOMIZE) build config/prometheus | kubectl apply -f -;\
 	fi

--- a/pkg/controllers/tlspolicy/tlspolicy_controller.go
+++ b/pkg/controllers/tlspolicy/tlspolicy_controller.go
@@ -67,8 +67,8 @@ type TLSPolicyReconciler struct {
 //+kubebuilder:rbac:groups=kuadrant.io,resources=tlspolicies,verbs=get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=kuadrant.io,resources=tlspolicies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kuadrant.io,resources=tlspolicies/finalizers,verbs=update
-//+kubebuilder:rbac:groups="cert-manager.io",resources=issuers,verbs=get;list;
-//+kubebuilder:rbac:groups="cert-manager.io",resources=clusterissuers,verbs=get;list;
+//+kubebuilder:rbac:groups="cert-manager.io",resources=issuers,verbs=get;list;watch;
+//+kubebuilder:rbac:groups="cert-manager.io",resources=clusterissuers,verbs=get;list;watch;
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="cert-manager.io",resources=certificates,verbs=get;list;watch;create;update;patch;delete
 

--- a/test/e2e/gateway_single_spoke_test.go
+++ b/test/e2e/gateway_single_spoke_test.go
@@ -409,13 +409,18 @@ var _ = Describe("Gateway single target cluster", func() {
 						}
 						otherHostname = gatewayapi.Hostname(strings.Join([]string{"other", tconfig.ManagedZone()}, "."))
 						AddListener("other", otherHostname, gatewayapi.ObjectName(otherHostname), gw)
-						err = tconfig.HubClient().Update(ctx, gw)
-						Expect(err).ToNot(HaveOccurred())
+
 						expectedLiseners := 3
 						Eventually(func(ctx SpecContext) error {
+							err = tconfig.HubClient().Update(ctx, gw)
+							if err != nil {
+								return fmt.Errorf("failed to update gateway and add new listeners: %w", err)
+							}
 							checkGateway := &gatewayapi.Gateway{}
 							err = tconfig.HubClient().Get(ctx, client.ObjectKey{Name: testID, Namespace: tconfig.HubNamespace()}, checkGateway)
-							Expect(err).ToNot(HaveOccurred())
+							if err != nil {
+								return fmt.Errorf("failed to get updated gateway after adding listeners: %w", err)
+							}
 							if len(checkGateway.Spec.Listeners) == expectedLiseners {
 								return nil
 							}

--- a/test/e2e/gateway_single_spoke_test.go
+++ b/test/e2e/gateway_single_spoke_test.go
@@ -398,33 +398,6 @@ var _ = Describe("Gateway single target cluster", func() {
 							return fmt.Errorf("dns names for secret not as expected")
 						}).WithContext(ctx).WithTimeout(180 * time.Second).WithPolling(2 * time.Second).ShouldNot(HaveOccurred())
 					}
-
-					By("checking a wildcard cert is present via get request")
-					{
-						dialer := &net.Dialer{Resolver: authoritativeResolver}
-						dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
-							return dialer.DialContext(ctx, network, addr)
-						}
-						http.DefaultTransport.(*http.Transport).DialContext = dialContext
-						http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-						otherHostname = gatewayapi.Hostname(strings.Join([]string{"other", tconfig.ManagedZone()}, "."))
-						var resp *http.Response
-						Eventually(func(ctx SpecContext) error {
-							httpClient := &http.Client{}
-							resp, err = httpClient.Get("https://" + string(otherHostname))
-							if err != nil {
-								GinkgoWriter.Printf("[debug] GET error: '%s'\n", err)
-								return err
-							}
-							err = TestCertificate(string(wildcardHostname), resp)
-							if err != nil {
-								GinkgoWriter.Printf("[debug] Cert error: '%s'\n", err)
-								return err
-							}
-							return nil
-						}).WithTimeout(600 * time.Second).WithPolling(10 * time.Second).WithContext(ctx).ShouldNot(HaveOccurred())
-						defer resp.Body.Close()
-					}
 					By("adding/removing listeners tls secrets are added/removed")
 					{
 						gw := &gatewayapi.Gateway{}


### PR DESCRIPTION
fix `pkg/mod/k8s.io/client-go@v0.28.3/tools/cache/reflector.go:229: Failed to watch *v1.ClusterIssuer: unknown (get clusterissuers.cert-manager.io)`