### PR TITLE
Update dns policy required fields to remove routingStrategy

### DIFF
--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -201,7 +201,6 @@ spec:
                 - name
                 type: object
             required:
-            - routingStrategy
             - targetRef
             type: object
           status:

--- a/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-11-10T17:08:34Z"
+    createdAt: "2023-11-20T13:03:30Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-gateway-controller.v0.0.0

--- a/config/policy-controller/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/policy-controller/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -200,6 +200,7 @@ spec:
                 - name
                 type: object
             required:
+            - routingStrategy
             - targetRef
             type: object
           status:

--- a/config/policy-controller/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/policy-controller/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -200,7 +200,6 @@ spec:
                 - name
                 type: object
             required:
-            - routingStrategy
             - targetRef
             type: object
           status:

--- a/pkg/apis/v1alpha1/dnspolicy_types.go
+++ b/pkg/apis/v1alpha1/dnspolicy_types.go
@@ -45,7 +45,7 @@ type DNSPolicySpec struct {
 	// +optional
 	LoadBalancing *LoadBalancingSpec `json:"loadBalancing"`
 
-	// +required
+	// +optional
 	// +kubebuilder:validation:Enum=simple;loadbalanced
 	// +kubebuilder:default=loadbalanced
 	RoutingStrategy RoutingStrategy `json:"routingStrategy"`

--- a/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -23,7 +23,6 @@ package v1alpha1
 
 import (
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )


### PR DESCRIPTION
fixes an issue where we get an error back from the API server if the new `routingStrategy` is not set during DNSPolicy creation