### PR TITLE
Make some scripts more generic

### DIFF
--- a/docs/how-to/multicluster-gateways-walkthrough.md
+++ b/docs/how-to/multicluster-gateways-walkthrough.md
@@ -13,7 +13,7 @@ We will start with a hub cluster and 2 workload clusters and highlight the autom
 
 ## Initial Setup
 
-In this walkthrough, we'll deploy test echo services across multiple clusters. If you followed the [Getting Started Guide](https://docs.kuadrant.io/getting-started/), you would have already set up a `MGC_ZONE_ROOT_DOMAIN` environment variable. For this tutorial, we'll derive a host from this domain for these echo services.
+In this walkthrough, we'll deploy test echo services across multiple clusters. If you followed the [Getting Started Guide](https://docs.kuadrant.io/getting-started/), you would have already set up a `KUADRANT_ZONE_ROOT_DOMAIN` environment variable. For this tutorial, we'll derive a host from this domain for these echo services.
 
 ### Create a gateway
 
@@ -50,7 +50,7 @@ You are now ready to begin creating a gateway! :tada:
         namespaces:
           from: All
       name: api
-      hostname: "*.$MGC_ZONE_ROOT_DOMAIN"
+      hostname: "*.$KUADRANT_ZONE_ROOT_DOMAIN"
       port: 443
       protocol: HTTPS
       tls:
@@ -202,7 +202,7 @@ The listener is configured to use this TLS secret also. So now our gateway has b
 
 So now we have workload ingress clusters configured with the same Gateway. 
 
