### PR TITLE
Install guide updates

### DIFF
--- a/config/mgc-install-guide/delete-cluster-issuer.yaml
+++ b/config/mgc-install-guide/delete-cluster-issuer.yaml
@@ -1,0 +1,8 @@
+---
+$patch: delete
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+group: cert-manager.io
+metadata:
+  name: mgc-glbc-ca
+  namespace: multicluster-gateway-controller-system

--- a/config/mgc-install-guide/kustomization.yaml
+++ b/config/mgc-install-guide/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 
 
 patchesStrategicMerge:
-  - delete-cluster-issuer.yaml  
+  - delete-cluster-issuer.yaml
+  

--- a/config/mgc-install-guide/kustomization.yaml
+++ b/config/mgc-install-guide/kustomization.yaml
@@ -1,3 +1,7 @@
 resources:
   - ../default
   - gatewayclass.yaml
+
+
+patchesStrategicMerge:
+  - delete-cluster-issuer.yaml  

--- a/docs/installation/control-plane-installation.md
+++ b/docs/installation/control-plane-installation.md
@@ -38,7 +38,7 @@ All OCM spoke clusters must be configured with the `RawFeedbackJsonString` featu
 First, run the following command in the context of your hub cluster to install the Gateway API CRDs:
 
 ```bash
-kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.2"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml"
 ```
 
 We can then add a `wait` to verify the CRDs have been established:
@@ -55,7 +55,7 @@ customresourcedefinition.apiextensions.k8s.io/httproutes.gateway.networking.k8s.
 Then run the following command to install the MGC:
 
 ```bash
-kubectl apply -k "github.com/kuadrant/multicluster-gateway-controller.git/config/mgc-install-guide?ref=main"
+kubectl apply -k "github.com/kuadrant/multicluster-gateway-controller.git/config/mgc-install-guide?ref=release-0.2"
 ```
 
 In addition to the MGC, this will also install the Kuadrant add-on manager and a `GatewayClass` from which MGC-managed `Gateways` can be instantiated.
@@ -63,11 +63,12 @@ In addition to the MGC, this will also install the Kuadrant add-on manager and a
 After the configuration has been applied, you can verify that the MGC and add-on manager have been installed and are running:
 
 ```bash
-kubectl wait --timeout=5m -n multicluster-gateway-controller-system deployment/mgc-controller-manager deployment/mgc-add-on-manager --for=condition=Available
+kubectl wait --timeout=5m -n multicluster-gateway-controller-system deployment/mgc-controller-manager deployment/mgc-add-on-manager deployment/mgc-policy-controller --for=condition=Available
 ```
 ```
 deployment.apps/mgc-controller-manager condition met
 deployment.apps/mgc-add-on-manager condition met
+deployment/mgc-policy-controller condition met
 ```
 
 We can also verify that the `GatewayClass` has been accepted by the MGC:

--- a/docs/installation/control-plane-installation.md
+++ b/docs/installation/control-plane-installation.md
@@ -13,39 +13,43 @@ This guide will show you how to install and configure the Multi-Cluster Gateway 
 
 ## Configure OCM with RawFeedbackJsonString Feature Gate
 
-All OCM spoke clusters must be configured with the `RawFeedbackJsonString` feature gate enabled. This can be done in two ways:
+All OCM spoke clusters must be configured with the `RawFeedbackJsonString` feature gate enabled:
 
-1. When running the `clusteradm join` command that joins the spoke cluster to the hub:
-
-    Get the `join` flags and token by running
-
-    ```bash
-    join=$(clusteradm get token --context kind-test-control-plane | grep -o 'join.*--cluster-name')
-    ```
-    
-    ```bash
-    clusteradm $join --feature-gates=RawFeedbackJsonString=true
-    ```
-
-2. By patching each spoke cluster's `klusterlet` in an existing OCM install:
+1. By patching each spoke cluster's `klusterlet` in an existing OCM install:
 
     ```bash
     kubectl patch klusterlet klusterlet --type merge --patch '{"spec": {"workConfiguration": {"featureGates": [{"feature": "RawFeedbackJsonString", "mode": "Enable"}]}}}' --context <EACH_SPOKE_CLUSTER>
     ```
