### PR TITLE
docs: Add DNSPolicy overview doc

### DIFF
--- a/docs/dnspolicy/dns-health-checks.md
+++ b/docs/dnspolicy/dns-health-checks.md
@@ -2,7 +2,7 @@
 DNS Health Checks are a crucial tool for ensuring the availability and reliability of your multi-cluster applications. Kuadrant offers a powerful feature known as DNSPolicy, which allows you to configure and verify health checks for DNS endpoints. This guide provides a comprehensive overview of how to set up, utilize, and understand DNS health checks.
 
 ## What are DNS Health Checks?
-DNS Health Checks are a way to assess the availability and health of DNS endpoints associated with your applications. These checks involve sending periodic requests to the specified endpoints to determine their responsiveness and health status. by configuring these checks via the [DNSPolicy](dns-policy.md), you can ensure that your applications are correctly registered, operational, and serving traffic as expected.
+DNS Health Checks are a way to assess the availability and health of DNS endpoints associated with your applications. These checks involve sending periodic requests to the specified endpoints to determine their responsiveness and health status. by configuring these checks via the [DNSPolicy](./dnspolicy.md), you can ensure that your applications are correctly registered, operational, and serving traffic as expected.
 
 ## Configuration of Health Checks
 >Note: By default, health checks occur at 60-second intervals.

--- a/docs/dnspolicy/dnspolicy-quickstart.md
+++ b/docs/dnspolicy/dnspolicy-quickstart.md
@@ -53,4 +53,4 @@ be available through the defined hosts.
 ## Advanced DNS configuration
 
 The DNSPolicy supports other optional configuration options like geographic and
-weighted load balancing and health checks. For more detailed information about these options, see [DNSPolicy reference](dns-policy.md)
+weighted load balancing and health checks. For more detailed information about these options, see [DNSPolicy](./dnspolicy.md)

