### PR TITLE
Change multi cluster docs link to new location

### DIFF
--- a/docs/gateways/define-and-place-a-gateway.md
+++ b/docs/gateways/define-and-place-a-gateway.md
@@ -3,7 +3,7 @@
 In this guide, we will go through defining a Gateway in the OCM hub cluster that can then be distributed to and instantiated on a set of managed spoke clusters.
 
 ### Prerequisites
-* Complete the [Getting Started Guide](https://docs.kuadrant.io/getting-started-multi-cluster/) to bring up a suitable environment. 
+* Complete the [Getting Started Guide](https://docs.kuadrant.io/getting-started-multi-cluster-ocm/) to bring up a suitable environment. 
 
 If you are looking to change provider from the default Istio:
 * Please have the Gateway provider of your choice installed and configured (in this example we use Envoy gateway. See the following [docs](https://gateway.envoyproxy.io/v0.5.0/user/quickstart.html))

--- a/docs/how-to/multicluster-gateways-walkthrough.md
+++ b/docs/how-to/multicluster-gateways-walkthrough.md
@@ -9,11 +9,11 @@ We will start with a hub cluster and 2 workload clusters and highlight the autom
 
 ## Requirements
 
-- Complete the [Getting Started - Multi Cluster Guide](https://docs.kuadrant.io/getting-started-multi-cluster/).
+- Complete the [Getting Started - Multi Cluster Guide](https://docs.kuadrant.io/getting-started-multi-cluster-ocm/).
 
 ## Initial Setup
 
-In this walkthrough, we'll deploy test echo services across multiple clusters. If you followed the [Getting Started - Multi Cluster Guide](https://docs.kuadrant.io/getting-started-multi-cluster/), you would have already set up a `KUADRANT_ZONE_ROOT_DOMAIN` environment variable. For this tutorial, we'll derive a host from this domain for these echo services.
+In this walkthrough, we'll deploy test echo services across multiple clusters. If you followed the [Getting Started - Multi Cluster Guide](https://docs.kuadrant.io/getting-started-multi-cluster-ocm/), you would have already set up a `KUADRANT_ZONE_ROOT_DOMAIN` environment variable. For this tutorial, we'll derive a host from this domain for these echo services.
 
 ### Create a gateway
 
@@ -202,7 +202,7 @@ The listener is configured to use this TLS secret also. So now our gateway has b
 
 So now we have workload ingress clusters configured with the same Gateway. 
 
-5. Let's create the HTTPRoute in the first workload cluster. Again, remembering to replace the hostname accordingly if you haven't already set a value for the `KUADRANT_ZONE_ROOT_DOMAIN` variable as described in the [Getting Started - Multi Cluster Guide](https://docs.kuadrant.io/getting-started-multi-cluster/):
+5. Let's create the HTTPRoute in the first workload cluster. Again, remembering to replace the hostname accordingly if you haven't already set a value for the `KUADRANT_ZONE_ROOT_DOMAIN` variable as described in the [Getting Started - Multi Cluster Guide](https://docs.kuadrant.io/getting-started-multi-cluster-ocm/):
     ```bash
     kubectl --context kind-mgc-workload-1 apply -f - <<EOF
     apiVersion: gateway.networking.k8s.io/v1

--- a/docs/installation/control-plane-installation.md
+++ b/docs/installation/control-plane-installation.md
@@ -83,7 +83,7 @@ gatewayclass.gateway.networking.k8s.io/kuadrant-multi-cluster-gateway-instance-p
 
 **Note:** :exclamation: To manage the creation of DNS records, MGC uses [ManagedZone](https://github.com/Kuadrant/dns-operator/blob/main/docs/reference/managedzone.md) resources. A `ManagedZone` can be configured to use DNS Zones on both AWS (Route53), and GCP (Cloud DNS). Commands to create each are provided below. 
 
-First, depending on the provider you would like to use export the [environment variables detailed here](https://docs.kuadrant.io/getting-started-multi-cluster/) in a terminal session.
+First, depending on the provider you would like to use export the [environment variables detailed here](https://docs.kuadrant.io/getting-started-multi-cluster-ocm/) in a terminal session.
 
 Next, create a secret containing either the AWS or GCP credentials. We'll also create a namespace for your MGC configs:
 


### PR DESCRIPTION
The new url is https://docs.kuadrant.io/getting-started-multi-cluster-ocm, which will be live after https://github.com/Kuadrant/docs.kuadrant.io/pull/97 lands.
It's just the url that is changing. The page and content is the same as before.
This is to accommodate a move of all mgc & ocm related content into a separate sub-section in the docs.
The previous url https://docs.kuadrant.io/getting-started-multi-cluster will still be live, but point to a new page that doesn't use ocm or mgc.