+
+## Setup for hub commands
+Many of the commands in this document should be run in the context of your hub cluster.
+By configure HUB_CLUSTER which will be used in the commands:
+
+```bash
+export HUB_CLUSTER=<hub-cluster-name>
+```
+
+## Install Cert-Manager
+[Cert-manager](https://cert-manager.io/) first needs to be installed on your hub cluster. If this has not previously been installed on the cluster you can run the command below to do so:
+
+```bash
+kustomize --load-restrictor LoadRestrictionsNone build "github.com/kuadrant/multicluster-gateway-controller.git/config/mgc-install-guide/cert-manager?ref=release-0.2" --enable-helm | kubectl apply -f - --context $HUB_CLUSTER
+```
 
 ## Installing MGC
 
 First, run the following command in the context of your hub cluster to install the Gateway API CRDs:
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml --context $HUB_CLUSTER
 ```
 
 We can then add a `wait` to verify the CRDs have been established:
 
 ```bash
-kubectl wait --timeout=5m crd/gatewayclasses.gateway.networking.k8s.io crd/gateways.gateway.networking.k8s.io crd/httproutes.gateway.networking.k8s.io --for=condition=Established
+kubectl wait --timeout=5m crd/gatewayclasses.gateway.networking.k8s.io crd/gateways.gateway.networking.k8s.io crd/httproutes.gateway.networking.k8s.io --for=condition=Established --context $HUB_CLUSTER
 ```
+
 ```
 customresourcedefinition.apiextensions.k8s.io/gatewayclasses.gateway.networking.k8s.io condition met
 customresourcedefinition.apiextensions.k8s.io/gateways.gateway.networking.k8s.io condition met
@@ -55,7 +59,7 @@ customresourcedefinition.apiextensions.k8s.io/httproutes.gateway.networking.k8s.
 Then run the following command to install the MGC:
 
 ```bash
-kubectl apply -k "github.com/kuadrant/multicluster-gateway-controller.git/config/mgc-install-guide?ref=release-0.2"
+kubectl apply -k "github.com/kuadrant/multicluster-gateway-controller.git/config/mgc-install-guide?ref=release-0.2" --context $HUB_CLUSTER
 ```
 
 In addition to the MGC, this will also install the Kuadrant add-on manager and a `GatewayClass` from which MGC-managed `Gateways` can be instantiated.
@@ -63,7 +67,7 @@ In addition to the MGC, this will also install the Kuadrant add-on manager and a
 After the configuration has been applied, you can verify that the MGC and add-on manager have been installed and are running:
 
 ```bash
-kubectl wait --timeout=5m -n multicluster-gateway-controller-system deployment/mgc-controller-manager deployment/mgc-add-on-manager deployment/mgc-policy-controller --for=condition=Available
+kubectl wait --timeout=5m -n multicluster-gateway-controller-system deployment/mgc-controller-manager deployment/mgc-add-on-manager deployment/mgc-policy-controller --for=condition=Available --context $HUB_CLUSTER
 ```
 ```
 deployment.apps/mgc-controller-manager condition met
@@ -74,7 +78,7 @@ deployment/mgc-policy-controller condition met
 We can also verify that the `GatewayClass` has been accepted by the MGC:
 
 ```bash
-kubectl wait --timeout=5m gatewayclass/kuadrant-multi-cluster-gateway-instance-per-cluster --for=condition=Accepted
+kubectl wait --timeout=5m gatewayclass/kuadrant-multi-cluster-gateway-instance-per-cluster --for=condition=Accepted --context $HUB_CLUSTER
 ```
 ```
 gatewayclass.gateway.networking.k8s.io/kuadrant-multi-cluster-gateway-instance-per-cluster condition met
@@ -92,7 +96,7 @@ Next, create a secret containing either the AWS or GCP credentials. We'll also c
 
 #### AWS:
 ```bash
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f - --context $HUB_CLUSTER
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -112,7 +116,7 @@ EOF
 ```
 #### GCP
 ```bash
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f - --context $HUB_CLUSTER
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -135,7 +139,7 @@ A `ManagedZone` can then be created:
 #### AWS:
 
 ```bash
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f - --context $HUB_CLUSTER
 apiVersion: kuadrant.io/v1alpha1
 kind: ManagedZone
 metadata:
@@ -153,7 +157,7 @@ EOF
 #### GCP
 
 ```bash
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f - --context $HUB_CLUSTER
 apiVersion: kuadrant.io/v1alpha1
 kind: ManagedZone
 metadata:
@@ -172,7 +176,7 @@ EOF
 You can now verify that the `ManagedZone` has been created and is in a ready state:
 
 ```bash
-kubectl get managedzone -n multi-cluster-gateways
+kubectl get managedzone -n multi-cluster-gateways --context $HUB_CLUSTER
 ```
 ```
 NAME         DOMAIN NAME      ID                                  RECORD COUNT   NAMESERVERS                                                                                         READY
@@ -181,16 +185,10 @@ mgc-dev-mz   ef.hcpapps.net   /hostedzone/Z06419551EM30QQYMZN7F   2             
 
 ## Creating a Cert Issuer
 
-To create a `CertIssuer`, [cert-manager](https://cert-manager.io/) first needs to be installed on your hub cluster. If this has not previously been installed on the cluster you can run the command below to do so:
-
-```bash
-kustomize --load-restrictor LoadRestrictionsNone build "github.com/kuadrant/multicluster-gateway-controller.git/config/mgc-install-guide/cert-manager?ref=main" --enable-helm | kubectl apply -f -
-```
-
 We will now create a `ClusterIssuer` to be used with `cert-manager`. For simplicity, we will create a self-signed cert issuer here, but [other issuers can also be configured](https://cert-manager.io/docs/configuration/).
 
 ```bash
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f - --context $HUB_CLUSTER
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -204,7 +202,7 @@ EOF
 Verify that the `clusterIssuer` is ready:
 
 ```bash
-kubectl wait --timeout=5m -n cert-manager clusterissuer/mgc-ca --for=condition=Ready
+kubectl wait --timeout=5m -n cert-manager clusterissuer/mgc-ca --for=condition=Ready --context $HUB_CLUSTER
 ```
 ```
 clusterissuer.cert-manager.io/mgc-ca condition met

--- a/docs/installation/control-plane-installation.md
+++ b/docs/installation/control-plane-installation.md
@@ -86,13 +86,11 @@ gatewayclass.gateway.networking.k8s.io/kuadrant-multi-cluster-gateway-instance-p
 
 ## Creating a ManagedZone
 
-To manage the creation of DNS records, MGC uses [ManagedZone](../dnspolicy/managed-zone.md) resources. A `ManagedZone` can be configured to use DNS Zones on both AWS (Route53), and GCP (Cloud DNS). 
+**Note:** :exclamation: To manage the creation of DNS records, MGC uses [ManagedZone](../dnspolicy/managed-zone.md) resources. A `ManagedZone` can be configured to use DNS Zones on both AWS (Route53), and GCP (Cloud DNS). Commands to create each are provided below. 
 
-First, depending on the provider you would like to use export the [environment variables detailed here](https://docs.kuadrant.io/multicluster-gateway-controller/docs/getting-started/#config) in a terminal session.
+First, depending on the provider you would like to use export the [environment variables detailed here](https://docs.kuadrant.io/getting-started/#config) in a terminal session.
 
 Next, create a secret containing either the AWS or GCP credentials. We'll also create a namespace for your MGC configs:
-
-:**Note:** :exclamation: If you need help getting the configuration for these credentials, see the [DNS Provider](../dnspolicy/dns-provider.md) guide.
 
 #### AWS:
 ```bash
@@ -134,7 +132,7 @@ stringData:
 EOF
 ```
 
-A `ManagedZone` can then be created:
+A `ManagedZone` can now be created:
 
 #### AWS:
 

--- a/docs/installation/control-plane-installation.md
+++ b/docs/installation/control-plane-installation.md
@@ -5,6 +5,7 @@ This guide will show you how to install and configure the Multi-Cluster Gateway 
 ## Prerequisites
 
 - A **hub cluster** running the OCM control plane (v0.11.0 or greater)
+- Addons enabled `clusteradm install hub-addon --names application-manager`
 - Any number of additional **spoke clusters** that have been configured as OCM [ManagedClusters](https://open-cluster-management.io/concepts/managedcluster/)
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) (>= v1.14.0)
 - Either a pre-existing [cert-manager](https://cert-manager.io/)(>=v1.12.2) installation or the [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) and [Helm](https://helm.sh/docs/intro/quickstart/#install-helm) CLIs

--- a/docs/installation/service-protection-installation.md
+++ b/docs/installation/service-protection-installation.md
@@ -11,19 +11,21 @@ This walkthrough will show you how to install and setup the Kuadrant Operator in
     * [https://open-cluster-management.io/concepts/managedcluster/]
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) (>= v1.14.0)
 * OLM will need to be installed into the ManagedCluster where you want to run the Kuadrant Service Protection components
-  * See https://olm.operatorframework.io/docs/getting-started/
+  * See: 
+    * https://sdk.operatorframework.io/docs/installation/
+    * https://olm.operatorframework.io/docs/getting-started/
 * Kuadrant uses Istio as a Gateway API provider - this will need to be installed into the data plane clusters
-  * We recommend installing Istio 1.17.0, including Gateway API v1
-  * ```bash
+  * We recommend installing Istio 1.20.0, including Gateway API v1
+  * ```
     kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml"
     ```
-  * See also: [https://istio.io/v1.17/blog/2022/getting-started-gtwapi/]
+  * See also: [https://preliminary.istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/]
 
 ## Install the Kuadrant OCM Add-On
 To install the Kuadrant Service Protection components into a spoke `ManagedCluster`, target your OCM Hub cluster with `kubectl` and run:
 
-```bash
-kubectl apply -k "github.com/kuadrant/multicluster-gateway-controller.git/config/service-protection-install-guide?ref=main" -n namespace-of-your-managed-spoke-cluster-on-the-hub
+```
+kubectl apply -k "github.com/kuadrant/multicluster-gateway-controller.git/config/service-protection-install-guide?ref=release-0.2" -n namespace-of-your-managed-spoke-cluster-on-the-hub
 ```
 
 The above command will install the `ManagedClusterAddOn` resource needed to install the Kuadrant addon into the namespace representing a spoke cluster, and install the Kuadrant data-plane components into the `open-cluster-management-agent-addon` namespace. 

--- a/docs/installation/service-protection-installation.md
+++ b/docs/installation/service-protection-installation.md
@@ -13,9 +13,9 @@ This walkthrough will show you how to install and setup the Kuadrant Operator in
 * OLM will need to be installed into the ManagedCluster where you want to run the Kuadrant Service Protection components
   * See https://olm.operatorframework.io/docs/getting-started/
 * Kuadrant uses Istio as a Gateway API provider - this will need to be installed into the data plane clusters
-  * We recommend installing Istio 1.17.0, including Gateway API v0.6.2
+  * We recommend installing Istio 1.17.0, including Gateway API v1
   * ```bash
-    kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.2"
+    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml"
     ```
   * See also: [https://istio.io/v1.17/blog/2022/getting-started-gtwapi/]
 


### PR DESCRIPTION
Fix issue in docs with no add-ons enabled via ocm
Fix issue with glbc ClusterIssuer being installed
Fix issue with install check not looking at policy controller
Fix Gateway API version

Add Context to hub commands - after ocm quickstart the context is set to the last spoke cluster.
Remove one of the options for adding the `RawFeedbackJsonString` - option 1 was problematic on mac. also if the user follows https://open-cluster-management.io/getting-started/quick-start/ some of the steps that were in option 1 were done by the installer. 
Move the installation of the cert-manager step above (optional with the removal of the issuer during installation)
Improve the flow of creating the ManagedZone section/commands

