### PR TITLE
fix: GCP e2e tests

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -103,6 +103,7 @@ jobs:
       - name: Dump Gateway Controller logs
         if: ${{ failure() }}
         run: |
+          kubectl get deployments -A
           kubectl --context kind-mgc-control-plane logs --all-containers --ignore-errors deployment/mgc-controller-manager -n multicluster-gateway-controller-system
       - name: Dump Policy Controller logs
         if: ${{ failure() }}

--- a/hack/.deployUtils
+++ b/hack/.deployUtils
@@ -64,7 +64,6 @@ deployOCMHub(){
   echo "checking if cluster is single or multi"
   if [[ -n "${OCM_SINGLE}" ]]; then
     deployOCMSpoke ${clusterName}
-    configureManagedAddon ${clusterName} ${clusterName}
     deployOLM ${KIND_CLUSTER_CONTROL_PLANE}
 
     if ! [[ -n "${minimal}" ]]; then


### PR DESCRIPTION
Don't configure managed addon when OCM_SINGLE is being used. 

**Note:** OCM_SINGLE shouldn't really be used anywhere now but our e2e tests currently still rely on it.

Changes added to allow errors to be surfaced when checking the dnsrecord resource status.