### PR TITLE
Fix Alertmanager name so patch gets applied

### DIFF
--- a/config/prometheus-for-federation/kustomization.yaml
+++ b/config/prometheus-for-federation/kustomization.yaml
@@ -40,12 +40,12 @@ patches:
           name: additional-scrape-configs
           key: prometheus-additional.yaml
   - target:
-      kind: AlertManager
-      name: k8s
+      kind: Alertmanager
+      name: main
     patch: |-
-      kind: AlertManager
+      kind: Alertmanager
       metadata:
-        name: k8s
+        name: main
       spec:
         replicas: 1
   - target:


### PR DESCRIPTION
If following the metrics quickstart, alertmanager runs with 3 replicas.
This change fixes a patch so that only 1 replica runs (which was the expected behaviour when originally added)

@R-Lawton This makes sense to cherry-pick from #756 back to main as well.