### PR TITLE
Add kaudrant resources to ksm permissions

### DIFF
--- a/config/prometheus-for-federation/ksm_clusterrole_patch.yaml
+++ b/config/prometheus-for-federation/ksm_clusterrole_patch.yaml
@@ -24,3 +24,16 @@
     verbs:
     - list
     - watch
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - "kuadrant.io"
+    resources:
+    - tlspolicies
+    - dnspolicies
+    - ratelimitpolicies
+    - authpolicies
+    verbs:
+    - list
+    - watch


### PR DESCRIPTION
This has been already applied to the api-upstream branch [here](https://github.com/Kuadrant/multicluster-gateway-controller/commit/b9f53406c94827fecaeac263796afac857660509), which is needed & referenced by the api-quickstart repo.
However, it should land back on main here as well.