-5. Let's create the HTTPRoute in the first workload cluster. Again, remembering to replace the hostname accordingly if you haven't already set a value for the `MGC_ZONE_ROOT_DOMAIN` variable as described in the [Getting Started Guide](https://docs.kuadrant.io/getting-started/):
+5. Let's create the HTTPRoute in the first workload cluster. Again, remembering to replace the hostname accordingly if you haven't already set a value for the `KUADRANT_ZONE_ROOT_DOMAIN` variable as described in the [Getting Started Guide](https://docs.kuadrant.io/getting-started/):
     ```bash
     kubectl --context kind-mgc-workload-1 apply -f - <<EOF
     apiVersion: gateway.networking.k8s.io/v1
@@ -215,7 +215,7 @@ So now we have workload ingress clusters configured with the same Gateway.
         name: prod-web
         namespace: kuadrant-multi-cluster-gateways
       hostnames:
-      - "echo.$MGC_ZONE_ROOT_DOMAIN"
+      - "echo.$KUADRANT_ZONE_ROOT_DOMAIN"
       rules:
       - backendRefs:
         - name: echo
@@ -271,7 +271,7 @@ So now we have workload ingress clusters configured with the same Gateway.
         name: prod-web
         namespace: kuadrant-multi-cluster-gateways
       hostnames:
-      - "echo.$MGC_ZONE_ROOT_DOMAIN"
+      - "echo.$KUADRANT_ZONE_ROOT_DOMAIN"
       rules:
       - backendRefs:
         - name: echo
@@ -323,18 +323,18 @@ So now we have workload ingress clusters configured with the same Gateway.
 8. Give DNS a minute or two to update. You should then be able to execute the following and get back the correct A record. 
 
     ```bash
-    dig echo.$MGC_ZONE_ROOT_DOMAIN
+    dig echo.$KUADRANT_ZONE_ROOT_DOMAIN
     ```
 9. You should also be able to curl that endpoint
 
     ```bash
-    curl -k https://echo.$MGC_ZONE_ROOT_DOMAIN
+    curl -k https://echo.$KUADRANT_ZONE_ROOT_DOMAIN
 
     # Request served by echo-XXX-XXX
     ```
 
 ## Watching DNS changes
-If you want you can use ```watch dig echo.$MGC_ZONE_ROOT_DOMAIN``` to see the DNS switching between the two addresses
+If you want you can use ```watch dig echo.$KUADRANT_ZONE_ROOT_DOMAIN``` to see the DNS switching between the two addresses
 
 ## Follow-on Walkthroughs
 Here are some good, follow-on guides that build on this walkthrough:

--- a/docs/how-to/simple-ratelimitpolicy-for-app-developers.md
+++ b/docs/how-to/simple-ratelimitpolicy-for-app-developers.md
@@ -8,7 +8,7 @@ This user guide walks you through an example of how to configure rate limiting f
 
 ## Overview
 
-In this guide, we will rate limit a sample REST API called **Toy Store**. In reality, this API is just an echo service that echoes back to the user whatever attributes it gets in the request. The API listens to requests at the hostname `api.$MGC_ZONE_ROOT_DOMAIN`, where it exposes the endpoints `GET /toys*` and `POST /toys`, respectively, to mimic operations of reading and writing toy records.
+In this guide, we will rate limit a sample REST API called **Toy Store**. In reality, this API is just an echo service that echoes back to the user whatever attributes it gets in the request. The API listens to requests at the hostname `api.$KUADRANT_ZONE_ROOT_DOMAIN`, where it exposes the endpoints `GET /toys*` and `POST /toys`, respectively, to mimic operations of reading and writing toy records.
 
 We will rate limit the `POST /toys` endpoint to a maximum of 5rp10s ("5 requests every 10 seconds").
 
@@ -81,7 +81,7 @@ spec:
       name: prod-web
       namespace: kuadrant-multi-cluster-gateways
   hostnames:
-  - toystore.$MGC_ZONE_ROOT_DOMAIN
+  - toystore.$KUADRANT_ZONE_ROOT_DOMAIN
   rules:
   - matches:
     - method: GET
@@ -106,7 +106,7 @@ done
 Verify the routes work:
 
 ```sh
-curl -ik https://toystore.$MGC_ZONE_ROOT_DOMAIN/toys
+curl -ik https://toystore.$KUADRANT_ZONE_ROOT_DOMAIN/toys
 # HTTP/1.1 200 OK
 ```
 
@@ -154,13 +154,13 @@ Verify the rate limiting works by sending requests in a loop.
 Up to 5 successful (`200 OK`) requests every 10 seconds to `POST /toys`, then `429 Too Many Requests`:
 
 ```sh
-while :; do curl --write-out '%{http_code}' --silent -k --output /dev/null https://toystore.$MGC_ZONE_ROOT_DOMAIN/toys -X POST | egrep --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}' --silent -k --output /dev/null https://toystore.$KUADRANT_ZONE_ROOT_DOMAIN/toys -X POST | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
 Unlimited successful (`200 OK`) to `GET /toys`:
 
 ```sh
-while :; do curl --write-out '%{http_code}' --silent -k  --output /dev/null https://toystore.$MGC_ZONE_ROOT_DOMAIN/toys | egrep --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}' --silent -k  --output /dev/null https://toystore.$KUADRANT_ZONE_ROOT_DOMAIN/toys | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
 ## Next Steps

--- a/docs/installation/control-plane-installation.md
+++ b/docs/installation/control-plane-installation.md
@@ -103,9 +103,9 @@ metadata:
   namespace: multi-cluster-gateways
 type: "kuadrant.io/aws"
 stringData:
-  AWS_ACCESS_KEY_ID: ${MGC_AWS_ACCESS_KEY_ID}
-  AWS_SECRET_ACCESS_KEY: ${MGC_AWS_SECRET_ACCESS_KEY}
-  AWS_REGION: ${MGC_AWS_REGION}
+  AWS_ACCESS_KEY_ID: ${KUADRANT_AWS_ACCESS_KEY_ID}
+  AWS_SECRET_ACCESS_KEY: ${KUADRANT_AWS_SECRET_ACCESS_KEY}
+  AWS_REGION: ${KUADRANT_AWS_REGION}
 EOF
 ```
 #### GCP
@@ -140,8 +140,8 @@ metadata:
   name: mgc-dev-mz
   namespace: multi-cluster-gateways
 spec:
-  id: ${MGC_AWS_DNS_PUBLIC_ZONE_ID}
-  domainName: ${MGC_ZONE_ROOT_DOMAIN}
+  id: ${KUADRANT_AWS_DNS_PUBLIC_ZONE_ID}
+  domainName: ${KUADRANT_ZONE_ROOT_DOMAIN}
   description: "Dev Managed Zone"
   dnsProviderSecretRef:
     name: mgc-aws-credentials

--- a/hack/.deployUtils
+++ b/hack/.deployUtils
@@ -323,6 +323,10 @@ deployPrometheusForFederation() {
 # quickstart-setup specific functions
 
 setupAWSProvider() {
+  local namespace="$1"
+  if [ -z "$1" ]; then
+    namespace="multi-cluster-gateways"
+  fi
   if [ "$MGC_AWS_ACCESS_KEY_ID" == "" ]; then
     echo "MGC_AWS_ACCESS_KEY_ID is not set"
     exit 1
@@ -333,7 +337,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ${KIND_CLUSTER_PREFIX}aws-credentials
-  namespace: multi-cluster-gateways
+  namespace: ${namespace}
 type: "kuadrant.io/aws"
 stringData:
   AWS_ACCESS_KEY_ID: ${MGC_AWS_ACCESS_KEY_ID}
@@ -344,7 +348,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ${KIND_CLUSTER_PREFIX}controller-config
-  namespace: multicluster-gateway-controller-system
+  namespace: ${namespace}
 data:
   AWS_DNS_PUBLIC_ZONE_ID: ${MGC_AWS_DNS_PUBLIC_ZONE_ID}
   ZONE_ROOT_DOMAIN: ${MGC_ZONE_ROOT_DOMAIN}
@@ -354,7 +358,7 @@ apiVersion: kuadrant.io/v1alpha1
 kind: ManagedZone
 metadata:
   name: ${KIND_CLUSTER_PREFIX}dev-mz
-  namespace: multi-cluster-gateways
+  namespace: ${namespace}
 spec:
   id: ${MGC_AWS_DNS_PUBLIC_ZONE_ID}
   domainName: ${MGC_ZONE_ROOT_DOMAIN}
@@ -365,12 +369,16 @@ EOF
 }
 
 setupGCPProvider() {
+  local namespace="$1"
+  if [ -z "$1" ]; then
+    namespace="multi-cluster-gateways"
+  fi
   kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
   name: ${KIND_CLUSTER_PREFIX}gcp-credentials
-  namespace: multi-cluster-gateways
+  namespace: ${namespace}
 type: "kuadrant.io/gcp"
 stringData:
   GOOGLE: '${GOOGLE}'
@@ -380,7 +388,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ${KIND_CLUSTER_PREFIX}controller-config
-  namespace: multicluster-gateway-controller-system
+  namespace: ${namespace}
 data:
   ZONE_DNS_NAME: ${ZONE_DNS_NAME}
   ZONE_NAME: ${ZONE_NAME}
@@ -390,7 +398,7 @@ apiVersion: kuadrant.io/v1alpha1
 kind: ManagedZone
 metadata:
   name: ${KIND_CLUSTER_PREFIX}dev-mz
-  namespace: multi-cluster-gateways
+  namespace: ${namespace}
 spec:
   id: ${ZONE_NAME}
   domainName: ${ZONE_DNS_NAME}
@@ -402,17 +410,18 @@ EOF
 
 configureController() {
     clusterName=${1}
+    namespace=${2}
     kubectl config use-context kind-${clusterName}
     echo "Initialize local dev setup for the controller on ${clusterName}"
 
     case $DNS_PROVIDER in
       aws)
           echo "Setting up an AWS Route 53 DNS provider"
-          setupAWSProvider
+          setupAWSProvider ${namespace}
           ;;
       gcp)
           echo "Setting up a Google Cloud DNS provider"
-          setupGCPProvider
+          setupGCPProvider ${namespace}
           ;;
       *)
         echo "Unknown DNS provider"

--- a/hack/.deployUtils
+++ b/hack/.deployUtils
@@ -327,8 +327,8 @@ setupAWSProvider() {
   if [ -z "$1" ]; then
     namespace="multi-cluster-gateways"
   fi
-  if [ "$MGC_AWS_ACCESS_KEY_ID" == "" ]; then
-    echo "MGC_AWS_ACCESS_KEY_ID is not set"
+  if [ "$KUADRANT_AWS_ACCESS_KEY_ID" == "" ]; then
+    echo "KUADRANT_AWS_ACCESS_KEY_ID is not set"
     exit 1
   fi
 
@@ -340,9 +340,9 @@ metadata:
   namespace: ${namespace}
 type: "kuadrant.io/aws"
 stringData:
-  AWS_ACCESS_KEY_ID: ${MGC_AWS_ACCESS_KEY_ID}
-  AWS_SECRET_ACCESS_KEY: ${MGC_AWS_SECRET_ACCESS_KEY}
-  AWS_REGION: ${MGC_AWS_REGION}
+  AWS_ACCESS_KEY_ID: ${KUADRANT_AWS_ACCESS_KEY_ID}
+  AWS_SECRET_ACCESS_KEY: ${KUADRANT_AWS_SECRET_ACCESS_KEY}
+  AWS_REGION: ${KUADRANT_AWS_REGION}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -350,8 +350,8 @@ metadata:
   name: ${KIND_CLUSTER_PREFIX}controller-config
   namespace: ${namespace}
 data:
-  AWS_DNS_PUBLIC_ZONE_ID: ${MGC_AWS_DNS_PUBLIC_ZONE_ID}
-  ZONE_ROOT_DOMAIN: ${MGC_ZONE_ROOT_DOMAIN}
+  AWS_DNS_PUBLIC_ZONE_ID: ${KUADRANT_AWS_DNS_PUBLIC_ZONE_ID}
+  ZONE_ROOT_DOMAIN: ${KUADRANT_ZONE_ROOT_DOMAIN}
   LOG_LEVEL: "${LOG_LEVEL}"
 ---
 apiVersion: kuadrant.io/v1alpha1
@@ -360,8 +360,8 @@ metadata:
   name: ${KIND_CLUSTER_PREFIX}dev-mz
   namespace: ${namespace}
 spec:
-  id: ${MGC_AWS_DNS_PUBLIC_ZONE_ID}
-  domainName: ${MGC_ZONE_ROOT_DOMAIN}
+  id: ${KUADRANT_AWS_DNS_PUBLIC_ZONE_ID}
+  domainName: ${KUADRANT_ZONE_ROOT_DOMAIN}
   description: "Dev Managed Zone"
   dnsProviderSecretRef:
     name: ${KIND_CLUSTER_PREFIX}aws-credentials

--- a/hack/.kindUtils
+++ b/hack/.kindUtils
@@ -72,7 +72,7 @@ kindSetupMGCClusters() {
     local dataPlaneClusterCount=$5
 
     # Create network for the clusters
-    docker network create -d bridge --subnet 172.31.0.0/16 mgc --gateway 172.31.0.1 \
+    docker network create -d bridge --subnet 172.31.0.0/16 ${KIND_CLUSTER_DOCKER_NETWORK} --gateway 172.31.0.1 \
       -o "com.docker.network.bridge.enable_ip_masquerade"="true" \
       -o "com.docker.network.driver.mtu"="1500"
 

--- a/hack/.quickstartEnv
+++ b/hack/.quickstartEnv
@@ -2,7 +2,11 @@ export TOOLS_IMAGE=quay.io/kuadrant/mgc-tools:latest
 export TMP_DIR=/tmp/mgc
 
 dockerBinCmd() {
-  echo "docker run --rm -u $UID -v ${TMP_DIR}:/tmp/mgc:z --network mgc -e KUBECONFIG=/tmp/mgc/kubeconfig --entrypoint=$1 $TOOLS_IMAGE"
+  local network=""
+  if [ ! -z ${KIND_CLUSTER_DOCKER_NETWORK} ]; then
+    network=" --network ${KIND_CLUSTER_DOCKER_NETWORK}"
+  fi
+  echo "docker run --rm -u $UID -v ${TMP_DIR}:/tmp/mgc:z${network} -e KUBECONFIG=/tmp/mgc/kubeconfig --entrypoint=$1 $TOOLS_IMAGE"
 }
 
 export KIND_BIN=kind

--- a/hack/.quickstartEnv
+++ b/hack/.quickstartEnv
@@ -26,34 +26,34 @@ requiredENV() {
   fi
 
   if [[ "$PROVIDER" == "aws" ]]; then
-    if [[ -z "${MGC_AWS_ACCESS_KEY_ID}" ]]; then
+    if [[ -z "${KUADRANT_AWS_ACCESS_KEY_ID}" ]]; then
     echo "Enter an AWS access key ID for an account where you have access to Route53:"
-    read MGC_AWS_ACCESS_KEY_ID </dev/tty
-    echo "export MGC_AWS_ACCESS_KEY_ID for future executions of the script to skip this step"
+    read KUADRANT_AWS_ACCESS_KEY_ID </dev/tty
+    echo "export KUADRANT_AWS_ACCESS_KEY_ID for future executions of the script to skip this step"
     fi
 
-    if [[ -z "${MGC_AWS_SECRET_ACCESS_KEY}" ]]; then
+    if [[ -z "${KUADRANT_AWS_SECRET_ACCESS_KEY}" ]]; then
     echo "Enter the corresponding AWS secret access key for the AWS access key ID entered above:"
-    read MGC_AWS_SECRET_ACCESS_KEY </dev/tty
-    echo "export MGC_AWS_SECRET_ACCESS_KEY for future executions of the script to skip this step"
+    read KUADRANT_AWS_SECRET_ACCESS_KEY </dev/tty
+    echo "export KUADRANT_AWS_SECRET_ACCESS_KEY for future executions of the script to skip this step"
     fi
 
-    if [[ -z "${MGC_AWS_REGION}" ]]; then
+    if [[ -z "${KUADRANT_AWS_REGION}" ]]; then
     echo "Enter an AWS region (e.g. eu-west-1) for an Account where you have access to Route53:"
-    read MGC_AWS_REGION </dev/tty
-    echo "export MGC_AWS_REGION for future executions of the script to skip this step"
+    read KUADRANT_AWS_REGION </dev/tty
+    echo "export KUADRANT_AWS_REGION for future executions of the script to skip this step"
     fi
 
-    if [[ -z "${MGC_AWS_DNS_PUBLIC_ZONE_ID}" ]]; then
+    if [[ -z "${KUADRANT_AWS_DNS_PUBLIC_ZONE_ID}" ]]; then
     echo "Enter the Public Zone ID of your Route53 zone:"
-    read MGC_AWS_DNS_PUBLIC_ZONE_ID </dev/tty
-    echo "export MGC_AWS_DNS_PUBLIC_ZONE_ID for future executions of the script to skip this step"
+    read KUADRANT_AWS_DNS_PUBLIC_ZONE_ID </dev/tty
+    echo "export KUADRANT_AWS_DNS_PUBLIC_ZONE_ID for future executions of the script to skip this step"
     fi
 
-    if [[ -z "${MGC_ZONE_ROOT_DOMAIN}" ]]; then
+    if [[ -z "${KUADRANT_ZONE_ROOT_DOMAIN}" ]]; then
     echo "Enter the root domain of your Route53 hosted zone (e.g. www.example.com):"
-    read MGC_ZONE_ROOT_DOMAIN </dev/tty
-    echo "export MGC_ZONE_ROOT_DOMAIN for future executions of the script to skip this step"
+    read KUADRANT_ZONE_ROOT_DOMAIN </dev/tty
+    echo "export KUADRANT_ZONE_ROOT_DOMAIN for future executions of the script to skip this step"
     fi
   else 
       if [[ -z "${GOOGLE}" ]]; then

--- a/hack/.setupEnv
+++ b/hack/.setupEnv
@@ -3,6 +3,7 @@
 export KIND_CLUSTER_PREFIX="mgc-"
 export KIND_CLUSTER_CONTROL_PLANE="${KIND_CLUSTER_PREFIX}control-plane"
 export KIND_CLUSTER_WORKLOAD="${KIND_CLUSTER_PREFIX}workload"
+export KIND_CLUSTER_DOCKER_NETWORK="mgc"
 
 export port80=9090
 export port443=8445


### PR DESCRIPTION
To be able to re-use some of the functions in the quickstart script for kuadrant-operator I've tried to make them a little more generic:

- Made the network in `dockerBinCmd` overridable by env var instead of set to mgc
- Made the namespace for `configureController` overridable
- Renamed quite a few environment variables to `KUADRANT_` instead of `MGC_`