### PR TITLE
Remove namespace on dnsProviderSecretRef to force same namespace as M…

### DIFF
--- a/bundle/manifests/kuadrant.io_managedzones.yaml
+++ b/bundle/manifests/kuadrant.io_managedzones.yaml
@@ -62,11 +62,8 @@ spec:
                 properties:
                   name:
                     type: string
-                  namespace:
-                    type: string
                 required:
                 - name
-                - namespace
                 type: object
               domainName:
                 description: Domain name of this ManagedZone

--- a/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
+++ b/bundle/manifests/multicluster-gateway-controller.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2023-11-21T16:17:37Z"
+    createdAt: "2023-12-08T11:41:09Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-gateway-controller.v0.0.0

--- a/config/local-setup/controller/aws/managed_zone.yaml
+++ b/config/local-setup/controller/aws/managed_zone.yaml
@@ -8,5 +8,3 @@ spec:
   description: "Dev Managed Zone"
   dnsProviderSecretRef:
     name: mgc-aws-credentials
-    namespace: multi-cluster-gateways
-

--- a/config/local-setup/controller/gcp/managed_zone.yaml
+++ b/config/local-setup/controller/gcp/managed_zone.yaml
@@ -8,5 +8,3 @@ spec:
   description: "Dev Managed Zone"
   dnsProviderSecretRef:
     name: mgc-gcp-credentials
-    namespace: multi-cluster-gateways
-

--- a/config/policy-controller/crd/bases/kuadrant.io_managedzones.yaml
+++ b/config/policy-controller/crd/bases/kuadrant.io_managedzones.yaml
@@ -63,11 +63,8 @@ spec:
                 properties:
                   name:
                     type: string
-                  namespace:
-                    type: string
                 required:
                 - name
-                - namespace
                 type: object
               domainName:
                 description: Domain name of this ManagedZone

--- a/docs/demos/dns-policy/resources/managedzone_jm.hcpapps.net.yaml
+++ b/docs/demos/dns-policy/resources/managedzone_jm.hcpapps.net.yaml
@@ -9,5 +9,3 @@ spec:
   description: "jm.hcpapps.net managed domain"
   dnsProviderSecretRef:
     name: mgc-aws-credentials
-    namespace: multi-cluster-gateways
-    type: AWS

--- a/docs/dnspolicy/dnspolicy.md
+++ b/docs/dnspolicy/dnspolicy.md
@@ -117,7 +117,6 @@ spec:
   description: "apps.hcpapps.net managed domain"
   dnsProviderSecretRef:
     name: my-aws-credentials
-    namespace: <ManagedZone Namespace>
 ```
 
 The managed zone references a secret containing the external DNS provider services credentials.

--- a/docs/how-to/multicluster-loadbalanced-dnspolicy.md
+++ b/docs/how-to/multicluster-loadbalanced-dnspolicy.md
@@ -62,7 +62,6 @@ spec:
   description: "apps.hcpapps.net managed domain"
   dnsProviderSecretRef:
     name: my-aws-credentials
-    namespace: multi-cluster-gateways
 ```
 
 ## DNSPolicy creation and attachment

--- a/docs/installation/control-plane-installation.md
+++ b/docs/installation/control-plane-installation.md
@@ -149,7 +149,6 @@ spec:
   description: "Dev Managed Zone"
   dnsProviderSecretRef:
     name: mgc-aws-credentials
-    namespace: multi-cluster-gateways
 EOF
 ```
 #### GCP
@@ -167,7 +166,6 @@ spec:
   description: "Dev Managed Zone"
   dnsProviderSecretRef:
     name: mgc-gcp-credentials
-    namespace: multi-cluster-gateways
 EOF
 ```
 

--- a/docs/managed-zone.md
+++ b/docs/managed-zone.md
@@ -45,7 +45,6 @@ spec:
   description: "My Managed Zone"
   dnsProviderSecretRef:
     name: my-aws-credentials