--- a/docs/dnspolicy/dnspolicy.md
+++ b/docs/dnspolicy/dnspolicy.md
@@ -1,0 +1,282 @@
+# Kuadrant DNSPolicy
+
+The DNSPolicy is a [GatewayAPI](https://gateway-api.sigs.k8s.io/) policy that uses `Direct Policy Attachment` as defined in the [policy attachment mechanism](https://gateway-api.sigs.k8s.io/v1alpha2/references/policy-attachment/) standard.
+This policy is used to provide dns management for gateway listeners by managing the lifecycle of dns records in external dns providers such as AWS Route53 and Google DNS.
+
+## How it works
+
+A DNSPolicy and its targeted Gateway API networking resource contain all the statements to configure both the ingress gateway and the external DNS service. 
+The needed dns names are gathered from the listener definitions and the IPAdresses | CNAME hosts are gathered from the status block of the gateway resource.
+
+### The DNSPolicy custom resource
+
+#### Overview
+
+The `DNSPolicy` spec includes the following parts:
+
+* A reference to an existing Gateway API resource (`spec.targetRef`)
+* DNS Routing Strategy (`spec.routingStrategy`)
+* LoadBalancing specification (`spec.loadBalancing`)
+* HealthCheck specification (`spec.healthCheck`)
+
+#### High-level example and field definition
+
+```yaml
+apiVersion: kuadrant.io/v1alpha1
+kind: DNSPolicy
+metadata:
+  name: my-dns-policy
+spec:
+  # reference to an existing networking resource to attach the policy to
+  # it can only be a Gateway API Gateway resource
+  # it can only refer to objects in the same namespace as the DNSPolicy
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: mygateway
+   
+  # (optional) routing strategy to use when creating DNS records, defaults to `loadbalanced`
+  # determines what DNS records are created in the DNS provider
+  # check out Kuadrant RFC 0005 https://github.com/Kuadrant/architecture/blob/main/rfcs/0005-single-cluster-dnspolicy.md to learn more about the Routing Strategy field
+  # One-of: simple, loadbalanced.
+  routingStrategy: loadbalanced
+
+  # (optional) loadbalancing specification
+  # use it for providing the specification of how dns will be configured in order to provide balancing of load across multiple clusters when using the `loadbalanced` routing strategy
+  # Primary use of this is for multi cluster deployments
+  # check out Kuadrant RFC 0003 https://github.com/Kuadrant/architecture/blob/main/rfcs/0003-dns-policy.md to learn more about the options that can be used in this field
+  loadBalancing:
+    # (optional) weighted specification
+    # use it to control the weight value applied to records
+    weighted:
+      # use it to change the weight of a record based on labels applied to the target meta resource i.e. Gateway in a single cluster context or ManagedCluster in multi cluster with OCM
+      custom:
+        - weight: 200
+          selector:
+            matchLabels:
+              kuadrant.io/lb-attribute-custom-weight: AWS
+      # (optional) weight value that will be applied to weighted dns records by default. Integer greater than 0 and no larger than the maximum value accepted by the target dns provider, defaults to `120` 
+      defaultWeight: 100
+    # (optional) geo specification
+    # use it to control the geo value applied to records 
+    geo:
+      # (optional) default geo to be applied to records 
+      defaultGeo: IE
+
+  # (optional) health check specification
+  # health check probes with the following specification will be created for each DNS target 
+  # check out [DNS Health Checks](./dns-health-checks.md) to learn more about the HealthChecks that can be used in this field
+  healthCheck:
+    allowInsecureCertificates: true
+    endpoint: /
+    expectedResponses:
+      - 200
+      - 201
+      - 301
+    failureThreshold: 5
+    port: 443
+    protocol: https
+```
+
+Check out the [API reference](../reference/dnspolicy.md) for a full specification of the DNSPolicy CRD.
+
+## Using the DNSPolicy
+
+### DNS Provider and ManagedZone Setup
+
+A DNSPolicy acts against a target Gateway by processing its listeners for hostnames that it can create dns records for. 
+In order for it to do this, it must know about dns providers, and what domains these dns providers are currently hosting.
+This is done through the creation of ManagedZones and dns provider secrets containing the credentials for the dns provider account.
+
+If for example a Gateway is created with a listener with a hostname of `echo.apps.hcpapps.net`:
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-gw
+spec:
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: All
+      name: api
+      hostname: echo.apps.hcpapps.net
+      port: 80
+      protocol: HTTP
+```
+
+In order for the DNSPolicy to act upon that listener, a ManagedZone must exist for that hostnames' domain.
+
+```yaml
+apiVersion: kuadrant.io/v1alpha1
+kind: ManagedZone
+metadata:
+  name: apps.hcpapps.net
+spec:
+  domainName: apps.hcpapps.net
+  description: "apps.hcpapps.net managed domain"
+  dnsProviderSecretRef:
+    name: my-aws-credentials
+    namespace: <ManagedZone Namespace>
+```
+
+The managed zone references a secret containing the external DNS provider services credentials.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-aws-credentials
+  namespace: <ManagedZone Namespace>
+data:
+  AWS_ACCESS_KEY_ID: <AWS_ACCESS_KEY_ID>
+  AWS_REGION: <AWS_REGION>
+  AWS_SECRET_ACCESS_KEY: <AWS_SECRET_ACCESS_KEY>
+type: kuadrant.io/aws
+```
+
+### Targeting a Gateway networking resource
+
+When a DNSPolicy targets a Gateway, the policy will be enforced on all gateway listeners that have a matching ManagedZone.
+
+Target a Gateway by setting the `spec.targetRef` field of the DNSPolicy as follows:
+
+```yaml
+apiVersion: kuadrant.io/v1beta2
+kind: DNSPolicy
+metadata:
+  name: <DNSPolicy name>
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: <Gateway Name>
+```
+
+### DNSRecord Resource
+
+The DNSPolicy will create a DNSRecord resource for each listener hostname with a suitable ManagedZone configured. The DNSPolicy resource uses the status of the Gateway to determine what dns records need to be created based on the clusters it has been placed onto.
+
+Given the following multi cluster gateway status:
+```yaml
+status:
+  addresses:
+    - type: kuadrant.io/MultiClusterIPAddress
+      value: kind-mgc-workload-1/172.31.201.1
+    - type: kuadrant.io/MultiClusterIPAddress
+      value: kind-mgc-workload-2/172.31.202.1
+  listeners:
+    - attachedRoutes: 1
+      conditions: []
+      name: kind-mgc-workload-1.api
+      supportedKinds: []
+    - attachedRoutes: 1
+      conditions: []
+      name: kind-mgc-workload-2.api
+      supportedKinds: []        
+```
+
+A DNSPolicy targeting this gateway would create an appropriate DNSRecord based on the routing strategy selected.
+
+#### loadbalanced
+```yaml
+apiVersion: kuadrant.io/v1alpha1
+kind: DNSRecord
+metadata:
+  name: echo.apps.hcpapps.net
+  namespace: <Gateway Namespace>
+spec:
+  endpoints:
+    - dnsName: 24osuu.lb-2903yb.echo.apps.hcpapps.net
+      recordTTL: 60
+      recordType: A
+      targets:
+        - 172.31.202.1
+    - dnsName: default.lb-2903yb.echo.apps.hcpapps.net
+      providerSpecific:
+        - name: weight
+          value: "120"
+      recordTTL: 60
+      recordType: CNAME
+      setIdentifier: 24osuu.lb-2903yb.echo.apps.hcpapps.net
+      targets:
+        - 24osuu.lb-2903yb.echo.apps.hcpapps.net
+    - dnsName: default.lb-2903yb.echo.apps.hcpapps.net
+      providerSpecific:
+        - name: weight
+          value: "120"
+      recordTTL: 60
+      recordType: CNAME
+      setIdentifier: lrnse3.lb-2903yb.echo.apps.hcpapps.net
+      targets:
+        - lrnse3.lb-2903yb.echo.apps.hcpapps.net
+    - dnsName: echo.apps.hcpapps.net
+      recordTTL: 300
+      recordType: CNAME
+      targets:
+        - lb-2903yb.echo.apps.hcpapps.net
+    - dnsName: lb-2903yb.echo.apps.hcpapps.net
+      providerSpecific:
+        - name: geo-country-code
+          value: '*'
+      recordTTL: 300
+      recordType: CNAME
+      setIdentifier: default
+      targets:
+        - default.lb-2903yb.echo.apps.hcpapps.net
+    - dnsName: lrnse3.lb-2903yb.echo.apps.hcpapps.net
+      recordTTL: 60
+      recordType: A
+      targets:
+        - 172.31.201.1
+  managedZone:
+    name: apps.hcpapps.net   
+```
+
+After DNSRecord reconciliation the listener hostname should be resolvable through dns:
+
+```bash
+dig echo.apps.hcpapps.net +short
+lb-2903yb.echo.apps.hcpapps.net.
+default.lb-2903yb.echo.apps.hcpapps.net.
+lrnse3.lb-2903yb.echo.apps.hcpapps.net.
+172.31.201.1
+```
+
+#### simple
+```yaml
+apiVersion: kuadrant.io/v1alpha1
+kind: DNSRecord
+metadata:
+  name: echo.apps.hcpapps.net
+  namespace: <Gateway Namespace>
+spec:
+  endpoints:
+    - dnsName: echo.apps.hcpapps.net
+      recordTTL: 60
+      recordType: A
+      targets:
+        - 172.31.201.1
+        - 172.31.202.1
+  managedZone:
+    name: apps.hcpapps.net   
+```
+
+After DNSRecord reconciliation the listener hostname should be resolvable through dns:
+
+```bash
+dig echo.apps.hcpapps.net +short
+172.31.201.1
+```
+
+More information about the dns record structure can be found in the [DNSRecord structure](../proposals/DNSRecordStructure.md) document.
+
+### Examples
+
+Check out the following user guides for examples of using the Kuadrant DNSPolicy:
+* [Multicluster LoadBalanced DNSPolicy](../how-to/multicluster-loadbalanced-dnspolicy.md)
+
+### Known limitations
+
+* One Gateway can only be targeted by one DNSPolicy.
+* DNSPolicies can only target Gateways defined within the same namespace of the DNSPolicy.

--- a/docs/how-to/multicluster-loadbalanced-dnspolicy.md
+++ b/docs/how-to/multicluster-loadbalanced-dnspolicy.md
@@ -1,7 +1,4 @@
-# DNS Policy
-
-The DNSPolicy is a [GatewayAPI](https://gateway-api.sigs.k8s.io/) policy that uses `Direct Policy Attachment` as defined in the [policy attachment mechanism](https://gateway-api.sigs.k8s.io/v1alpha2/references/policy-attachment/) standard.
-This policy is used to provide dns management for gateway listeners by managing the lifecycle of dns records in external dns providers such as AWS Route53 and Google DNS.
+# Multicluster LoadBalanced DNSPolicy
 
 ## Terms
 
@@ -115,7 +112,7 @@ The health check section is optional, the following fields are available:
 - `port`: The port to connect to
 - `protocol`: The protocol to use for this connection
 
-For more information about DNS Health Checks, see [this guide](./dns-health-checks.md).
+For more information about DNS Health Checks, see [this guide](../dnspolicy/dns-health-checks.md).
 
 #### Checking status of health checks
 To list all health checks:


### PR DESCRIPTION
* Created a dnspolicy overview doc docs/dnspolicy/dnspolicy.md based on the structure of other kuadrant overview docs. 
*  Moved current dnspolicy doc to docs/how-to/multicluster-loadbalanced-dnspolicy.md (This needs a follow on to convert it correctly to a how to guide). What is in this doc currently is kind of a mix of a guide and reference.

closes #670 