### PR TITLE
Add config/samples/kustomization.yaml

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,0 +1,6 @@
+## Append samples you want in your CSV to this file as resources ##
+resources:
+# Used as examples in kuadrant-operator bundle
+- kuadrant.io_v1alpha1_tlspolicy.yaml
+- kuadrant.io_v1alpha1_managedzone.yaml
+- dnspolicy.yaml


### PR DESCRIPTION
This PR is related to: [kuadrant-operator/pull/372](https://github.com/Kuadrant/kuadrant-operator/pull/372)

Adds a kustomization.yaml containing a reference to a set of yaml samples.
To be used as a remote kustomize base in the kuadrant-operator.

The main purpose of this is to have the YAML samples for TLSPolicy, DNSPolicy and ManagedZone displayed in the Operator Hub for kuadrant-operator.

Follow up on the discussion [here](https://github.com/Kuadrant/kuadrant-operator/pull/372/files/b99f99eca66980e61653d4fc7bb48d0242d56544#r1423749325).

No effect on MGC.
