### PR TITLE
#703: Re-add health check components

### DIFF
--- a/cmd/policy_controller/main.go
+++ b/cmd/policy_controller/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	certmanv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -37,11 +38,13 @@ import (
 	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
 
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/apis/v1alpha1"
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/dnshealthcheckprobe"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/dnspolicy"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/dnsrecord"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/managedzone"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/controllers/tlspolicy"
 	"github.com/Kuadrant/multicluster-gateway-controller/pkg/dns/dnsprovider"
+	"github.com/Kuadrant/multicluster-gateway-controller/pkg/health"
 )
 
 var (
@@ -94,6 +97,19 @@ func main() {
 	}
 	provider := dnsprovider.NewProvider(mgr.GetClient())
 
+	healthMonitor := health.NewMonitor()
+	healthCheckQueue := health.NewRequestQueue(time.Second * 5)
+
+	if err := mgr.Add(healthMonitor); err != nil {
+		setupLog.Error(err, "unable to start health monitor")
+		os.Exit(1)
+	}
+
+	if err := mgr.Add(healthCheckQueue); err != nil {
+		setupLog.Error(err, "unable to start health check queue")
+		os.Exit(1)
+	}
+
 	if err = (&dnsrecord.DNSRecordReconciler{
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),
@@ -116,6 +132,15 @@ func main() {
 		DNSProvider: provider.DNSProviderFactory,
 	}).SetupWithManager(mgr, ocmHub); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DNSPolicy")
+		os.Exit(1)
+	}
+
+	if err = (&dnshealthcheckprobe.DNSHealthCheckProbeReconciler{
+		Client:        mgr.GetClient(),
+		HealthMonitor: healthMonitor,
+		Queue:         healthCheckQueue,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "DNSHealthCheckProbe")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder

--- a/pkg/health/monitor.go
+++ b/pkg/health/monitor.go
@@ -22,6 +22,7 @@ func NewMonitor() *Monitor {
 
 func (m *Monitor) Start(ctx context.Context) error {
 	logger := log.FromContext(ctx)
+	logger.V(3).Info("Starting health check monitor")
 
 	<-ctx.Done()
 	m.mux.Lock()

--- a/pkg/health/probeQueuer.go
+++ b/pkg/health/probeQueuer.go
@@ -56,6 +56,8 @@ func (p *ProbeQueuer) Start() {
 	p.cancel = cancel
 	p.logger = log.FromContext(ctx)
 
+	p.logger.V(3).Info("Starting probe queuer", "id", p.ID)
+
 	go func() {
 		for {
 			select {

--- a/pkg/health/queuedProbeWorker.go
+++ b/pkg/health/queuedProbeWorker.go
@@ -50,6 +50,7 @@ func (q *QueuedProbeWorker) EnqueueCheck(req HealthRequest) {
 	q.mux.Lock()
 	defer q.mux.Unlock()
 
+	q.logger.V(3).Info("enqueueing health check", "request", req)
 	q.requests = append(q.requests, req)
 }
 
@@ -90,6 +91,7 @@ func (q *QueuedProbeWorker) dequeue(ctx context.Context) (HealthRequest, bool) {
 
 func (q *QueuedProbeWorker) Start(ctx context.Context) error {
 	q.logger = log.FromContext(ctx)
+	q.logger.V(3).Info("Starting health check queue")
 	defer q.logger.Info("Stopping health check queue")
 
 	for {
@@ -100,6 +102,7 @@ func (q *QueuedProbeWorker) Start(ctx context.Context) error {
 			}
 			return nil
 		case <-time.After(q.Throttle):
+			q.logger.V(3).Info("dequeing health check")
 			req, ok := q.dequeue(ctx)
 			if !ok {
 				return nil


### PR DESCRIPTION
> Closes #703 

Re-add health check monitor and queue, as well as reconciler to policy controller. These components were removed accidentally as part of the separation of controllers

## Verification steps

Run the local setup and include a health check section in the DNSPolicy
Verify that a DNSHealthCheckProbe is created and the status is updated 