### PR TITLE
add status to DNS policy for ignored wilcard hosts

### DIFF
--- a/pkg/controllers/dnspolicy/dnspolicy_controller.go
+++ b/pkg/controllers/dnspolicy/dnspolicy_controller.go
@@ -44,10 +44,12 @@ import (
 )
 
 const (
-	DNSPolicyFinalizer                                    = "kuadrant.io/dns-policy"
-	DNSPoliciesBackRefAnnotation                          = "kuadrant.io/dnspolicies"
-	DNSPolicyBackRefAnnotation                            = "kuadrant.io/dnspolicy"
-	DNSPolicyAffected            conditions.ConditionType = "kuadrant.io/DNSPolicyAffected"
+	DNSPolicyFinalizer                                           = "kuadrant.io/dns-policy"
+	DNSPoliciesBackRefAnnotation                                 = "kuadrant.io/dnspolicies"
+	DNSPolicyBackRefAnnotation                                   = "kuadrant.io/dnspolicy"
+	DNSPolicyAffected                   conditions.ConditionType = "kuadrant.io/DNSPolicyAffected"
+	DNSPolicyHealthChecksNoIgnoredHosts                          = "NoIgnoredHosts"
+	DNSPolicyHealthChecksIgnoredReason                           = "NoGatewaysWithWildcardHosts"
 )
 
 type DNSPolicyRefsConfig struct{}


### PR DESCRIPTION
When a gateway has wildcard listeners and does not create health probes for them, it should be more obvious that it has skipped them.

## Verification

- Create a gateway with no wildcard listeners
- Target with DNS Policy with health check spec
- see status on DNS policy is:
```
  healthCheck:
    conditions:
    - lastTransitionTime: "....."
      message: 'all gateways routes are creating health checks'
      observedGeneration: 1
      reason: NoGatewaysWithWildcardHosts
      status: "True"
      type: NoIgnoredHosts
```
- Add a wildcard listener to the gateway
- See status on DNS Policy is:
```
  healthCheck:
    conditions:
    - lastTransitionTime: "...."
      message: 'gateways with ignored wildcard hosts: <NAMESPACE>/<GATEWAY NAME>'
      observedGeneration: 2
      reason: NoGatewaysWithWildcardHosts
      status: "False"
      type: NoIgnoredHosts
```
## Closes
#726 