### PR TITLE
Fix dns provider secret namespace to match ManagedZone namespace

### DIFF
--- a/hack/.deployUtils
+++ b/hack/.deployUtils
@@ -333,7 +333,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ${KIND_CLUSTER_PREFIX}aws-credentials
-  namespace: multicluster-gateway-controller-system
+  namespace: multi-cluster-gateways
 type: "kuadrant.io/aws"
 stringData:
   AWS_ACCESS_KEY_ID: ${MGC_AWS_ACCESS_KEY_ID}
@@ -370,7 +370,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ${KIND_CLUSTER_PREFIX}gcp-credentials
-  namespace: multicluster-gateway-controller-system
+  namespace: multi-cluster-gateways
 type: "kuadrant.io/gcp"
 stringData:
   GOOGLE: '${GOOGLE}'


### PR DESCRIPTION
Fix for ManagedZone status during local setup/quickstart
```
      message: 'The DNS provider failed to ensure the managed zone: Secret "mgc-aws-credentials"
        not found'
```