-    namespace: multicluster-gateway-controller-system
 EOF
 ```
 
@@ -66,7 +65,6 @@ spec:
   description: "My Managed Zone"
   dnsProviderSecretRef:
     name: my-aws-credentials
-    namespace: multicluster-gateway-controller-system
 EOF
 ```
 
@@ -74,6 +72,8 @@ EOF
 
 This is a reference to secret containing the credentials and other configuration for accessing your dns provider
 [dnsProvider](/docs/dnspolicy/dns-provider.md)
+
+**Note:** the Secret referenced in the `dnsProviderSecretRef` field must be in the same namespace as the ManagedZone.
 
 **Note:** as an `id` was specified, the Managed Gateway Controller will not re-create this zone, nor will it delete it if this `ManagedZone` is deleted.
 

--- a/hack/.deployUtils
+++ b/hack/.deployUtils
@@ -361,7 +361,6 @@ spec:
   description: "Dev Managed Zone"
   dnsProviderSecretRef:
     name: ${KIND_CLUSTER_PREFIX}aws-credentials
-    namespace: multicluster-gateway-controller-system
 EOF
 }
 
@@ -398,7 +397,6 @@ spec:
   description: "Dev Managed Zone"
   dnsProviderSecretRef:
     name: ${KIND_CLUSTER_PREFIX}gcp-credentials
-    namespace: multicluster-gateway-controller-system
 EOF
 }
 

--- a/pkg/apis/v1alpha1/managedzone_types.go
+++ b/pkg/apis/v1alpha1/managedzone_types.go
@@ -46,8 +46,7 @@ type ManagedZoneSpec struct {
 
 type SecretRef struct {
 	//+required
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
+	Name string `json:"name"`
 }
 
 // ManagedZoneStatus defines the observed state of a Zone

--- a/pkg/dns/dnsprovider/dnsProvider.go
+++ b/pkg/dns/dnsprovider/dnsProvider.go
@@ -33,7 +33,7 @@ func (p *providerFactory) DNSProviderFactory(ctx context.Context, managedZone *v
 	providerSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      managedZone.Spec.SecretRef.Name,
-			Namespace: managedZone.Spec.SecretRef.Namespace,
+			Namespace: managedZone.Namespace, // must be in same namespace as ManagedZone
 		}}
 
 	if err := p.Client.Get(ctx, client.ObjectKeyFromObject(providerSecret), providerSecret); err != nil {

--- a/test/policy_integration/managedzone_controller_test.go
+++ b/test/policy_integration/managedzone_controller_test.go
@@ -42,8 +42,7 @@ var _ = Describe("ManagedZoneReconciler", func() {
 					ID:         testutil.Domain,
 					DomainName: testutil.Domain,
 					SecretRef: &v1alpha1.SecretRef{
-						Name:      providerCredential,
-						Namespace: defaultNS,
+						Name: providerCredential,
 					},
 				},
 			}

--- a/test/util/test_dnspolicy_types.go
+++ b/test/util/test_dnspolicy_types.go
@@ -122,8 +122,7 @@ func NewManagedZoneBuilder(name, ns, domainName string) *ManagedZoneBuilder {
 				DomainName:  domainName,
 				Description: domainName,
 				SecretRef: &v1alpha1.SecretRef{
-					Name:      "secretname",
-					Namespace: ns,
+					Name: "secretname",
 				},
 			},
 		},


### PR DESCRIPTION
…anagedZone

Fixes #712 

* Updated types
* Regenerated crd & bundle
* Updated example ManagedZones
* Added note to docs
* Updated tests

Locally the ManagedZone and dns Secret are in the same namespace:
```
kubectl get managedzone,secret -n multi-cluster-gateways
NAME                                     DOMAIN NAME      ID    RECORD COUNT   NAMESERVERS   READY
managedzone.kuadrant.io/mgc-dev-mz-aws   dm.hcpapps.net

NAME                         TYPE              DATA   AGE
secret/mgc-aws-credentials   kuadrant.io/aws   3      13m
```